### PR TITLE
fix/dual-audio

### DIFF
--- a/core/downloader.py
+++ b/core/downloader.py
@@ -60,6 +60,10 @@ class StreamDownloader:
         ydl_opts = {
             "format": "best",
             "outtmpl": str(output_path),
+            "postprocessor_args": [
+                "-c",
+                "copy",
+            ],
             "http_headers": {
                 "Referer": "https://rplay.live",
                 "Origin": "https://rplay.live",


### PR DESCRIPTION
fix:  yt-dlp downloaded video is not dual-audio