### PR TITLE
release/v2.1.0-vibe

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@
 ## 📑 Table of Contents
 
 - [📝 Description](#description)
-- [🆕 What's New in v2](#whats-new-in-v2)
 - [⚠️ v2 Upgrade Notes](#v2-upgrade-notes)
 - [✨ Features](#features)
 - [🚀 Quick Start](#quick-start)
@@ -45,23 +44,6 @@
 
 > [!WARNING]
 > **Vibe Coding Notice**: versions with the `-vibe` suffix (for example `2.0.0-vibe`) are AI-assisted releases. They pass automated tests, but you should still review breaking changes before upgrading production deployments.
-
----
-
-<a id="whats-new-in-v2"></a>
-
-## 🆕 What's New in v2
-
-Version `2.0.0-vibe` introduces a session-aware download pipeline:
-
-- each live session is tracked by `creator_oid + stream oid`
-- raw media is downloaded into a per-session staging directory as `.ts`
-- completed raw outputs are merged into a final `.mp4`
-- the visible final filename stays compatible with older releases
-- a new live session can start even while the previous session is still merging
-- startup now fails fast when the app detects the legacy `./config.yaml` path
-- detailed runtime behavior is documented below in [Download and Merge Flow](#download-and-merge-flow)
-- `apiBaseUrl` now lives in `config/config.yaml`, is reloaded every poll, and is auto-written with `https://api.rplay.live` if missing
 
 ---
 
@@ -96,12 +78,12 @@ Startup protection:
 
 - automated live monitoring for multiple creators
 - session-aware download tracking to avoid creator-level blocking
-- raw `.ts` staging plus final `.mp4` output for better HLS stability
+- flat archive layout with timestamp-prefixed `.ts` files per session
 - immediate merge queueing after raw download completion
 - legacy-compatible final filenames such as `#Creator 2026-03-06 Title.mp4`
 - duplicate title protection with suffixed outputs like `_1`, `_2`, and so on
 - paid/private stream detection with blocked-session handling
-- failed merge preservation under `archive/<creator>/_failed/`
+- failed merge leaves raw `.ts` files in place for manual recovery
 - fail-fast startup validation for legacy config path upgrades
 - Docker-first deployment for long-running operation
 
@@ -111,9 +93,7 @@ Startup protection:
 
 ## 🚀 Quick Start
 
-1. Create your environment file.
-   - Local / Poetry run: copy `.env.example` to `.env`
-   - Included `docker-compose.yaml`: copy `.env.example` to `env`, or update the compose volume to mount `.env` instead
+1. Create your environment file: copy `.env.example` to `.env`.
 2. Create `config/config.yaml` from `config.yaml.example`.
 3. Fill in your RPlay credentials, creator list, and optionally `apiBaseUrl`.
 4. Optionally set `LOG_LEVEL=DEBUG` when you want verbose lifecycle logs.
@@ -133,12 +113,6 @@ docker compose up -d
 docker compose logs -f
 ```
 
-If you use the stock `docker-compose.yaml` without modification, replace step 1 with:
-
-```bash
-cp .env.example env
-```
-
 ---
 
 <a id="usage-guide"></a>
@@ -152,7 +126,7 @@ Production:
 - Docker
 - valid RPlay account credentials
 - stable network connectivity
-- enough disk space for raw `.ts` staging and final `.mp4` files
+- enough disk space for `.ts` recordings and final `.mp4` files
 
 Development:
 
@@ -191,7 +165,7 @@ Development:
 
 #### Environment file
 
-Copy `.env.example` to `.env` for local runs. If you use the bundled `docker-compose.yaml`, the host file named `env` is mounted to `/app/.env`.
+Copy `.env.example` to `.env`. Both local runs and the bundled `docker-compose.yaml` use `.env`.
 
 Full example:
 
@@ -236,7 +210,7 @@ Environment variables:
 Notes:
 
 - local runs load from `.env` or process environment variables
-- the bundled Docker Compose file maps a host file named `env` to `/app/.env`
+- the bundled Docker Compose file mounts `.env` to `/app/.env`
 - `LOG_YTDLP_INTERNAL=true` is only for deep diagnosis; it is intentionally noisy
 
 #### Creator configuration
@@ -281,31 +255,31 @@ The v2 runtime uses a session-aware download pipeline.
 
 2. **Create a session**
    - each live stream gets a session key based on `creator_oid` and the API `oid`
-   - the raw download is isolated in `archive/<creator>/.staging/<session_dir>/`
-   - `session_dir` is the filesystem-safe form of the session key, not the raw key string
+   - a timestamp prefix (`YYYYMMDD_HHMMSS_`) is derived from `recording_started_at` in machine local time
+   - raw files are written directly to `archive/<creator>/` using this prefix for isolation
 
 3. **Download raw transport stream files**
-   - yt-dlp writes raw outputs as `.ts`
+   - yt-dlp writes raw outputs as `.ts` directly into `archive/<creator>/`
    - each download task uses a `10`-second socket timeout
    - transient task failures automatically retry up to `3` attempts total with exponential backoff
-   - `HTTP 404` on a fresh stream is retried before the current session is marked blocked
+   - `HTTP 404` on the stream playlist is retried with exponential backoff before the session is marked blocked
    - `HTTP 403` is still treated as immediate blocked/private access
    - `HTTP 401` is treated as an authentication failure instead of a blocked session
-   - raw staging names keep the familiar visible format, for example:
-     - `#Creator 2026-03-06 Title.ts`
-     - `#Creator 2026-03-06 Title_1.ts`
+   - raw filenames carry the session timestamp prefix, for example:
+     - `20260306_120000_#Creator 2026-03-06 Title.ts`
+     - `20260306_120000_#Creator 2026-03-06 Title_1.ts`
 
 4. **Queue merge immediately after download completes**
    - as soon as raw download finishes, the merge job is submitted to the merge executor
    - the control loop can move on quickly, so a new live session from the same creator can be picked up without waiting for the old merge to finish
 
 5. **Merge into final `.mp4`**
-   - all `.ts` files in that session staging directory are merged into one final `.mp4`
+   - all `.ts` files in `archive/<creator>/` matching the session prefix are merged into one final `.mp4`
    - even if only one raw `.ts` file exists, the final visible output is still `.mp4`
 
 6. **Clean up or preserve for recovery**
-   - on success, the merged `.ts` files are deleted and the session staging directory is removed
-   - on merge failure or timeout, the whole session staging directory is moved to `archive/<creator>/_failed/<session_dir>/`
+   - on success, the `.ts` files matching the session prefix are deleted from `archive/<creator>/`
+   - on merge failure, the `.ts` files remain in `archive/<creator>/` for manual inspection and recovery
 
 7. **Observe lifecycle logs**
    - set `LOG_LEVEL=DEBUG` in `.env` to see stream-candidate evaluation and skip reasons
@@ -314,17 +288,17 @@ The v2 runtime uses a session-aware download pipeline.
 
 #### Final filename rules
 
-Visible final outputs intentionally keep the old naming style:
+Visible final outputs use a clean naming style:
 
 - first session: `#Creator 2026-03-06 Title.mp4`
 - second session on the same day with the same title: `#Creator 2026-03-06 Title_1.mp4`
 - later duplicates continue as `_2`, `_3`, and so on
 
-This means:
+Raw `.ts` files carry a timestamp prefix for session isolation:
 
-- users still see the same filename pattern as previous releases
-- collisions are resolved only at the final visible output layer
-- raw session isolation happens inside `.staging`, not in the archive root
+- `20260306_120000_#Creator 2026-03-06 Title.ts`
+- prefix format is `YYYYMMDD_HHMMSS_` in machine local time
+- prefix uniquely identifies the recording session; files from different sessions never collide
 
 ### Deployment
 
@@ -347,7 +321,7 @@ docker compose up -d
 
 The bundled `docker-compose.yaml` mounts:
 
-- `./env` → `/app/.env`
+- `./.env` → `/app/.env`
 - `./config` → `/app/config`
 - `./archive` → `/app/archive`
 - `./logs` → `/app/logs`
@@ -373,26 +347,21 @@ rplay-live-dl/
 │   └── Creator/
 │       ├── #Creator 2026-03-06 Title.mp4
 │       ├── #Creator 2026-03-06 Title_1.mp4
-│       ├── .staging/
-│       │   └── creator_oid_2026-03-06T12_00_00/
-│       │       └── #Creator 2026-03-06 Title.ts
-│       └── _failed/
-│           └── creator_oid_2026-03-06T13_00_00/
-│               └── #Creator 2026-03-06 Title.ts
+│       ├── 20260306_120000_#Creator 2026-03-06 Title.ts    ← active or failed session
+│       └── 20260306_130000_#Creator 2026-03-06 Title.ts    ← active or failed session
 ├── config/
 │   ├── .gitkeep
 │   └── config.yaml
-├── env                  # used by the bundled docker-compose.yaml
-├── .env                 # used for local runs or custom docker run usage
+├── .env                 # credentials and runtime settings
 ├── logs/
 └── docker-compose.yaml
 ```
 
 Notes:
 
-- `.staging` is an internal working area for active or just-finished sessions
-- `_failed` keeps raw files visible for manual inspection and recovery
-- `.staging` and `_failed` appear only when there is active or failed session data
+- `.ts` files with a timestamp prefix are either active downloads or unmerged fragments from a failed session
+- on successful merge the matching `.ts` files are deleted automatically
+- on merge failure the `.ts` files remain in place for manual inspection and recovery
 - final user-facing recordings live directly under `archive/<creator>/`
 
 ### Troubleshooting
@@ -443,7 +412,7 @@ Check:
 
 Behavior:
 
-- raw files are preserved under `archive/<creator>/_failed/<session_dir>/`
+- the `.ts` files matching the failed session prefix remain in `archive/<creator>/`
 - the app does not silently delete the session fragments
 
 Check:
@@ -451,7 +420,7 @@ Check:
 - FFmpeg availability in the runtime image
 - file-system permissions
 - available disk space
-- the preserved raw `.ts` files for manual recovery
+- the preserved raw `.ts` files in `archive/<creator>/` for manual recovery
 
 #### 5. Shutdown takes time
 

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -123,6 +123,7 @@ class StreamDownloader:
         session_key: Optional[str] = None,
         output_dir: Optional[Path] = None,
         output_extension: str = ".mp4",
+        filename_prefix: str = "",
         on_download_complete: Optional[Callable[[RawDownloadCompleted], None]] = None,
         on_download_failure: Optional[Callable[[RawDownloadFailed], None]] = None,
     ) -> None:
@@ -146,6 +147,7 @@ class StreamDownloader:
         self.session_key = session_key
         self.output_dir = output_dir
         self.output_extension = output_extension
+        self.filename_prefix = filename_prefix
         self._on_download_complete = on_download_complete
         self._on_download_failure = on_download_failure
         self._yt_dlp_logger = _YtDlpLoggerBridge(
@@ -221,7 +223,7 @@ class StreamDownloader:
             Path object for the output file
         """
         date_str = datetime.today().strftime("%Y-%m-%d")
-        filename = f"#{self.creator_name} {date_str} {safe_title}{self.output_extension}"
+        filename = f"{self.filename_prefix}#{self.creator_name} {date_str} {safe_title}{self.output_extension}"
 
         if self.output_dir is not None:
             return self.output_dir / filename
@@ -533,7 +535,7 @@ class StreamDownloader:
             self._on_download_complete(
                 RawDownloadCompleted(
                     session_key=self.session_key,
-                    staging_dir=output_path.parent,
+                    output_dir=output_path.parent,
                 )
             )
         except Exception as e:

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -657,9 +657,7 @@ class LiveStreamMonitor:
 
     def _make_session_prefix(self, recording_started_at: datetime) -> str:
         """Build the filename prefix from the local recording start time."""
-        local_dt = recording_started_at
-        if local_dt.tzinfo is not None:
-            local_dt = local_dt.replace(tzinfo=None)
+        local_dt = recording_started_at.astimezone().replace(tzinfo=None)
         return local_dt.strftime("%Y%m%d_%H%M%S_")
 
     def _on_raw_download_complete(self, event: RawDownloadCompleted) -> None:
@@ -736,7 +734,6 @@ class LiveStreamMonitor:
                 return
 
             session.state = SessionState.MERGE_QUEUED
-            session.output_dir = event.output_dir
             active_session_key = self._active_raw_session_by_creator.get(session.creator_oid)
             if active_session_key == session.session_key:
                 self._active_raw_session_by_creator.pop(session.creator_oid, None)
@@ -745,7 +742,7 @@ class LiveStreamMonitor:
                 creator_name=session.creator_name,
                 title=session.title,
                 stream_start_time=session.stream_start_time,
-                output_dir=event.output_dir,
+                output_dir=session.output_dir,
                 session_prefix=session.session_prefix,
             )
 

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -1,6 +1,5 @@
 """Live stream monitoring module."""
 
-import shutil
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -384,8 +383,9 @@ class LiveStreamMonitor:
             ),
             on_download_auth_error=self._on_raw_download_auth_failed,
             session_key=session.session_key,
-            output_dir=session.staging_dir,
+            output_dir=session.output_dir,
             output_extension=".ts",
+            filename_prefix=session.session_prefix,
             on_download_complete=self._on_raw_download_complete,
             on_download_failure=self._on_raw_download_failed,
         )
@@ -612,6 +612,8 @@ class LiveStreamMonitor:
                     session_key = f"{base_session_key}-{suffix}"
                     suffix += 1
 
+            session_prefix = self._make_session_prefix(recording_started_at)
+            output_dir = self._build_session_output_dir(creator_name)
             self.sessions[session_key] = DownloadSession(
                 session_key=session_key,
                 creator_oid=stream.creator_oid,
@@ -619,7 +621,8 @@ class LiveStreamMonitor:
                 title=stream.title,
                 stream_start_time=stream.stream_start_time,
                 state=SessionState.RAW_RUNNING,
-                staging_dir=self._build_staging_dir(creator_name, session_key),
+                output_dir=output_dir,
+                session_prefix=session_prefix,
                 recording_started_at=recording_started_at,
             )
             self._active_raw_session_by_creator[stream.creator_oid] = session_key
@@ -648,21 +651,16 @@ class LiveStreamMonitor:
             recording_started_at = recording_started_at.astimezone(timezone.utc)
         return f"{creator_oid}:{int(recording_started_at.timestamp() * 1000)}"
 
-    def _build_staging_dir(self, creator_name: str, session_key: str) -> Path:
-        """Build the staging directory for one session."""
-        return (
-            Path.cwd()
-            / StreamDownloader.ARCHIVE_DIR
-            / creator_name
-            / ".staging"
-            / self._make_session_dir_name(session_key)
-        )
+    def _build_session_output_dir(self, creator_name: str) -> Path:
+        """Return the flat output directory for a creator's recordings."""
+        return Path.cwd() / StreamDownloader.ARCHIVE_DIR / creator_name
 
-    def _make_session_dir_name(self, session_key: str) -> str:
-        """Convert a session key into a filesystem-safe directory name."""
-        if ":" in session_key:
-            return session_key.rsplit(":", 1)[1]
-        return sanitize_filename(session_key, replacement_text="_")
+    def _make_session_prefix(self, recording_started_at: datetime) -> str:
+        """Build the filename prefix from the local recording start time."""
+        local_dt = recording_started_at
+        if local_dt.tzinfo is not None:
+            local_dt = local_dt.replace(tzinfo=None)
+        return local_dt.strftime("%Y%m%d_%H%M%S_")
 
     def _on_raw_download_complete(self, event: RawDownloadCompleted) -> None:
         """Receive raw completion from a downloader thread and queue it."""
@@ -717,12 +715,11 @@ class LiveStreamMonitor:
                 )
             elif isinstance(event, MergeFailed):
                 session.last_error = event.error_message
-                session.staging_dir = event.failed_staging_dir
                 session.state = SessionState.MERGE_FAILED
                 log_method = self.logger.warning
                 log_message = (
                     f"⚠️ Merge failed for {session.creator_name}: {event.error_message}. "
-                    f"Raw files preserved at: {event.failed_staging_dir}"
+                    f"Raw .ts files left in: {session.output_dir}"
                 )
             else:
                 self.logger.error(f"Unhandled session event type: {type(event)}")
@@ -739,7 +736,7 @@ class LiveStreamMonitor:
                 return
 
             session.state = SessionState.MERGE_QUEUED
-            session.staging_dir = event.staging_dir
+            session.output_dir = event.output_dir
             active_session_key = self._active_raw_session_by_creator.get(session.creator_oid)
             if active_session_key == session.session_key:
                 self._active_raw_session_by_creator.pop(session.creator_oid, None)
@@ -748,13 +745,14 @@ class LiveStreamMonitor:
                 creator_name=session.creator_name,
                 title=session.title,
                 stream_start_time=session.stream_start_time,
-                staging_dir=session.staging_dir,
+                output_dir=event.output_dir,
+                session_prefix=session.session_prefix,
             )
 
         self.merge_executor.submit_merge(lambda: self._run_merge_job(merge_job))
         self.logger.info(
             f"🧩 Queued merge for {merge_job.creator_name}: "
-            f"session_key={merge_job.session_key}, staging_dir={merge_job.staging_dir}"
+            f"session_key={merge_job.session_key}, output_dir={merge_job.output_dir}"
         )
 
     def _handle_raw_download_auth_failed(self, event: RawDownloadAuthFailed) -> None:
@@ -861,12 +859,13 @@ class LiveStreamMonitor:
 
     def _merge_session_to_mp4(self, merge_job: MergeJobSpec) -> Union[MergeCompleted, MergeFailed]:
         """Merge one session's raw ts outputs into the final mp4 artifact."""
-        ts_files = sorted(merge_job.staging_dir.glob("*.ts"))
+        ts_files = sorted(merge_job.output_dir.glob(f"{merge_job.session_prefix}*.ts"))
 
         try:
             if not ts_files:
                 raise FileNotFoundError(
-                    f"No ts files found for session {merge_job.session_key}"
+                    f"No ts files found for session {merge_job.session_key} "
+                    f"(prefix={merge_job.session_prefix})"
                 )
 
             output_path = self._reserve_final_output_path(
@@ -879,36 +878,21 @@ class LiveStreamMonitor:
             for ts_file in ts_files:
                 ts_file.unlink(missing_ok=True)
 
-            if merge_job.staging_dir.exists():
-                shutil.rmtree(merge_job.staging_dir)
-
             return MergeCompleted(
                 session_key=merge_job.session_key,
                 output_path=output_path,
             )
 
         except subprocess.TimeoutExpired as exc:
-            failed_dir = self._move_failed_staging_dir(
-                creator_name=merge_job.creator_name,
-                session_key=merge_job.session_key,
-                staging_dir=merge_job.staging_dir,
-            )
             timeout_value = int(exc.timeout) if exc.timeout is not None else self.merge_timeout_seconds
             return MergeFailed(
                 session_key=merge_job.session_key,
                 error_message=f"ffmpeg merge timeout after {timeout_value} seconds",
-                failed_staging_dir=failed_dir,
             )
         except Exception as exc:
-            failed_dir = self._move_failed_staging_dir(
-                creator_name=merge_job.creator_name,
-                session_key=merge_job.session_key,
-                staging_dir=merge_job.staging_dir,
-            )
             return MergeFailed(
                 session_key=merge_job.session_key,
                 error_message=str(exc),
-                failed_staging_dir=failed_dir,
             )
 
     def _reserve_final_output_path(
@@ -970,30 +954,6 @@ class LiveStreamMonitor:
         """Format one concat-demuxer input line with apostrophe-safe escaping."""
         escaped_path = ts_file.resolve().as_posix().replace("'", "'\''")
         return f"file '{escaped_path}'"
-
-    def _move_failed_staging_dir(
-        self,
-        creator_name: str,
-        session_key: str,
-        staging_dir: Path,
-    ) -> Path:
-        """Move failed raw session files into the visible failed directory."""
-        failed_dir = (
-            Path.cwd()
-            / StreamDownloader.ARCHIVE_DIR
-            / creator_name
-            / "_failed"
-            / self._make_session_dir_name(session_key)
-        )
-
-        if not staging_dir.exists():
-            return failed_dir
-
-        failed_dir.parent.mkdir(parents=True, exist_ok=True)
-        if failed_dir.exists():
-            shutil.rmtree(failed_dir)
-        shutil.move(staging_dir, failed_dir)
-        return failed_dir
 
     def shutdown(self) -> None:
         """Shut down background monitor and merge work."""

--- a/core/rplay.py
+++ b/core/rplay.py
@@ -280,11 +280,14 @@ class RPlayAPI:
                             "Authentication failed. Please check your AUTH_TOKEN."
                         )
 
-                    if status_code in (403, 404):
+                    if status_code == 403:
                         self.logger.debug(
-                            f"M3U8 validation stopped on non-retriable status {status_code}"
+                            "M3U8 validation stopped on non-retriable status 403"
                         )
                         return False
+
+                    if status_code == 404:
+                        raise _RetryableStatusCodeError(status_code)
 
                     if self._is_retryable_status_code(status_code):
                         raise _RetryableStatusCodeError(status_code)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       - PYTHONUNBUFFERED=1
       - TZ=Asia/Taipei
     volumes:
-      - ./env:/app/.env
+      - ./.env:/app/.env
       - ./config:/app/config
       - ./archive:/app/archive
       - ./logs:/app/logs

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from core.env import EnvConfigError, load_env
 from core.logger import cleanup_old_logs, setup_logger
 from core.scheduler import run_scheduler
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"
 
 
 def main() -> None:

--- a/models/download.py
+++ b/models/download.py
@@ -1,4 +1,4 @@
-﻿"""Session-aware download and monitor event models."""
+"""Session-aware download and monitor event models."""
 
 from dataclasses import dataclass
 from datetime import datetime
@@ -28,7 +28,8 @@ class DownloadSession:
     title: str
     stream_start_time: datetime
     state: SessionState
-    staging_dir: Path
+    output_dir: Path
+    session_prefix: str
     recording_started_at: Optional[datetime] = None
     final_output_path: Optional[Path] = None
     last_error: Optional[str] = None
@@ -39,7 +40,7 @@ class RawDownloadCompleted:
     """Event emitted when a raw yt-dlp session finishes successfully."""
 
     session_key: str
-    staging_dir: Path
+    output_dir: Path
 
 
 @dataclass(frozen=True)
@@ -74,7 +75,8 @@ class MergeJobSpec:
     creator_name: str
     title: str
     stream_start_time: datetime
-    staging_dir: Path
+    output_dir: Path
+    session_prefix: str
 
 
 @dataclass(frozen=True)
@@ -98,4 +100,3 @@ class MergeFailed:
 
     session_key: str
     error_message: str
-    failed_staging_dir: Path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rplay-live-dl"
-version = "2.0.0"
+version = "2.1.0"
 description = ""
 authors = ["paver(kevinsun)"]
 license = "MIT"

--- a/tests/test_download_models.py
+++ b/tests/test_download_models.py
@@ -1,6 +1,7 @@
 """Tests for session-aware download models."""
 
 from datetime import datetime
+from pathlib import Path
 
 from models.download import (
     DownloadSession,
@@ -25,7 +26,8 @@ class TestDownloadSession:
             title="Test",
             stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
             state=SessionState.RAW_RUNNING,
-            staging_dir=tmp_path,
+            output_dir=tmp_path,
+            session_prefix="20260306_120000",
         )
 
         assert session.final_output_path is None
@@ -47,11 +49,11 @@ class TestMonitorEvents:
         """Test raw completion event carries only the needed transport data."""
         event = RawDownloadCompleted(
             session_key="creator1:2026-03-06T12:00:00",
-            staging_dir=tmp_path,
+            output_dir=tmp_path,
         )
 
         assert event.session_key == "creator1:2026-03-06T12:00:00"
-        assert event.staging_dir == tmp_path
+        assert event.output_dir == tmp_path
 
     def test_raw_download_blocked_carries_error_message(self):
         """Test blocked event preserves the emitted error message."""
@@ -71,16 +73,15 @@ class TestMonitorEvents:
 
         assert event.output_path.name == "final.mp4"
 
-    def test_merge_failed_stores_failed_staging_dir(self, tmp_path):
-        """Test merge failure event points to the visible failed staging directory."""
+    def test_merge_failed_has_no_failed_staging_dir(self):
+        """Test merge failure event carries only session key and error message."""
         event = MergeFailed(
             session_key="creator1:2026-03-06T12:00:00",
             error_message="ffmpeg timeout",
-            failed_staging_dir=tmp_path / "_failed" / "session",
         )
 
         assert event.error_message == "ffmpeg timeout"
-        assert event.failed_staging_dir.name == "session"
+        assert not hasattr(event, "failed_staging_dir")
 
     def test_merge_job_spec_groups_merge_inputs(self, tmp_path):
         """Test merge job inputs are grouped into one immutable spec."""
@@ -89,9 +90,10 @@ class TestMonitorEvents:
             creator_name="Creator",
             title="Test",
             stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
-            staging_dir=tmp_path,
+            output_dir=tmp_path,
+            session_prefix="20260306_120000",
         )
 
         assert spec.creator_name == "Creator"
-        assert spec.staging_dir == tmp_path
-
+        assert spec.output_dir == tmp_path
+        assert spec.session_prefix == "20260306_120000"

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -116,6 +116,20 @@ class TestBuildOutputPath:
             session_key="creator1:2026-03-06T12:00:00",
             output_dir=tmp_path,
             output_extension=".ts",
+            filename_prefix="20260306_120000_",
+        )
+
+        path = downloader._build_output_path("Test")
+
+        assert path == tmp_path / "20260306_120000_#Creator 2026-01-17 Test.ts"
+
+    @freeze_time("2026-01-17")
+    def test_output_path_no_prefix_when_not_set(self, tmp_path):
+        """Test output path has no prefix when filename_prefix is not provided."""
+        downloader = StreamDownloader(
+            "Creator",
+            output_dir=tmp_path,
+            output_extension=".ts",
         )
 
         path = downloader._build_output_path("Test")
@@ -365,6 +379,7 @@ class TestDownloadWorker:
         assert len(events) == 1
         assert isinstance(events[0], RawDownloadCompleted)
         assert events[0].session_key == "creator1:2026-03-06T12:00:00"
+        assert events[0].output_dir == tmp_path
 
     def test_worker_missing_ts_output_without_fragments_does_not_notify_completion(
         self, mock_yt_dlp, tmp_path

--- a/tests/test_live_stream_monitor.py
+++ b/tests/test_live_stream_monitor.py
@@ -164,7 +164,7 @@ class TestSessionAwareMonitoring:
         monitor._handle_monitor_event(
             RawDownloadCompleted(
                 session_key=first_session_key,
-                staging_dir=tmp_path / "first-staging",
+                output_dir=tmp_path / "first-staging",
             )
         )
         monitor.check_live_streams_and_start_download()
@@ -287,7 +287,8 @@ class TestSessionAwareMonitoring:
             title="Old Stream",
             stream_start_time=old_time,
             state=SessionState.MERGING,
-            staging_dir=tmp_path / "old",
+            output_dir=tmp_path / "old",
+            session_prefix="20260306_120000_",
         )
 
         monitor.check_live_streams_and_start_download()
@@ -318,7 +319,8 @@ class TestSessionAwareMonitoring:
             title="Old Stream",
             stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
             state=SessionState.DONE,
-            staging_dir=tmp_path / "old",
+            output_dir=tmp_path / "old",
+            session_prefix="20260306_120000_",
         )
         mock_stream = MagicMock()
         mock_stream.oid = "stream-2"
@@ -352,7 +354,8 @@ class TestSessionAwareMonitoring:
             title="Finished Stream",
             stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
             state=SessionState.DONE,
-            staging_dir=tmp_path / "creator1",
+            output_dir=tmp_path / "creator1",
+            session_prefix="20260306_120000_",
         )
         monitor.sessions[active_session_key] = DownloadSession(
             session_key=active_session_key,
@@ -361,7 +364,8 @@ class TestSessionAwareMonitoring:
             title="Active Stream",
             stream_start_time=datetime(2026, 3, 6, 12, 5, 0),
             state=SessionState.RAW_RUNNING,
-            staging_dir=tmp_path / "creator2",
+            output_dir=tmp_path / "creator2",
+            session_prefix="20260306_120500_",
         )
         monitor._creator_states["creator1"] = CreatorStreamState(
             last_stream_oid="stream-1"
@@ -405,7 +409,8 @@ class TestSessionAwareMonitoring:
             title="Test Stream",
             stream_start_time=start_time,
             state=SessionState.RAW_RUNNING,
-            staging_dir=tmp_path / "running",
+            output_dir=tmp_path / "running",
+            session_prefix="20260306_120000_",
         )
         monitor._active_raw_session_by_creator["creator1"] = "creator1:1772798400"
 
@@ -429,11 +434,12 @@ class TestSessionAwareMonitoring:
             title="Test Stream",
             stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
             state=SessionState.RAW_RUNNING,
-            staging_dir=tmp_path,
+            output_dir=tmp_path,
+            session_prefix="20260306_120000_",
         )
         result = RawDownloadCompleted(
             session_key=session_key,
-            staging_dir=tmp_path,
+            output_dir=tmp_path,
         )
 
         with patch.object(monitor.merge_executor, 'submit_merge') as mock_submit:
@@ -552,7 +558,8 @@ class TestUpdateDownloaders:
             title="Test Stream",
             stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
             state=SessionState.RAW_RUNNING,
-            staging_dir=tmp_path,
+            output_dir=tmp_path,
+            session_prefix="20260306_120000_",
         )
 
         mock_read_config.return_value = _runtime_config([])
@@ -778,7 +785,8 @@ class TestCheckLiveStreams:
             title="Test Stream",
             stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
             state=SessionState.RAW_RUNNING,
-            staging_dir=tmp_path,
+            output_dir=tmp_path,
+            session_prefix="20260306_120000_",
         )
         monitor._active_raw_session_by_creator["creator_oid"] = "creator_oid:1772798400"
 
@@ -960,7 +968,8 @@ class TestGetActiveDownloads:
             title="Test Stream",
             stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
             state=SessionState.MERGING,
-            staging_dir=tmp_path,
+            output_dir=tmp_path,
+            session_prefix="20260306_120000_",
         )
 
         assert monitor.get_active_downloads() == []
@@ -980,7 +989,8 @@ class TestGetActiveDownloads:
             title="Test Stream",
             stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
             state=SessionState.RAW_RUNNING,
-            staging_dir=tmp_path,
+            output_dir=tmp_path,
+            session_prefix="20260306_120000_",
         )
         monitor.sessions["inactive:2026-03-06T11:00:00"] = DownloadSession(
             session_key="inactive:2026-03-06T11:00:00",
@@ -989,7 +999,8 @@ class TestGetActiveDownloads:
             title="Old Stream",
             stream_start_time=datetime(2026, 3, 6, 11, 0, 0),
             state=SessionState.MERGING,
-            staging_dir=tmp_path,
+            output_dir=tmp_path,
+            session_prefix="20260306_110000_",
         )
 
         result = monitor.get_active_downloads()
@@ -1011,7 +1022,8 @@ class TestGetActiveDownloads:
                 title="Test Stream",
                 stream_start_time=datetime(2026, 3, 6, 12, i, 0),
                 state=SessionState.RAW_RUNNING,
-                staging_dir=tmp_path,
+                output_dir=tmp_path,
+                session_prefix=f"2026030612{i:02d}00_",
             )
 
         result = monitor.get_active_downloads()
@@ -1174,7 +1186,8 @@ class TestCreatorStateTracking:
             title="Test Stream",
             stream_start_time=datetime(2026, 1, 26, 12, 0, 0),
             state=SessionState.DONE,
-            staging_dir=tmp_path,
+            output_dir=tmp_path,
+            session_prefix="20260126_120000_",
         )
 
         with patch.object(monitor.logger, 'info') as mock_info:
@@ -1201,7 +1214,8 @@ class TestCreatorStateTracking:
             title="Test Stream",
             stream_start_time=datetime(2026, 1, 26, 12, 0, 0),
             state=SessionState.RAW_RUNNING,
-            staging_dir=tmp_path,
+            output_dir=tmp_path,
+            session_prefix="20260126_120000_",
         )
 
         monitor._handle_raw_download_blocked(
@@ -1401,7 +1415,8 @@ class TestSessionDownloadBlockedHandling:
             title="Test Stream",
             stream_start_time=datetime(2026, 1, 26, 12, 0, 0),
             state=SessionState.RAW_RUNNING,
-            staging_dir=tmp_path,
+            output_dir=tmp_path,
+            session_prefix="20260126_120000_",
         )
         monitor._creator_states["creator1"] = CreatorStreamState(
             last_stream_oid="stream-1",
@@ -1431,7 +1446,8 @@ class TestSessionDownloadBlockedHandling:
             title="Test Stream",
             stream_start_time=datetime(2026, 1, 26, 12, 0, 0),
             state=SessionState.RAW_RUNNING,
-            staging_dir=tmp_path,
+            output_dir=tmp_path,
+            session_prefix="20260126_120000_",
         )
         monitor._creator_states["creator1"] = CreatorStreamState(
             last_stream_oid="stream-1",
@@ -1474,7 +1490,8 @@ class TestSessionDownloadBlockedHandling:
             title="Test Stream",
             stream_start_time=datetime(2026, 1, 26, 12, 0, 0),
             state=SessionState.BLOCKED,
-            staging_dir=tmp_path,
+            output_dir=tmp_path,
+            session_prefix="20260126_120000_",
         )
         monitor._creator_states["creator1"] = CreatorStreamState(
             last_stream_start_time=datetime(2026, 1, 26, 12, 0, 0),
@@ -1609,7 +1626,8 @@ class TestSessionLifecycleLogging:
             title="Test Stream",
             stream_start_time=datetime(2026, 3, 7, 5, 1, 0),
             state=SessionState.RAW_RUNNING,
-            staging_dir=tmp_path / "running",
+            output_dir=tmp_path / "running",
+            session_prefix="20260307_050005_",
             recording_started_at=recording_started_at,
         )
         monitor._active_raw_session_by_creator["creator1"] = "creator1:1772859660"
@@ -1649,7 +1667,8 @@ class TestSessionLifecycleLogging:
             title="Test Stream",
             stream_start_time=datetime(2026, 3, 7, 5, 0, 0),
             state=SessionState.RAW_RUNNING,
-            staging_dir=tmp_path / "running",
+            output_dir=tmp_path / "running",
+            session_prefix="20260307_050000_",
         )
         monitor._active_raw_session_by_creator["creator1"] = "creator1:1741323600"
 
@@ -1682,7 +1701,8 @@ class TestSessionLifecycleLogging:
             title="Test Stream",
             stream_start_time=datetime(2026, 3, 7, 5, 0, 0),
             state=SessionState.RAW_RUNNING,
-            staging_dir=tmp_path / "staging",
+            output_dir=tmp_path / "staging",
+            session_prefix="20260307_050000_",
         )
 
         with patch.object(monitor.merge_executor, "submit_merge") as mock_submit_merge:
@@ -1690,7 +1710,7 @@ class TestSessionLifecycleLogging:
                 monitor._handle_raw_download_completed(
                     RawDownloadCompleted(
                         session_key="creator1:stream-1",
-                        staging_dir=tmp_path / "staging",
+                        output_dir=tmp_path / "staging",
                     )
                 )
 
@@ -1711,7 +1731,8 @@ class TestSessionLifecycleLogging:
             title="Test Stream",
             stream_start_time=datetime(2026, 3, 7, 5, 0, 0),
             state=SessionState.MERGING,
-            staging_dir=tmp_path / "staging",
+            output_dir=tmp_path / "staging",
+            session_prefix="20260307_050000_",
         )
         output_path = tmp_path / "archive" / "Creator1" / "#Creator1 2026-03-07 Test Stream.mp4"
 

--- a/tests/test_merge_flow.py
+++ b/tests/test_merge_flow.py
@@ -1,4 +1,4 @@
-﻿"""Tests for session merge flow."""
+"""Tests for session merge flow."""
 
 import subprocess
 from pathlib import Path
@@ -12,14 +12,14 @@ from models.download import MergeCompleted, MergeFailed, MergeJobSpec
 class TestMergeFlow:
     """Tests for merging raw ts outputs into final mp4 files."""
 
-    def test_merge_uses_old_visible_mp4_name(self, tmp_path, monkeypatch):
-        """Test one session merges to the legacy visible mp4 file name."""
+    def test_merge_uses_stream_start_time_for_mp4_name(self, tmp_path, monkeypatch):
+        """Test one session merges to a mp4 file named after stream start time."""
         monkeypatch.chdir(tmp_path)
         monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=None)
-        session_key = "creator1:2026-03-06T12:00:00"
-        staging_dir = monitor._build_staging_dir("Creator", session_key)
-        staging_dir.mkdir(parents=True)
-        ts_file = staging_dir / "#Creator 2026-03-06 123.ts"
+        output_dir = tmp_path / "archive" / "Creator"
+        output_dir.mkdir(parents=True)
+        prefix = "20260306_120000_"
+        ts_file = output_dir / f"{prefix}#Creator 2026-03-06 123.ts"
         ts_file.write_bytes(b"ts")
 
         def fake_merge(ts_files, output_path):
@@ -30,11 +30,12 @@ class TestMergeFlow:
 
         event = monitor._merge_session_to_mp4(
             MergeJobSpec(
-                session_key=session_key,
+                session_key="creator1:2026-03-06T12:00:00",
                 creator_name="Creator",
                 title="123",
                 stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
-                staging_dir=staging_dir,
+                output_dir=output_dir,
+                session_prefix=prefix,
             )
         )
 
@@ -51,10 +52,9 @@ class TestMergeFlow:
         (final_dir / "#Creator 2026-03-06 123.mp4").write_bytes(b"existing")
 
         monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=None)
-        session_key = "creator1:2026-03-06T12:30:00"
-        staging_dir = monitor._build_staging_dir("Creator", session_key)
-        staging_dir.mkdir(parents=True)
-        (staging_dir / "#Creator 2026-03-06 123.ts").write_bytes(b"ts")
+        prefix = "20260306_123000_"
+        ts_file = final_dir / f"{prefix}#Creator 2026-03-06 123.ts"
+        ts_file.write_bytes(b"ts")
 
         def fake_merge(ts_files, output_path):
             output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -64,11 +64,12 @@ class TestMergeFlow:
 
         event = monitor._merge_session_to_mp4(
             MergeJobSpec(
-                session_key=session_key,
+                session_key="creator1:2026-03-06T12:30:00",
                 creator_name="Creator",
                 title="123",
                 stream_start_time=datetime(2026, 3, 6, 12, 30, 0),
-                staging_dir=staging_dir,
+                output_dir=final_dir,
+                session_prefix=prefix,
             )
         )
 
@@ -76,14 +77,14 @@ class TestMergeFlow:
         assert event.output_path == final_dir / "#Creator 2026-03-06 123_1.mp4"
         monitor.shutdown()
 
-    def test_failed_merge_moves_ts_files_to_failed_directory(self, tmp_path, monkeypatch):
-        """Test failed merges move raw files into the visible failed directory."""
+    def test_failed_merge_leaves_ts_files_in_output_dir(self, tmp_path, monkeypatch):
+        """Test failed merges leave raw ts files in place — no _failed/ directory."""
         monkeypatch.chdir(tmp_path)
         monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=None)
-        session_key = "creator1:2026-03-06T12:00:00"
-        staging_dir = monitor._build_staging_dir("Creator", session_key)
-        staging_dir.mkdir(parents=True)
-        ts_file = staging_dir / "#Creator 2026-03-06 123.ts"
+        output_dir = tmp_path / "archive" / "Creator"
+        output_dir.mkdir(parents=True)
+        prefix = "20260306_120000_"
+        ts_file = output_dir / f"{prefix}#Creator 2026-03-06 123.ts"
         ts_file.write_bytes(b"ts")
 
         def fake_merge(ts_files, output_path):
@@ -93,30 +94,28 @@ class TestMergeFlow:
 
         event = monitor._merge_session_to_mp4(
             MergeJobSpec(
-                session_key=session_key,
+                session_key="creator1:2026-03-06T12:00:00",
                 creator_name="Creator",
                 title="123",
                 stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
-                staging_dir=staging_dir,
+                output_dir=output_dir,
+                session_prefix=prefix,
             )
         )
 
         assert isinstance(event, MergeFailed)
-        assert event.failed_staging_dir == (
-            tmp_path / "archive" / "Creator" / "_failed" / monitor._make_session_dir_name(session_key)
-        )
-        assert (event.failed_staging_dir / "#Creator 2026-03-06 123.ts").exists()
-        assert not ts_file.exists()
+        assert ts_file.exists()
+        assert not (tmp_path / "archive" / "Creator" / "_failed").exists()
         monitor.shutdown()
 
     def test_merge_timeout_returns_failure_event(self, tmp_path, monkeypatch):
         """Test ffmpeg timeout becomes a merge failure event."""
         monkeypatch.chdir(tmp_path)
         monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=None)
-        session_key = "creator1:2026-03-06T12:00:00"
-        staging_dir = monitor._build_staging_dir("Creator", session_key)
-        staging_dir.mkdir(parents=True)
-        (staging_dir / "#Creator 2026-03-06 123.ts").write_bytes(b"ts")
+        output_dir = tmp_path / "archive" / "Creator"
+        output_dir.mkdir(parents=True)
+        prefix = "20260306_120000_"
+        (output_dir / f"{prefix}#Creator 2026-03-06 123.ts").write_bytes(b"ts")
 
         def fake_merge(ts_files, output_path):
             raise subprocess.TimeoutExpired(cmd=["ffmpeg"], timeout=1)
@@ -125,11 +124,12 @@ class TestMergeFlow:
 
         event = monitor._merge_session_to_mp4(
             MergeJobSpec(
-                session_key=session_key,
+                session_key="creator1:2026-03-06T12:00:00",
                 creator_name="Creator",
                 title="123",
                 stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
-                staging_dir=staging_dir,
+                output_dir=output_dir,
+                session_prefix=prefix,
             )
         )
 
@@ -137,14 +137,52 @@ class TestMergeFlow:
         assert "timeout" in event.error_message.lower()
         monitor.shutdown()
 
+    def test_merge_only_picks_up_ts_files_matching_session_prefix(self, tmp_path, monkeypatch):
+        """Test merge globs only ts files with the correct session prefix."""
+        monkeypatch.chdir(tmp_path)
+        monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=None)
+        output_dir = tmp_path / "archive" / "Creator"
+        output_dir.mkdir(parents=True)
+
+        prefix = "20260306_120000_"
+        target_ts = output_dir / f"{prefix}#Creator 2026-03-06 123.ts"
+        target_ts.write_bytes(b"ts")
+
+        # A ts file from a different session — must NOT be picked up
+        other_ts = output_dir / "20260305_090000_#Creator 2026-03-05 Old.ts"
+        other_ts.write_bytes(b"ts")
+
+        captured_files = []
+
+        def fake_merge(ts_files, output_path):
+            captured_files.extend(ts_files)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(b"mp4")
+
+        monitor._run_ffmpeg_merge = fake_merge
+
+        monitor._merge_session_to_mp4(
+            MergeJobSpec(
+                session_key="creator1:2026-03-06T12:00:00",
+                creator_name="Creator",
+                title="123",
+                stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
+                output_dir=output_dir,
+                session_prefix=prefix,
+            )
+        )
+
+        assert captured_files == [target_ts]
+        assert other_ts.exists()  # untouched
+        monitor.shutdown()
 
     def test_run_ffmpeg_merge_escapes_single_quotes_in_concat_paths(self, tmp_path, monkeypatch):
         """Test concat input escapes apostrophes in fragment paths."""
         monkeypatch.chdir(tmp_path)
         monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=None)
-        staging_dir = tmp_path / "staging"
-        staging_dir.mkdir()
-        ts_file = staging_dir / "#Creator 2026-03-06 it's live.ts"
+        output_dir = tmp_path / "archive" / "Creator"
+        output_dir.mkdir(parents=True)
+        ts_file = output_dir / "#Creator 2026-03-06 it's live.ts"
         ts_file.write_bytes(b"ts")
         output_path = tmp_path / "archive" / "Creator" / "final.mp4"
         captured = {}

--- a/tests/test_monitor_events.py
+++ b/tests/test_monitor_events.py
@@ -32,12 +32,13 @@ def test_raw_completion_event_immediately_submits_merge(tmp_path):
         title="Test Stream",
         stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
         state=SessionState.RAW_RUNNING,
-        staging_dir=tmp_path,
+        output_dir=tmp_path,
+        session_prefix="20260306_120000_",
     )
 
     with patch.object(monitor.merge_executor, "submit_merge") as mock_submit:
         monitor._on_raw_download_complete(
-            RawDownloadCompleted(session_key=session_key, staging_dir=tmp_path)
+            RawDownloadCompleted(session_key=session_key, output_dir=tmp_path)
         )
         monitor._event_queue.join()
 
@@ -62,7 +63,8 @@ def test_raw_failure_event_allows_same_session_retry(tmp_path):
         title="Test Stream",
         stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
         state=SessionState.RAW_RUNNING,
-        staging_dir=tmp_path,
+        output_dir=tmp_path,
+        session_prefix="20260306_120000_",
     )
     mock_stream = MagicMock()
     mock_stream.creator_oid = "creator1"
@@ -96,7 +98,8 @@ def test_get_active_downloads_uses_session_state_only(tmp_path):
         title="Test Stream",
         stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
         state=SessionState.RAW_RUNNING,
-        staging_dir=tmp_path,
+        output_dir=tmp_path,
+        session_prefix="20260306_120000_",
     )
 
     assert monitor.get_active_downloads() == ["Creator1"]
@@ -133,7 +136,8 @@ def test_unhandled_session_event_logs_error(tmp_path):
         title="Test Stream",
         stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
         state=SessionState.MERGE_QUEUED,
-        staging_dir=tmp_path,
+        output_dir=tmp_path,
+        session_prefix="20260306_120000_",
     )
 
     class UnknownSessionEvent:
@@ -174,7 +178,8 @@ def test_shutdown_drains_pending_raw_completion_before_executor_shutdown(tmp_pat
         title="Test Stream",
         stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
         state=SessionState.RAW_RUNNING,
-        staging_dir=tmp_path,
+        output_dir=tmp_path,
+        session_prefix="20260306_120000_",
     )
 
     handle_started = ThreadEvent()
@@ -214,7 +219,7 @@ def test_shutdown_drains_pending_raw_completion_before_executor_shutdown(tmp_pat
         ),
     ):
         monitor._on_raw_download_complete(
-            RawDownloadCompleted(session_key=session_key, staging_dir=tmp_path)
+            RawDownloadCompleted(session_key=session_key, output_dir=tmp_path)
         )
         assert handle_started.wait(timeout=1)
 

--- a/tests/test_rplay.py
+++ b/tests/test_rplay.py
@@ -288,10 +288,9 @@ class TestValidateM3u8Url:
         assert result is False
 
     @responses.activate
-    @pytest.mark.parametrize("status_code", [403, 404])
-    def test_does_not_retry_blocked_statuses(self, status_code):
-        """Test blocked statuses stop validation immediately."""
-        responses.add(responses.HEAD, self.TEST_URL, status=status_code)
+    def test_does_not_retry_blocked_statuses(self):
+        """Test 403 stops validation immediately without retry."""
+        responses.add(responses.HEAD, self.TEST_URL, status=403)
         api = RPlayAPI(auth_token="test", user_oid="test")
 
         with patch("time.sleep"):
@@ -299,6 +298,33 @@ class TestValidateM3u8Url:
 
         assert result is False
         assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_retries_on_404_before_giving_up(self):
+        """Test 404 is retried before returning False (stream may not be ready yet)."""
+        responses.add(responses.HEAD, self.TEST_URL, status=404)
+        responses.add(responses.HEAD, self.TEST_URL, status=404)
+        responses.add(responses.HEAD, self.TEST_URL, status=404)
+        api = RPlayAPI(auth_token="test", user_oid="test")
+
+        with patch("time.sleep"):
+            result = api.validate_m3u8_url(self.TEST_URL, retries=3, retry_delay=0.1)
+
+        assert result is False
+        assert len(responses.calls) == 3
+
+    @responses.activate
+    def test_returns_true_after_404_then_200(self):
+        """Test returns True when 404 is followed by 200 on retry."""
+        responses.add(responses.HEAD, self.TEST_URL, status=404)
+        responses.add(responses.HEAD, self.TEST_URL, status=200)
+        api = RPlayAPI(auth_token="test", user_oid="test")
+
+        with patch("time.sleep"):
+            result = api.validate_m3u8_url(self.TEST_URL, retries=3, retry_delay=0.1)
+
+        assert result is True
+        assert len(responses.calls) == 2
 
     @responses.activate
     def test_401_raises_auth_error_during_validation(self):


### PR DESCRIPTION
## Summary

Replaces the `.staging/<session_id>/` directory isolation model with a flat
`archive/<creator_name>/` layout using timestamp-prefixed filenames. Each
recording session is now uniquely identified by its filename prefix
(`YYYYMMDD_HHMMSS_`) rather than a dedicated subdirectory.

### Architecture Changes

**Flat output layout**
- Recording files are written directly to `archive/<creator_name>/` instead
  of `.staging/<session_id>/` subdirectories
- Each session is identified by a `session_prefix` (`YYYYMMDD_HHMMSS_`)
  derived from `recording_started_at` converted to machine local time
- On merge success, the matched `.ts` files are deleted in-place; on merge
  failure they remain in `archive/<creator_name>/` for manual recovery
  (no `_failed/` directory)

**Model changes (`models/download.py`)**
- `DownloadSession`: `staging_dir` → `output_dir: Path` + `session_prefix: str`
- `RawDownloadCompleted`: `staging_dir` → `output_dir: Path`
- `MergeJobSpec`: `staging_dir` → `output_dir: Path` + `session_prefix: str`
- `MergeFailed`: removed `failed_staging_dir` field

**Downloader (`core/downloader.py`)**
- Added `filename_prefix: str` parameter; prepended to output filenames
- `_notify_download_complete` emits `output_dir` (parent of output file)
  instead of `staging_dir`

**Monitor (`core/live_stream_monitor.py`)**
- Removed: `_build_staging_dir`, `_move_failed_staging_dir`,
  `_make_session_dir_name`, `import shutil`
- Added: `_build_session_output_dir(creator_name)` →
  `Path.cwd() / ARCHIVE_DIR / creator_name`
- Added: `_make_session_prefix(recording_started_at)` →
  local-time `strftime("%Y%m%d_%H%M%S_")`
- Merge globs `output_dir.glob(f"{session_prefix}*.ts")` for session-scoped
  file selection

**API client (`core/rplay.py`)**
- `validate_m3u8_url` now retries on HTTP 404 with exponential backoff
  before returning `False`; 403 remains non-retriable (paid content wall)
  This prevents streams from being incorrectly marked inaccessible during
  the brief window when a stream is just starting up

**Documentation & config (`README.md`, `docker-compose.yaml`)**
- Removed "What's New in v2" section; updated all staging/`_failed/` references
- Fixed `docker-compose.yaml` volume mount from `./env` to `./.env`
- Unified `.env` usage across both Docker Compose and local runs

### Commits (8)

**chore (1)**
- `chore: bump version to 2.1.0-vibe`

**feat (1)**
- `feat(downloader): add filename_prefix support and emit output_dir on completion`

**refactor (2)**
- `refactor(models): replace staging_dir with output_dir + session_prefix`
- `refactor(monitor): replace staging dir with flat output_dir and session prefix`

**fix (2)**
- `fix(monitor): use local time for session prefix; remove dead output_dir reassignment`
- `fix(rplay): retry M3U8 404 before marking stream inaccessible`

**test (1)**
- `test(merge): rewrite merge flow tests for flat ts prefix layout`

**docs (1)**
- `docs: update README and docker-compose for v2.1.0`

### Testing

- 341 unit tests pass
- `test_merge_flow.py` fully rewritten for flat layout
- New test: `test_merge_only_picks_up_ts_files_matching_session_prefix`
- New test: `test_failed_merge_leaves_ts_files_in_output_dir`
- New tests: `test_retries_on_404_before_giving_up`, `test_returns_true_after_404_then_200`