### PR TITLE
fix: correct filename timezone, ffmpeg quoting, and env loading

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@ Dockerfile
 # Environment and config
 .env*
 config.yaml*
+config/
 .vscode/
 .pytest_cache/
 __pycache__/
@@ -26,3 +27,4 @@ logs/
 *.egg-info/
 .coverage
 .venv/
+tests/

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,6 +11,8 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
@@ -20,6 +22,12 @@ jobs:
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Refuse to publish a tag that is not on main
+              run: |
+                  git fetch --no-tags origin main
+                  git merge-base --is-ancestor "${{ github.sha }}" origin/main \
+                    || { echo "::error::tag is not an ancestor of main"; exit 1; }
 
             - name: Build and push
               uses: docker/build-push-action@v5

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Environment variables:
 Notes:
 
 - local runs load from `.env` or process environment variables
-- the bundled Docker Compose file mounts `.env` to `/app/.env`
+- the bundled Docker Compose file loads `.env` through `env_file`, so its values become real container environment variables
 - `LOG_YTDLP_INTERNAL=true` is only for deep diagnosis; it is intentionally noisy
 
 #### Creator configuration
@@ -254,7 +254,7 @@ The v2 runtime uses a session-aware download pipeline.
    - it checks live status for all configured creators
 
 2. **Create a session**
-   - each live stream gets a session key based on `creator_oid` and the API `oid`
+   - each live stream gets a session key based on `creator_oid` and the local recording start time (`recording_started_at`), not the API stream `oid`
    - a timestamp prefix (`YYYYMMDD_HHMMSS_`) is derived from `recording_started_at` in machine local time
    - raw files are written directly to `archive/<creator>/` using this prefix for isolation
 
@@ -319,9 +319,8 @@ docker compose pull
 docker compose up -d
 ```
 
-The bundled `docker-compose.yaml` mounts:
+The bundled `docker-compose.yaml` reads `./.env` via `env_file`, and mounts:
 
-- `./.env` → `/app/.env`
 - `./config` → `/app/config`
 - `./archive` → `/app/archive`
 - `./logs` → `/app/logs`
@@ -330,11 +329,11 @@ The bundled `docker-compose.yaml` mounts:
 
 ```bash
 docker run -d \
-  -v $(pwd)/.env:/app/.env \
+  --env-file .env \
   -v $(pwd)/config:/app/config \
   -v $(pwd)/archive:/app/archive \
   -v $(pwd)/logs:/app/logs \
-  paverz/rplay-live-dl:latest
+  paverz/rplay-live-dl:v2.1.1-vibe
 ```
 
 ### Directory Structure
@@ -520,7 +519,6 @@ rplay-live-dl/
 ├── main.py
 ├── poetry.lock
 ├── pyproject.toml
-├── requirements.txt
 └── README.md
 ```
 

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -403,7 +403,6 @@ class LiveStreamMonitor:
         self._remove_session(session_key)
 
         if isinstance(exc, RPlayAuthError):
-            self._mark_check_failed()
             self.logger.error(
                 f"Auth error for {creator_name}: {exc}. "
                 "Please verify AUTH_TOKEN and USER_OID credentials."

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -403,6 +403,7 @@ class LiveStreamMonitor:
         self._remove_session(session_key)
 
         if isinstance(exc, RPlayAuthError):
+            self._mark_check_failed()
             self.logger.error(
                 f"Auth error for {creator_name}: {exc}. "
                 "Please verify AUTH_TOKEN and USER_OID credentials."
@@ -900,7 +901,7 @@ class LiveStreamMonitor:
     ) -> Path:
         """Reserve the next available final mp4 output path."""
         safe_title = sanitize_filename(title, replacement_text="_") or "untitled"
-        date_str = stream_start_time.strftime("%Y-%m-%d")
+        date_str = stream_start_time.astimezone().strftime("%Y-%m-%d")
         base_dir = Path.cwd() / StreamDownloader.ARCHIVE_DIR / creator_name
         base_dir.mkdir(parents=True, exist_ok=True)
 
@@ -949,7 +950,7 @@ class LiveStreamMonitor:
 
     def _format_ffconcat_input_path(self, ts_file: Path) -> str:
         """Format one concat-demuxer input line with apostrophe-safe escaping."""
-        escaped_path = ts_file.resolve().as_posix().replace("'", "'\''")
+        escaped_path = ts_file.resolve().as_posix().replace("'", r"'\''")
         return f"file '{escaped_path}'"
 
     def shutdown(self) -> None:

--- a/core/logger.py
+++ b/core/logger.py
@@ -18,7 +18,6 @@ from typing import Any, Dict, List, Optional
 
 import colorlog
 import wcwidth
-from dotenv import dotenv_values
 
 __all__ = [
     "setup_logger",
@@ -45,18 +44,6 @@ def _get_log_retention_days() -> int:
     return int(os.getenv("LOG_RETENTION_DAYS", "30"))
 
 
-def _read_log_level_from_dotenv() -> Optional[str]:
-    """Read LOG_LEVEL from the working-directory .env file when present."""
-    dotenv_path = Path.cwd() / ".env"
-    if not dotenv_path.exists():
-        return None
-
-    value = dotenv_values(dotenv_path).get(LOG_LEVEL_ENV_VAR)
-    if value is None:
-        return None
-    return str(value)
-
-
 def _parse_log_level(value: Optional[str]) -> Optional[int]:
     """Parse a case-insensitive log level name into a logging constant."""
     if value is None:
@@ -71,14 +58,11 @@ def _parse_log_level(value: Optional[str]) -> Optional[int]:
 
 
 def _resolve_log_level(level: Optional[int]) -> int:
-    """Resolve the configured log level from explicit args, env, or .env."""
+    """Resolve the configured log level from explicit args or env, else INFO."""
     if level is not None:
         return level
 
     configured_value = os.getenv(LOG_LEVEL_ENV_VAR)
-    if configured_value is None:
-        configured_value = _read_log_level_from_dotenv()
-
     parsed_level = _parse_log_level(configured_value)
     if parsed_level is None:
         return DEFAULT_LOG_LEVEL

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,12 +1,12 @@
 services:
   rplay-live-dl:
-    image: paverz/rplay-live-dl:latest
+    image: paverz/rplay-live-dl:v2.1.1-vibe
     container_name: rplay-live-dl
+    env_file: .env
     environment:
       - PYTHONUNBUFFERED=1
       - TZ=Asia/Taipei
     volumes:
-      - ./.env:/app/.env
       - ./config:/app/config
       - ./archive:/app/archive
       - ./logs:/app/logs

--- a/main.py
+++ b/main.py
@@ -8,6 +8,8 @@ import sys
 import tomllib
 from pathlib import Path
 
+from dotenv import load_dotenv
+
 from core.env import EnvConfigError, load_env
 from core.logger import cleanup_old_logs, setup_logger
 from core.scheduler import run_scheduler
@@ -25,6 +27,7 @@ __version__ = _read_version()
 
 def main() -> None:
     """Main entry point for the application."""
+    load_dotenv()
     logger = setup_logger("Main")
 
     # Cleanup old log files on startup

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -156,10 +156,10 @@ class TestLoadEnv:
 class TestLogConfigEnvVars:
     """Tests for log configuration environment variables."""
 
-    def test_log_config_defaults(self, monkeypatch):
+    def test_log_config_defaults(self, no_dotenv_file):
         """Test default values for log configuration."""
-        monkeypatch.setenv("AUTH_TOKEN", "test_token")
-        monkeypatch.setenv("USER_OID", "test_oid")
+        no_dotenv_file.setenv("AUTH_TOKEN", "test_token")
+        no_dotenv_file.setenv("USER_OID", "test_oid")
 
         config = load_env()
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -60,16 +60,6 @@ class TestSetupLogger:
 
         assert logger.level == logging.DEBUG
 
-    def test_uses_log_level_from_dotenv_when_env_missing(self, monkeypatch, tmp_path):
-        """Test LOG_LEVEL is read from .env when the process env var is absent."""
-        monkeypatch.delenv("LOG_LEVEL", raising=False)
-        monkeypatch.chdir(tmp_path)
-        (tmp_path / ".env").write_text("LOG_LEVEL=WARNING\n", encoding="utf-8")
-
-        logger = setup_logger("test_logger_dotenv_warning", log_to_file=False)
-
-        assert logger.level == logging.WARNING
-
     def test_invalid_log_level_falls_back_to_info(self, monkeypatch, tmp_path):
         """Test invalid LOG_LEVEL values fall back to INFO."""
         monkeypatch.delenv("LOG_LEVEL", raising=False)

--- a/tests/test_merge_flow.py
+++ b/tests/test_merge_flow.py
@@ -1,12 +1,32 @@
 """Tests for session merge flow."""
 
 import subprocess
+import time
 from pathlib import Path
 from unittest.mock import patch
-from datetime import datetime
+from datetime import datetime, timezone
+
+import pytest
 
 from core.live_stream_monitor import LiveStreamMonitor
 from models.download import MergeCompleted, MergeFailed, MergeJobSpec
+
+
+@pytest.fixture
+def taipei_timezone(monkeypatch):
+    """Pin the process timezone to UTC+8 so date-boundary assertions are host independent."""
+    # time.tzset() is POSIX-only; on Windows the process timezone cannot be rebound.
+    tzset = getattr(time, "tzset", None)
+    if tzset is None:
+        pytest.skip("pinning the process timezone requires POSIX time.tzset()")
+
+    monkeypatch.setenv("TZ", "Asia/Taipei")
+    tzset()
+    try:
+        yield
+    finally:
+        monkeypatch.undo()
+        tzset()
 
 
 class TestMergeFlow:
@@ -193,6 +213,25 @@ class TestMergeFlow:
         with patch("core.live_stream_monitor.subprocess.run", side_effect=fake_run):
             monitor._run_ffmpeg_merge([ts_file], output_path)
 
-        escaped = ts_file.resolve().as_posix().replace("'", "'\''")
-        assert captured["content"] == f"file '{escaped}'"
+        assert r"it'\''s live.ts" in captured["content"]
+        monitor.shutdown()
+
+    def test_reserve_final_output_path_uses_local_timezone_for_date(
+        self, tmp_path, monkeypatch, taipei_timezone
+    ):
+        """Test the mp4 filename date uses local time, not raw UTC (tz regression guard)."""
+        monkeypatch.chdir(tmp_path)
+        monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=None)
+
+        # 2026-03-06 23:50 UTC is 2026-03-07 07:50 in Asia/Taipei (UTC+8).
+        stream_start_time = datetime(2026, 3, 6, 23, 50, 0, tzinfo=timezone.utc)
+
+        output_path = monitor._reserve_final_output_path(
+            creator_name="Creator",
+            title="Title",
+            stream_start_time=stream_start_time,
+        )
+
+        assert "2026-03-07" in output_path.name
+        assert "2026-03-06" not in output_path.name
         monitor.shutdown()


### PR DESCRIPTION
﻿## Summary

Four independent correctness and packaging defects, each small and self-contained. They share one theme: the app silently did the wrong thing and nothing surfaced it.

The filename timezone bug and the ffmpeg escaping bug both corrupt recordings the user believes were captured successfully. The `.env` bug made four documented settings inert under Docker. The remaining two close a privacy leak and an unguarded release path.

A fifth fix was attempted and deliberately withdrawn — see *Withdrawn* below.

## Changes

**Correctness**

- `core/live_stream_monitor.py` — the final mp4 name mixed two timezones. The session prefix used local time while the date came from the raw UTC `stream_start_time`, so a 07:50 stream in UTC+8 was filed under the previous day.
- `core/live_stream_monitor.py` — the ffmpeg concat escape emitted three apostrophes instead of the shell-style close/escape/reopen sequence. Verified against real ffmpeg: a list line `file '.../it'''s a stream.ts'` resolves to the path `.../its`, so the merge fails and the raw `.ts` files are stranded permanently.

**Configuration**

- `main.py`, `core/logger.py` — nothing ever called `load_dotenv()`. pydantic-settings reads `.env` into its own model without touching `os.environ`, so every `os.getenv` call fell back to defaults under Docker. `LOG_MAX_SIZE_MB`, `LOG_BACKUP_COUNT`, `LOG_RETENTION_DAYS` and `LOG_YTDLP_INTERNAL` were documented but inert. The bespoke `_read_log_level_from_dotenv` fallback patched only `LOG_LEVEL` and is now dead code.
- `docker-compose.yaml` — bind-mounting `./.env` creates a directory when the file is missing. `env_file` avoids that and puts the values in the real container environment. Image tag pinned off `latest`.
- `.dockerignore` — ignore patterns are not recursive, so `config.yaml*` never matched `config/config.yaml` and real creator OIDs were copied into locally built images. `config/` is a volume mount point and never belonged in the image.

**Release**

- `.github/workflows/main.yaml` — the release workflow built and pushed on any tag with no test dependency. `needs:` cannot reference the `test` job in `test.yml`, so this asserts the tagged commit is an ancestor of `main`, which branch protection keeps green.

**Tests**

- `tests/test_merge_flow.py` — the ffconcat escaping test computed its expected value with the same expression as the implementation. A mirror assertion cannot fail, so the escaping bug above was fully covered and still shipped. The expected escape sequence is now a literal.
- `tests/test_merge_flow.py` — new timezone regression guard. It pins the process timezone to `Asia/Taipei` rather than depending on the host, so the date-boundary assertion is a hard-coded constant. Skipped on Windows, where `time.tzset()` does not exist.
- `tests/test_env.py` — `test_log_config_defaults` read the developer's real `.env` and passed only because CI has no such file. Switched to the isolation fixture already used elsewhere in that module.

**Docs**

- `README.md` — session keys use the local recording start time, not the API stream `oid`. `requirements.txt` does not exist. The `.env` bind mount was replaced by `env_file` in three places.

## Withdrawn

Marking the health check failed on auth errors was implemented, reviewed, and then removed in `revert(monitor)`.

It had no observable effect. `_handle_start_download_error` swallows the exception, the poll cycle continues, and `_run_poll_cycle` unconditionally calls `_mark_check_succeeded()` at the end, overwriting the flag. Shipping it would have advertised a fix that does nothing.

Re-raising so the existing cycle-level handler marks the monitor unhealthy is worse. `_get_stream_key` classifies auth failures with `_is_auth_status_code`, which treats **403** as an auth error — and 403 is exactly what a paid or unsubscribed stream returns. Re-raising would abort the entire poll and report the monitor unhealthy whenever one paid creator goes live.

Doing this correctly requires separating 401 from 403 in the API error taxonomy. That is design work, not a one-line fix, and it is tracked separately.

## Review decisions

Two suggestions from the over-engineering review were rejected, recorded here for the next reader:

- *Drop `fetch-depth: 0` from the release workflow.* Rejected. `actions/checkout` defaults to a shallow clone, and `git merge-base --is-ancestor` cannot decide ancestry against truncated history. Removing it would leave a release gate that silently stops gating.
- *Drop the timezone regression test entirely, since the fix is one line.* Rejected. The bug is invisible on a UTC host, already shipped once undetected, and produces silently misfiled recordings. This is precisely the case where a guard earns its keep.

## Verification

```
$ poetry run pytest -q
tests\test_scheduler.py ............................                     [ 95%]
tests\test_utils.py ...............                                      [100%]

======================= 341 passed, 1 skipped in 36.68s =======================
```

The single local skip is the new timezone guard, which requires POSIX `time.tzset()` and is exercised on the Linux CI runners rather than the Windows dev host.

The ffmpeg escaping claim was established empirically before the fix, using a generated mpegts segment whose filename contains an apostrophe:

```
apostrophe + previous escaping : FAIL   (ffmpeg: Impossible to open '.../its')
apostrophe + this change       : PASS
no apostrophe (control)        : PASS
```

## Acceptance

*Corrected after merge: the original list presented all six items as if they had been checked. Only the first three were verified at merge time; the last three were not — recorded here honestly rather than left implied.*

Verified at merge:

- [x] `test (3.11)` and `test (3.12)` green (CI on this PR)
- [x] The timezone guard executes on CI rather than skipping, proving the fix on a POSIX host (visible in the CI test output)
- [x] A title containing an apostrophe no longer strands its raw `.ts` files (empirical ffmpeg experiment in Verification above)

Not verified at merge time:

- [x] `docker build .` produces an image with no `config/` directory — verified later by the `docker-smoke` CI job added in #34, which builds the image and asserts `/app/config` does not exist
- [x] The four log settings in `.env` take effect under Docker Compose — verified 2026-07-28 on a Linux deployment host running `paverz/rplay-live-dl:v2.2.0-vibe` via `docker compose up -d` with test values in `.env`: `LOG_RETENTION_DAYS=1` deleted a prefilled 3-day-old log at startup ("Cleaned up 1 old log file(s)"), `LOG_MAX_SIZE_MB=1` rotated a prefilled 1.1 MB `Monitor.log` on first emit, `LOG_BACKUP_COUNT=2` pruned the oldest backup instead of creating `.log.3`, and `LOG_YTDLP_INTERNAL=true` (with `LOG_LEVEL=DEBUG`) produced `yt-dlp:` debug lines during a real live download. Bonus: `docker compose stop` during that recording delivered the true production SIGTERM — "Received SIGTERM, shutting down gracefully...", "Terminated 1 download subprocess(es) left running by yt-dlp", exit code 0 in 0.6 s, and the next startup's orphan scan listed the leftover `.ts.part`. (The rotation exercise also exposed a pre-existing `LazyRotatingFileHandler` rollover crash — tracked separately.)
- [ ] Tagging a commit that is not an ancestor of `main` fails the release workflow — logic reviewed only; never exercised with a real tag push


