### PR TITLE
refactor(logging): collapse one event into one line and clip long titles

### DIFF
--- a/core/downloader.py
+++ b/core/downloader.py
@@ -187,11 +187,18 @@ class StreamDownloader:
         # Configure yt-dlp options
         ydl_opts = self._build_ydl_options(output_path)
 
-        self._log("info", f"📥 Starting download: \"{safe_title}\"")
-        self._log("info", f"   Output: {output_path.name}")
+        # The title already appeared on the monitor's "is live" line; repeating it
+        # here (and again in the output filename) is what made one event span
+        # three lines. The session prefix is what ties this log to a file on disk.
+        session_prefix = (self.filename_prefix or "").rstrip("_")
+        self._log(
+            "info",
+            f"📥 Recording started (session {session_prefix})" if session_prefix
+            else "📥 Recording started",
+        )
         self._log(
             "debug",
-            f"   Context: session_key={self.session_key or 'none'}, output_path={output_path}",
+            f"session_key={self.session_key or 'none'}, output_path={output_path}",
         )
 
         # Start download in a separate thread
@@ -459,15 +466,20 @@ class StreamDownloader:
             for attempt in self._build_download_retrying():
                 with attempt:
                     attempt_number = attempt.retry_state.attempt_number
-                    self._log(
-                        "info",
-                        f"🔁 Download attempt {attempt_number}/{self.DOWNLOAD_TASK_RETRY_ATTEMPTS} started: "
-                        f"session_key={self.session_key or 'none'}, output={output_path.name}",
-                    )
+                    # The first attempt is already implied by "Recording started".
+                    # Only a retry is worth a line of its own.
+                    if attempt_number > 1:
+                        self._log(
+                            "info",
+                            f"🔁 Retry {attempt_number}/{self.DOWNLOAD_TASK_RETRY_ATTEMPTS}",
+                        )
                     if self.logger.isEnabledFor(logging.DEBUG):
                         self._log(
                             "debug",
-                            f"   Attempt context: {self._build_output_state_details(output_path)}",
+                            f"attempt {attempt_number}/{self.DOWNLOAD_TASK_RETRY_ATTEMPTS}, "
+                            f"session_key={self.session_key or 'none'}, "
+                            f"output={output_path.name}, "
+                            f"{self._build_output_state_details(output_path)}",
                         )
                     try:
                         with yt_dlp.YoutubeDL(ydl_opts) as ydl:

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -187,15 +187,6 @@ class StreamDownloader:
         # Configure yt-dlp options
         ydl_opts = self._build_ydl_options(output_path)
 
-        # The title already appeared on the monitor's "is live" line; repeating it
-        # here (and again in the output filename) is what made one event span
-        # three lines. The session prefix is what ties this log to a file on disk.
-        session_prefix = (self.filename_prefix or "").rstrip("_")
-        self._log(
-            "info",
-            f"📥 Recording started (session {session_prefix})" if session_prefix
-            else "📥 Recording started",
-        )
         self._log(
             "debug",
             f"session_key={self.session_key or 'none'}, output_path={output_path}",
@@ -209,6 +200,20 @@ class StreamDownloader:
             daemon=True,
         )
         self.download_thread.start()
+
+        # Logged only once the thread is actually running. This is now the sole
+        # confirmation that a recording began, so it must not be emitted while
+        # Thread.start() can still raise.
+        #
+        # The title already appeared on the monitor's "is live" line; repeating it
+        # here (and again in the output filename) is what made one event span
+        # three lines. The session prefix is what ties this log to a file on disk.
+        session_prefix = (self.filename_prefix or "").rstrip("_")
+        self._log(
+            "info",
+            f"📥 Recording started (session {session_prefix})" if session_prefix
+            else "📥 Recording started",
+        )
 
     def is_alive(self) -> bool:
         """

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -29,7 +29,7 @@ from models.rplay import CreatorStreamState, LiveStream, StreamState
 from .config import ConfigError, DEFAULT_CONFIG_PATH, read_app_config as read_config
 from .download_merge_executor import DownloadMergeExecutor
 from .downloader import StreamDownloader
-from .logger import setup_logger
+from .logger import bind, clip, setup_logger
 from .rplay import RPlayAPI, RPlayAPIError, RPlayAuthError, RPlayConnectionError
 
 __all__ = [
@@ -329,7 +329,7 @@ class LiveStreamMonitor:
             creator_name=creator_name,
             recording_started_at=recording_started_at,
         )
-        self.logger.info(f'🔴 {creator_name} is live: "{stream.title}"')
+        bind(self.logger, creator_name).info(f'🔴 Live: "{clip(stream.title)}"')
 
         try:
             self._launch_session_downloader(
@@ -361,8 +361,9 @@ class LiveStreamMonitor:
             on_download_failure=self._on_raw_download_failed,
         )
 
+        # The downloader logs "Recording started" itself; repeating it here added
+        # a line that carried no information the previous one did not already have.
         active_downloader.download(stream_url, title)
-        self.logger.info(f"⬇️  Started downloading: {session.creator_name}")
 
     def _handle_start_download_error(
         self,

--- a/core/logger.py
+++ b/core/logger.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import colorlog
-import wcwidth
 
 __all__ = [
     "setup_logger",
@@ -89,105 +88,27 @@ LOG_COLORS = {
 }
 
 
-def _get_display_width(text: str) -> int:
+def _fit(text: str, width: int) -> str:
+    """Center text in a fixed-width column, truncating anything that overflows."""
+    return f"{text:^{width}.{width}}"
+
+
+class ContextAdapter(logging.LoggerAdapter):
+    """Prefix every message with a stable ``[context]`` tag."""
+
+    def process(self, msg: Any, kwargs: Any) -> Any:
+        context = (self.extra or {}).get("context")
+        return (f"[{context}] {msg}" if context else msg), kwargs
+
+
+def bind(logger: logging.Logger, context: str) -> logging.LoggerAdapter:
     """
-    Calculate the display width of a string using wcwidth.
+    Bind a logger to a stable context tag, usually the creator name.
 
-    This properly handles East Asian characters (CJK) and emojis
-    that take multiple terminal columns.
-
-    Args:
-        text: The string to measure
-
-    Returns:
-        The display width in terminal columns
+    Every message logged through the returned adapter is prefixed with
+    ``[context]``, so one recording can be followed with a single grep.
     """
-    width = 0
-    for char in text:
-        char_width = wcwidth.wcwidth(char)
-        # wcwidth returns -1 for non-printable characters, treat as 0
-        if char_width < 0:
-            char_width = 0
-        width += char_width
-    return width
-
-
-def _truncate_to_width(text: str, max_width: int, suffix: str = "…") -> str:
-    """
-    Truncate a string to fit within a maximum display width.
-
-    Args:
-        text: The string to truncate
-        max_width: Maximum display width allowed
-        suffix: Suffix to append when truncating (default: "…")
-
-    Returns:
-        Truncated string that fits within max_width
-    """
-    current_width = _get_display_width(text)
-    if current_width <= max_width:
-        return text
-
-    suffix_width = _get_display_width(suffix)
-    target_width = max_width - suffix_width
-
-    # Build truncated string character by character
-    result = []
-    width = 0
-    for char in text:
-        char_width = wcwidth.wcwidth(char)
-        if char_width < 0:
-            char_width = 0
-        if width + char_width > target_width:
-            break
-        result.append(char)
-        width += char_width
-
-    return "".join(result) + suffix
-
-
-def _pad_to_width(text: str, target_width: int) -> str:
-    """
-    Pad a string to a target display width.
-
-    If the text is longer than target_width, it will be returned as-is
-    (no truncation). If shorter, it will be padded with spaces.
-
-    Args:
-        text: The string to pad
-        target_width: The desired display width
-
-    Returns:
-        String padded to at least target_width display width
-    """
-    current_width = _get_display_width(text)
-    if current_width >= target_width:
-        return text
-    padding = target_width - current_width
-    return text + " " * padding
-
-
-def _center_to_width(text: str, target_width: int) -> str:
-    """
-    Center a string within a target display width.
-
-    If the text is longer than target_width, it will be returned as-is
-    (no truncation). If shorter, it will be padded with spaces on both sides.
-
-    Args:
-        text: The string to center
-        target_width: The desired display width
-
-    Returns:
-        String centered within target_width display width
-    """
-    current_width = _get_display_width(text)
-    if current_width >= target_width:
-        return text
-    total_padding = target_width - current_width
-    left_padding = total_padding // 2
-    right_padding = total_padding - left_padding
-    return " " * left_padding + text + " " * right_padding
+    return ContextAdapter(logger, {"context": context})
 
 
 class AlignedFormatter(logging.Formatter):
@@ -210,16 +131,8 @@ class AlignedFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         """Format the record with centered logger name and level."""
-        # Center the name
-        name = record.name
-        name = _truncate_to_width(name, self.name_width)
-        name = _center_to_width(name, self.name_width)
-        record.name = name
-
-        # Center the level name
-        levelname = record.levelname
-        record.levelname = _center_to_width(levelname, self.level_width)
-
+        record.name = _fit(record.name, self.name_width)
+        record.levelname = _fit(record.levelname, self.level_width)
         return super().format(record)
 
 
@@ -244,24 +157,18 @@ class ColoredAlignedFormatter(colorlog.ColoredFormatter):
 
     def format(self, record: logging.LogRecord) -> str:
         """Format the record with centered logger name and level."""
-        # Center the name
         original_name = record.name
-        name = _truncate_to_width(original_name, self.name_width)
-        name = _center_to_width(name, self.name_width)
-        record.name = name
+        record.name = _fit(original_name, self.name_width)
 
-        # Save original levelname for color lookup
+        # colorlog picks the colour by looking up record.levelname, so it has to
+        # stay unpadded until after formatting.
         original_levelname = record.levelname
-
-        # Let colorlog format with original levelname (for correct color lookup)
         result = super().format(record)
-
-        # Restore original name
         record.name = original_name
 
         # Replace levelname with centered version in the output
         # The format is: "date │ <color>LEVELNAME<reset> │ name │ message"
-        centered_levelname = _center_to_width(original_levelname, self.level_width)
+        centered_levelname = _fit(original_levelname, self.level_width)
         parts = result.split('│', 2)
         if len(parts) >= 2:
             parts[1] = parts[1].replace(original_levelname, centered_levelname, 1)

--- a/core/logger.py
+++ b/core/logger.py
@@ -129,6 +129,10 @@ def clip(text: str, columns: int = LOG_TEXT_MAX_COLUMNS, suffix: str = "…") ->
         return text
 
     budget = columns - _display_width(suffix)
+    if budget < 0:
+        # No room for the suffix itself; the contract is that the result never
+        # exceeds `columns`, so nothing can be shown.
+        return ""
     kept, used = [], 0
     for char in text:
         width = wcwidth.wcwidth(char)

--- a/core/logger.py
+++ b/core/logger.py
@@ -17,12 +17,16 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import colorlog
+import wcwidth
 
 __all__ = [
     "setup_logger",
     "cleanup_old_logs",
     "get_logs_dir",
+    "bind",
+    "clip",
     "DEFAULT_LOG_LEVEL",
+    "LOG_TEXT_MAX_COLUMNS",
 ]
 
 # Default log configuration
@@ -75,6 +79,11 @@ LOGGER_NAME_WIDTH = 10
 # Set to match the longest level name: "CRITICAL" = 8 characters
 LOG_LEVEL_WIDTH = 8
 
+# Column budget for user-controlled text (stream titles) inside a log message.
+# Measured live: with this cap every line fits in ~110 columns, while 10 of 16
+# real titles would otherwise wrap a 120-column terminal.
+LOG_TEXT_MAX_COLUMNS = 40
+
 # Global logs directory
 _logs_dir: Optional[Path] = None
 
@@ -91,6 +100,44 @@ LOG_COLORS = {
 def _fit(text: str, width: int) -> str:
     """Center text in a fixed-width column, truncating anything that overflows."""
     return f"{text:^{width}.{width}}"
+
+
+def _display_width(text: str) -> int:
+    """
+    Terminal columns occupied by text.
+
+    CJK characters and emoji occupy two columns each, so len() understates them
+    badly: a 40-character Japanese title is 80 columns wide.
+    """
+    total = 0
+    for char in text:
+        width = wcwidth.wcwidth(char)
+        # wcwidth returns -1 for unprintable characters; they occupy nothing.
+        total += width if width and width > 0 else 0
+    return total
+
+
+def clip(text: str, columns: int = LOG_TEXT_MAX_COLUMNS, suffix: str = "…") -> str:
+    """
+    Clip text to a terminal-column budget, keeping the front.
+
+    Stream titles are front-loaded: the bracketed category comes first and the
+    tail is usually the creator name or a timestamp, both of which already
+    appear elsewhere on the log line. Keeping the head is what stays useful.
+    """
+    if _display_width(text) <= columns:
+        return text
+
+    budget = columns - _display_width(suffix)
+    kept, used = [], 0
+    for char in text:
+        width = wcwidth.wcwidth(char)
+        width = width if width and width > 0 else 0
+        if used + width > budget:
+            break
+        kept.append(char)
+        used += width
+    return "".join(kept) + suffix
 
 
 class ContextAdapter(logging.LoggerAdapter):

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -80,12 +80,11 @@ class LiveStreamScheduler:
         periodic checks at the configured interval.
         """
         try:
-            self.logger.info("=" * 50)
-            self.logger.info(f"rplay-live-dl v{self.version}")
-            if self.git_sha:
-                self.logger.info(f"Git SHA: {self.git_sha[:7]}")
-            self.logger.info("=" * 50)
-            self.logger.info("Starting live stream monitoring system")
+            build = f" ({self.git_sha[:7]})" if self.git_sha else ""
+            self.logger.info(
+                f"rplay-live-dl v{self.version}{build} — "
+                f"checking every {self.env.interval}s"
+            )
 
             self.scheduler.add_job(
                 self.check_and_download,
@@ -96,9 +95,6 @@ class LiveStreamScheduler:
             # Perform initial check
             self.check_and_download()
 
-            self.logger.info(
-                f"Scheduler started, checking every {self.env.interval} seconds"
-            )
             self.scheduler.start()
 
         except KeyboardInterrupt:

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -525,8 +525,8 @@ class TestDownloadErrorCallback:
         downloader._download_worker("http://example.com/stream.m3u8", {}, output_path)
         callback.assert_not_called()
 
-    def test_logs_attempt_start_at_info(self, mock_yt_dlp, tmp_path):
-        """Test each full-task download attempt emits a concise INFO log."""
+    def test_first_attempt_is_not_logged_at_info(self, mock_yt_dlp, tmp_path):
+        """Test the first download attempt does not emit a redundant Retry INFO log."""
         mock_ydl_class, mock_ydl = mock_yt_dlp
         downloader = StreamDownloader(
             "TestCreator",
@@ -543,8 +543,8 @@ class TestDownloadErrorCallback:
                 output_path,
             )
 
-        assert any(
-            "🔁 Download attempt 1/3 started" in str(call)
+        assert not any(
+            "Retry" in str(call)
             for call in mock_info.call_args_list
         )
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -313,6 +313,23 @@ class TestDownloadMethod:
             for call in mock_log.call_args_list
         )
 
+    def test_does_not_log_recording_started_when_thread_fails_to_start(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Test a failed thread start leaves no misleading Recording started log."""
+        monkeypatch.chdir(tmp_path)
+        downloader = StreamDownloader("TestCreator")
+
+        with patch("core.downloader.threading.Thread") as mock_thread_class:
+            mock_thread_class.return_value.start.side_effect = RuntimeError(
+                "can't start new thread"
+            )
+            with pytest.raises(RuntimeError):
+                downloader.download("http://example.com/stream.m3u8", "Test Stream")
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert not any("Recording started" in message for message in messages)
+
 
 class TestDownloadWorker:
     """Tests for _download_worker method."""

--- a/tests/test_live_stream_monitor.py
+++ b/tests/test_live_stream_monitor.py
@@ -604,8 +604,8 @@ class TestStartDownload:
             "http://example.com/stream.m3u8", "Test Stream"
         )
 
-    def test_start_download_logs_live_emoji(self, mock_api, monitor):
-        """Test the first live log preserves the visible red-circle marker."""
+    def test_start_download_logs_live_line_with_creator_prefix(self, mock_api, monitor, caplog):
+        """Test the first live log carries the creator-prefixed context line."""
         mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
         mock_stream = MagicMock()
         mock_stream.creator_oid = "test_oid"
@@ -616,13 +616,11 @@ class TestStartDownload:
             creator_oid="test_oid",
         )
 
-        with (
-            patch('core.live_stream_monitor.StreamDownloader.download'),
-            patch.object(monitor.logger, 'info') as mock_info,
-        ):
+        with patch('core.live_stream_monitor.StreamDownloader.download'):
             monitor._start_download(mock_stream)
 
-        assert mock_info.call_args_list[0].args[0] == "🔴 TestCreator is live: \"Test Stream\""
+        messages = [record.getMessage() for record in caplog.records]
+        assert '[TestCreator] 🔴 Live: "Test Stream"' in messages
 
     def test_start_download_auth_error(self, mock_api, monitor):
         """Test auth error is logged."""
@@ -725,7 +723,12 @@ class TestCheckLiveStreams:
             user_oid="test_oid",
             api=mock_api,
         )
-        monitor.check_live_streams_and_start_download()
+        # Without this the monitor spawns a real yt-dlp thread against
+        # example.com. Its failure callback lands after this test returns and
+        # logs through the process-wide "Monitor" logger, which is how it used
+        # to pollute whichever test happened to be patching that logger.
+        with patch('core.live_stream_monitor.StreamDownloader.download'):
+            monitor.check_live_streams_and_start_download()
         mock_api.get_stream_url.assert_called_once_with("creator_oid")
 
     @patch('core.live_stream_monitor.read_config')

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -431,3 +431,13 @@ class TestClip:
         result = clip("a" * 40)
         assert result == "a" * 40
         assert "…" not in result
+
+    def test_returns_empty_when_budget_cannot_fit_the_suffix(self):
+        """Test clip() returns empty text when the budget can't even fit the suffix."""
+        assert clip("界", columns=0) == ""
+
+    def test_never_exceeds_budget_for_any_small_budget(self):
+        """Test clip() never exceeds a small columns budget, for every budget 0-5."""
+        for n in range(6):
+            result = clip("配信配信配信", columns=n)
+            assert _display_width(result) <= n, f"columns={n} produced {result!r}"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -8,10 +8,7 @@ from pathlib import Path
 import pytest
 
 from core.logger import (
-    _get_display_width,
-    _truncate_to_width,
-    _pad_to_width,
-    _center_to_width,
+    bind,
     cleanup_old_logs,
     get_logs_dir,
     setup_logger,
@@ -152,118 +149,6 @@ class TestCleanupOldLogs:
         assert removed == 3
 
 
-class TestGetDisplayWidth:
-    """Tests for _get_display_width function."""
-
-    def test_ascii_characters(self):
-        """Test width calculation for ASCII characters."""
-        assert _get_display_width("hello") == 5
-        assert _get_display_width("a") == 1
-        assert _get_display_width("") == 0
-
-    def test_cjk_characters(self):
-        """Test width calculation for CJK (double-width) characters."""
-        assert _get_display_width("你好") == 4  # 2 chars * 2 width
-        assert _get_display_width("日本語") == 6  # 3 chars * 2 width
-
-    def test_mixed_characters(self):
-        """Test width calculation for mixed ASCII and CJK."""
-        assert _get_display_width("hello你好") == 9  # 5 + 4
-
-    def test_emoji_characters(self):
-        """Test width calculation for emoji characters."""
-        # Emoji width varies by implementation, test it doesn't crash
-        width = _get_display_width("👍")
-        assert isinstance(width, int)
-        assert width >= 0
-
-    def test_non_printable_characters(self):
-        """Test width calculation handles non-printable characters."""
-        # Non-printable should be treated as 0 width
-        assert _get_display_width("\x00") == 0
-
-
-class TestTruncateToWidth:
-    """Tests for _truncate_to_width function."""
-
-    def test_no_truncation_needed(self):
-        """Test string shorter than max width is unchanged."""
-        assert _truncate_to_width("hello", 10) == "hello"
-
-    def test_exact_width(self):
-        """Test string exactly at max width is unchanged."""
-        assert _truncate_to_width("hello", 5) == "hello"
-
-    def test_truncation_with_suffix(self):
-        """Test string longer than max width is truncated with suffix."""
-        result = _truncate_to_width("hello world", 8)
-        assert result == "hello w…"
-        assert _get_display_width(result) <= 8
-
-    def test_truncation_cjk(self):
-        """Test truncation with CJK characters."""
-        result = _truncate_to_width("你好世界", 5)
-        # Should truncate to fit within 5 width + suffix
-        assert _get_display_width(result) <= 5
-
-    def test_custom_suffix(self):
-        """Test truncation with custom suffix."""
-        result = _truncate_to_width("hello world", 8, suffix="...")
-        assert result.endswith("...")
-        assert _get_display_width(result) <= 8
-
-
-class TestPadToWidth:
-    """Tests for _pad_to_width function."""
-
-    def test_pad_shorter_string(self):
-        """Test padding a string shorter than target width."""
-        result = _pad_to_width("hi", 5)
-        assert result == "hi   "
-        assert len(result) == 5
-
-    def test_pad_exact_width(self):
-        """Test string at exact width is unchanged."""
-        result = _pad_to_width("hello", 5)
-        assert result == "hello"
-
-    def test_pad_longer_string(self):
-        """Test string longer than target is not truncated."""
-        result = _pad_to_width("hello world", 5)
-        assert result == "hello world"
-
-    def test_pad_cjk_string(self):
-        """Test padding with CJK characters."""
-        result = _pad_to_width("你好", 6)  # 你好 is 4 width
-        assert _get_display_width(result) == 6
-
-
-class TestCenterToWidth:
-    """Tests for _center_to_width function."""
-
-    def test_center_shorter_string(self):
-        """Test centering a string shorter than target width."""
-        result = _center_to_width("hi", 6)
-        assert result == "  hi  "
-        assert len(result) == 6
-
-    def test_center_odd_padding(self):
-        """Test centering with odd total padding."""
-        result = _center_to_width("hi", 5)
-        # 5 - 2 = 3 padding, left=1, right=2
-        assert result == " hi  "
-
-    def test_center_exact_width(self):
-        """Test string at exact width is unchanged."""
-        result = _center_to_width("hello", 5)
-        assert result == "hello"
-
-    def test_center_longer_string(self):
-        """Test string longer than target is not truncated."""
-        result = _center_to_width("hello world", 5)
-        assert result == "hello world"
-
-
 class TestAlignedFormatter:
     """Tests for AlignedFormatter class."""
 
@@ -322,7 +207,7 @@ class TestAlignedFormatter:
             exc_info=None,
         )
         result = formatter.format(record)
-        assert _get_display_width(result.strip()) <= 5
+        assert len(result.strip()) <= 5
 
 
 class TestColoredAlignedFormatter:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -8,8 +8,10 @@ from pathlib import Path
 import pytest
 
 from core.logger import (
+    _display_width,
     bind,
     cleanup_old_logs,
+    clip,
     get_logs_dir,
     setup_logger,
     AlignedFormatter,
@@ -17,6 +19,7 @@ from core.logger import (
     LazyRotatingFileHandler,
     LOGGER_NAME_WIDTH,
     LOG_LEVEL_WIDTH,
+    LOG_TEXT_MAX_COLUMNS,
     LOG_COLORS,
 )
 
@@ -393,3 +396,38 @@ class TestContextAdapter:
         record = caplog.records[-1]
         assert record.exc_info is not None
         assert record.getMessage() == "[SomeCreator] boom"
+
+
+class TestClip:
+    """Tests for clip() and _display_width()."""
+
+    def test_short_text_is_returned_unchanged(self):
+        """Test text under the column budget passes through unchanged."""
+        assert clip("耳舐めASMR") == "耳舐めASMR"
+
+    def test_ascii_text_is_clipped_to_the_budget(self):
+        """Test ASCII text over the budget is clipped to exactly 40 columns."""
+        result = clip("a" * 60)
+        assert len(result) == 40
+        assert result.endswith("…")
+
+    def test_cjk_counts_as_two_columns(self):
+        """Test CJK characters count as two columns each, unlike len()."""
+        assert _display_width("耳舐め") == 6
+        assert len("耳舐め") == 3
+
+    def test_clipped_result_never_exceeds_the_budget_in_columns(self):
+        """Test a clipped CJK string never exceeds the column budget."""
+        result = clip("配信" * 40)
+        assert _display_width(result) <= 40
+
+    def test_custom_budget_is_respected(self):
+        """Test a custom columns budget is honored instead of the default."""
+        result = clip("a" * 30, columns=10)
+        assert _display_width(result) <= 10
+
+    def test_exact_budget_is_not_clipped(self):
+        """Test text exactly at the budget is not clipped."""
+        result = clip("a" * 40)
+        assert result == "a" * 40
+        assert "…" not in result

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -341,3 +341,55 @@ class TestLazyRotatingFileHandler:
 
         content = log_file.read_text()
         assert "hello world" in content
+
+
+class TestContextAdapter:
+    """Tests for ContextAdapter and bind()."""
+
+    def test_prefixes_message_with_context(self, caplog):
+        """Test bind() prefixes a logged message with the bound context tag."""
+        logger = logging.getLogger("test_context_adapter_prefix")
+        logger.setLevel(logging.INFO)
+        adapter = bind(logger, "SomeCreator")
+
+        adapter.info("hello")
+
+        assert caplog.records[-1].getMessage() == "[SomeCreator] hello"
+
+    def test_returns_message_unchanged_when_context_is_empty(self, caplog):
+        """Test bind() with an empty context leaves the message unprefixed."""
+        logger = logging.getLogger("test_context_adapter_empty_context")
+        logger.setLevel(logging.INFO)
+        adapter = bind(logger, "")
+
+        adapter.info("hello")
+
+        assert caplog.records[-1].getMessage() == "hello"
+
+    def test_adapter_forwards_level_filtering(self, caplog):
+        """Test the adapter forwards the underlying logger's level filtering."""
+        logger = logging.getLogger("test_context_adapter_level_filter")
+        logger.setLevel(logging.WARNING)
+        adapter = bind(logger, "SomeCreator")
+
+        adapter.info("should be filtered")
+        adapter.warning("should be logged")
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert "[SomeCreator] should be filtered" not in messages
+        assert "[SomeCreator] should be logged" in messages
+
+    def test_exception_through_adapter_keeps_traceback(self, caplog):
+        """Test .exception() through the adapter keeps exc_info and the context prefix."""
+        logger = logging.getLogger("test_context_adapter_exception")
+        logger.setLevel(logging.INFO)
+        adapter = bind(logger, "SomeCreator")
+
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            adapter.exception("boom")
+
+        record = caplog.records[-1]
+        assert record.exc_info is not None
+        assert record.getMessage() == "[SomeCreator] boom"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -121,7 +121,7 @@ class TestStartScheduler:
             scheduler.start()
 
         log_calls = [str(call) for call in mock_logger.info.call_args_list]
-        assert any("Git SHA" in call and "5bae5e3" in call for call in log_calls)
+        assert any("5bae5e3" in call for call in log_calls)
 
     def test_start_adds_job(self, patched_scheduler_deps, mock_env, mock_logger):
         """Test that start adds scheduled job."""
@@ -159,7 +159,7 @@ class TestStartScheduler:
         scheduler.start()
 
         log_calls = [str(call) for call in mock_logger.info.call_args_list]
-        assert any("60 seconds" in call for call in log_calls)
+        assert any("60s" in call for call in log_calls)
 
     def test_start_handles_keyboard_interrupt(self, patched_scheduler_deps, mock_env, mock_logger):
         """Test that KeyboardInterrupt is handled gracefully."""


### PR DESCRIPTION
## Summary

Starting one recording used to emit five log lines across two components, and the stream title appeared three times inside them: once as the title, then twice more embedded in the output filename.

That repetition arrived pre-fragmented. Measured against 16 streams that were live at the time, **10 of their titles were wide enough to wrap a 120-column terminal** on their own. Titles are unbounded and CJK is double width, so a 40-character Japanese title occupies 80 columns.

One event is now one line, and user-controlled text is clipped to a column budget.

## Changes

**`core/logger.py`**

- `ContextAdapter` / `bind()` — a stdlib `LoggerAdapter` that prefixes every message with a stable `[creator]` tag, so a single recording can be followed with one grep. Previously only the downloader had a prefix, via a hand-rolled helper; the monitor had none.
- `clip()` — clips text to a terminal-column budget, keeping the front. Width comes from `wcwidth`, not `len()`.
- Dropped the old width machinery. It measured East Asian display width but only ever ran on `record.name` and `record.levelname`, which are always ASCII — the longest logger name is `Downloader` at 10 characters. A stdlib format spec centers and truncates in one expression. `wcwidth` now applies where display width actually varies.

**Why the front of the title is what survives**

These titles lead with a bracketed category and trail with the creator name or a timestamp. Both of those already appear elsewhere on the same line — the creator in the `[creator]` prefix, the time in the timestamp column — so a middle ellipsis would spend its budget restating them, and it cuts mid-word in CJK.

**Message changes**

- Monitor clips the title and carries the `[creator]` tag.
- Downloader reports the session prefix instead of restating the title. The prefix is what ties the line to a file on disk.
- Removed the `Output:` line: its content was already inside the following line.
- Removed the monitor's `Started downloading` line: the downloader had just said the same thing.
- The first download attempt no longer announces itself — `Recording started` already did. Retries still speak up.
- Session keys, full paths and attempt context moved to DEBUG.
- Startup banner is one line instead of five.

**Fixed during review**

- `clip()` returned a bare ellipsis when the budget was narrower than the suffix — wider than the budget it was asked to respect. It now returns nothing in that case.
- `Recording started` was emitted before `Thread.start()`. Removing the monitor's duplicate confirmation left this as the only signal that a recording began, so a thread that failed to start would still have announced success. It now runs after `start()` returns.

**Test fix, unrelated to formatting but found on the way**

`test_live_and_monitored_starts_download` never patched `StreamDownloader.download`, so it started a real yt-dlp download against `example.com`. The thread's failure callback landed after the test returned and logged through the process-wide `Monitor` logger, which intermittently corrupted the call count of whichever test was patching that logger. The suite was making outbound network calls and leaking threads between tests.

## Verification

```
$ poetry run pytest -q
run 1 : 301 passed, 1 skipped in 36.45s
run 2 : 301 passed, 1 skipped in 36.33s
run 3 : 301 passed, 1 skipped in 36.32s
```

Three consecutive runs, to confirm the intermittent failure is gone. The single skip is the timezone guard from #28, which needs POSIX `time.tzset()` and runs on the Linux CI runners.

Clip measurements:

```
long title  : 83 cols -> 40 cols, full line = 109 columns
short title : 10 cols, unchanged = True
CJK         : len('耳舐め') = 3 chars, display = 6 columns
```

The clip budget holds at every small budget, including ones narrower than the suffix:

```
budget=0 -> width=0    budget=3 -> width=3
budget=1 -> width=1    budget=4 -> width=3
budget=2 -> width=1    budget=5 -> width=5
```

Rendered against creators live at the time of writing:

```
│   INFO   │ Scheduler  │ rplay-live-dl v2.1.1 (081526a) — checking every 60s
│   INFO   │  Monitor   │ [榮初涵] 🔴 Live: "R18 お絵描き配信♡ ┊ 繪圖直播♡ ┊  Drawin…"
│   INFO   │  Monitor   │ [yabaszta1] 🔴 Live: "Dohna Dohna | Need to take care of our …"
│   INFO   │  Monitor   │ [TNDaki] 🔴 Live: "[ENGLISH] Real Seiso Cute and Funny Dra…"
│   INFO   │ Downloader │ [榮初涵] 📥 Recording started (session 20260727_021500)
│   INFO   │ Downloader │ [榮初涵] ✅ Recording complete: 1.24 GB in 44m 12s
```

No line exceeds the terminal width. Per creator going live, five lines became two.

## Acceptance

- [x] `test (3.11)` and `test (3.12)` green — both pass on run 30215481191
- [x] Full suite passes three consecutive local runs with no intermittent failure — 301 passed each time
- [x] A title wider than the budget is clipped and the line fits in ~110 columns — 83 → 40 cols, line total 109
- [x] A title inside the budget is emitted unchanged — 10-column title returned identical
- [x] Monitor and downloader lines both carry the `[creator]` tag — see the live render above
- [x] `wcwidth` still resolves display width correctly for CJK — 3 characters measured as 6 columns

## Not in this change

`logger.exception` is still effectively unused: the 36 `ERROR` sites carry only `str(e)`, so a failing daemon leaves no traceback. That is a behaviour change rather than a formatting one and gets its own change.

The downloader's `_log` helper and the new `bind()` are two mechanisms for the same job; collapsing them belongs with that work.
