### PR TITLE
feat: stop shutdown and failure paths from losing recordings silently

### DIFF
--- a/core/downloader.py
+++ b/core/downloader.py
@@ -369,6 +369,12 @@ class StreamDownloader:
                     f"{output_path}; {self._build_output_state_details(output_path)}",
                 )
                 if not self._has_sibling_fragment_outputs(output_path):
+                    # Without this the session never leaves RAW_RUNNING: no
+                    # completion, no failure, and the creator's raw lock stays
+                    # held until the process restarts.
+                    self._notify_download_failure(
+                        "download finished but produced no output file"
+                    )
                     return
 
             self._notify_download_complete(output_path)

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -807,8 +807,17 @@ class LiveStreamMonitor:
             )
             self._run_ffmpeg_merge(ts_files, output_path)
 
+            # The merge succeeded: from here the mp4 is the artifact of record.
+            # A locked .ts must neither fail the merge nor reach the except
+            # below, which would delete a perfectly good mp4 as a "partial".
             for ts_file in ts_files:
-                ts_file.unlink(missing_ok=True)
+                try:
+                    ts_file.unlink(missing_ok=True)
+                except OSError as cleanup_error:
+                    self.logger.warning(
+                        f"Merged, but could not remove {ts_file.name}: "
+                        f"{cleanup_error}. The startup scan will list it."
+                    )
 
             return MergeCompleted(
                 session_key=merge_job.session_key,
@@ -829,8 +838,7 @@ class LiveStreamMonitor:
                 error_message=str(exc),
             )
 
-    @staticmethod
-    def _discard_partial_merge_output(output_path: Optional[Path]) -> None:
+    def _discard_partial_merge_output(self, output_path: Optional[Path]) -> None:
         """
         Drop a half-written mp4 so a failed merge cannot pass for a finished one.
 
@@ -841,9 +849,12 @@ class LiveStreamMonitor:
             return
         try:
             output_path.unlink(missing_ok=True)
-        except OSError:
-            # A locked file must not turn a merge failure into a thread crash.
-            pass
+        except OSError as exc:
+            # A locked file must not turn a merge failure into a thread crash,
+            # but a broken mp4 surviving under a final name must not be silent.
+            self.logger.warning(
+                f"Could not remove partial merge output {output_path.name}: {exc}"
+            )
 
     def _reserve_final_output_path(
         self,

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -791,6 +791,7 @@ class LiveStreamMonitor:
     def _merge_session_to_mp4(self, merge_job: MergeJobSpec) -> Union[MergeCompleted, MergeFailed]:
         """Merge one session's raw ts outputs into the final mp4 artifact."""
         ts_files = sorted(merge_job.output_dir.glob(f"{merge_job.session_prefix}*.ts"))
+        output_path: Optional[Path] = None
 
         try:
             if not ts_files:
@@ -815,16 +816,34 @@ class LiveStreamMonitor:
             )
 
         except subprocess.TimeoutExpired as exc:
+            self._discard_partial_merge_output(output_path)
             timeout_value = int(exc.timeout) if exc.timeout is not None else self.merge_timeout_seconds
             return MergeFailed(
                 session_key=merge_job.session_key,
                 error_message=f"ffmpeg merge timeout after {timeout_value} seconds",
             )
         except Exception as exc:
+            self._discard_partial_merge_output(output_path)
             return MergeFailed(
                 session_key=merge_job.session_key,
                 error_message=str(exc),
             )
+
+    @staticmethod
+    def _discard_partial_merge_output(output_path: Optional[Path]) -> None:
+        """
+        Drop a half-written mp4 so a failed merge cannot pass for a finished one.
+
+        The raw .ts inputs are only deleted after a successful merge, so the
+        recording stays recoverable while the broken artifact goes away.
+        """
+        if output_path is None:
+            return
+        try:
+            output_path.unlink(missing_ok=True)
+        except OSError:
+            # A locked file must not turn a merge failure into a thread crash.
+            pass
 
     def _reserve_final_output_path(
         self,
@@ -897,6 +916,7 @@ class LiveStreamMonitor:
         self._event_queue.join()
         self._event_queue.put(_ShutdownRequested())
         self._control_thread.join()
+        self.api.close()
 
     def _make_session_download_error_callback(self, session_key: str) -> Callable[[str], None]:
         """Create a callback for a specific session download failure."""

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -17,6 +17,7 @@ from apscheduler.triggers.interval import IntervalTrigger
 from core.config import DEFAULT_CONFIG_PATH, validate_startup_config_path
 from core.env import EnvConfig
 from core.live_stream_monitor import LiveStreamMonitor
+from core.utils import terminate_child_processes
 
 __all__ = [
     "LiveStreamScheduler",
@@ -64,6 +65,7 @@ class LiveStreamScheduler:
         self.git_sha = os.getenv("APP_GIT_SHA", "").strip()
         self.monitor = LiveStreamMonitor(self.env.auth_token, self.env.user_oid)
         self.scheduler = BlockingScheduler()
+        self._stopped = False
 
     def check_and_download(self) -> None:
         """Execute check and download task."""
@@ -99,16 +101,34 @@ class LiveStreamScheduler:
 
         except KeyboardInterrupt:
             self.logger.info("Monitoring system manually stopped")
+            self.stop()
         except Exception as e:
             self.logger.error(f"System runtime error: {e}")
             raise
 
     def stop(self) -> None:
-        """Stop the scheduler gracefully."""
+        """Stop the scheduler, drain the monitor, and reap download subprocesses."""
+        if self._stopped:
+            return
+        self._stopped = True
+
         if self.scheduler.running:
             self.scheduler.shutdown(wait=False)
-            self.monitor.shutdown()
-            self.logger.info("Scheduler stopped")
+
+        # Always shut the monitor down, even when the scheduler never started:
+        # its control thread and merge executor exist from construction.
+        self.monitor.shutdown()
+
+        # The monitor has drained the merge queue by now, so any child process
+        # still alive is a recording ffmpeg spawned by yt-dlp's FFmpegFD. Those
+        # outlive the interpreter and keep downloading unless reaped here.
+        reaped = terminate_child_processes()
+        if reaped:
+            self.logger.warning(
+                f"Terminated {reaped} download subprocess(es) left running by yt-dlp"
+            )
+
+        self.logger.info("Scheduler stopped")
 
 
 def run_scheduler(env: EnvConfig, logger: logging.Logger, version: str) -> None:

--- a/core/utils.py
+++ b/core/utils.py
@@ -24,25 +24,34 @@ def terminate_child_processes(timeout_seconds: float = 10.0) -> int:
     Sends terminate to the whole child tree, waits, then kills whatever is
     still alive. Returns the number of children that had to be dealt with.
     """
-    try:
-        children = psutil.Process().children(recursive=True)
-    except psutil.Error:
-        return 0
-
-    for child in children:
+    total = 0
+    # Two passes: a still-running download thread can spawn a fresh ffmpeg
+    # between the snapshot and the kill (yt-dlp retry), so re-scan once.
+    for pass_timeout in (timeout_seconds, 2.0):
         try:
-            child.terminate()
-        except psutil.NoSuchProcess:
-            continue
+            children = psutil.Process().children(recursive=True)
+        except psutil.Error:
+            break
+        if not children:
+            break
 
-    _, alive = psutil.wait_procs(children, timeout=timeout_seconds)
-    for child in alive:
-        try:
-            child.kill()
-        except psutil.NoSuchProcess:
-            continue
+        for child in children:
+            try:
+                child.terminate()
+            except psutil.Error:
+                # Already gone, or access denied: neither may stop the sweep.
+                continue
 
-    return len(children)
+        _, alive = psutil.wait_procs(children, timeout=pass_timeout)
+        for child in alive:
+            try:
+                child.kill()
+            except psutil.Error:
+                continue
+
+        total += len(children)
+
+    return total
 
 
 def format_file_size(size_bytes: float) -> str:

--- a/core/utils.py
+++ b/core/utils.py
@@ -4,12 +4,48 @@ Utility functions for rplay-live-dl.
 Provides common helper functions used across multiple modules.
 """
 
+import psutil
+
 __all__ = [
     "format_file_size",
+    "terminate_child_processes",
 ]
 
 
-def format_file_size(size_bytes: int) -> str:
+def terminate_child_processes(timeout_seconds: float = 10.0) -> int:
+    """
+    Terminate every child process of this process, politely then firmly.
+
+    yt-dlp downloads HLS through FFmpegFD, which spawns ffmpeg as a subprocess
+    and keeps the Popen object in a local variable, so there is no handle to
+    stop it through. Measured on shutdown: the recording ffmpeg processes
+    survive the Python process and keep downloading indefinitely.
+
+    Sends terminate to the whole child tree, waits, then kills whatever is
+    still alive. Returns the number of children that had to be dealt with.
+    """
+    try:
+        children = psutil.Process().children(recursive=True)
+    except psutil.Error:
+        return 0
+
+    for child in children:
+        try:
+            child.terminate()
+        except psutil.NoSuchProcess:
+            continue
+
+    _, alive = psutil.wait_procs(children, timeout=timeout_seconds)
+    for child in alive:
+        try:
+            child.kill()
+        except psutil.NoSuchProcess:
+            continue
+
+    return len(children)
+
+
+def format_file_size(size_bytes: float) -> str:
     """
     Format file size in human-readable format.
 

--- a/main.py
+++ b/main.py
@@ -43,8 +43,10 @@ def _warn_about_orphaned_downloads(logger: logging.Logger) -> None:
     if not archive.is_dir():
         return
 
-    patterns = ("[0-9]*_*.ts", "*.part", "*.ytdl", "*.part-Frag*")
-    orphans = sorted({path for pattern in patterns for path in archive.glob(f"*/{pattern}")})
+    # *.part* covers .part, .part-FragN and .part-FragN.part in one pattern,
+    # so the three patterns are disjoint and need no dedup.
+    patterns = ("[0-9]*_*.ts", "*.part*", "*.ytdl")
+    orphans = sorted(path for pattern in patterns for path in archive.glob(f"*/{pattern}"))
     if not orphans:
         return
 

--- a/main.py
+++ b/main.py
@@ -4,12 +4,14 @@ rplay-live-dl - Automated RPlay live stream downloader.
 Entry point for the application.
 """
 
+import logging
 import sys
 import tomllib
 from pathlib import Path
 
 from dotenv import load_dotenv
 
+from core.downloader import StreamDownloader
 from core.env import EnvConfigError, load_env
 from core.logger import cleanup_old_logs, setup_logger
 from core.scheduler import run_scheduler
@@ -25,6 +27,34 @@ def _read_version() -> str:
 __version__ = _read_version()
 
 
+def _warn_about_orphaned_downloads(logger: logging.Logger) -> None:
+    """
+    List files left behind by interrupted recordings.
+
+    Nothing else in the codebase ever looks at these again, so without this
+    they accumulate silently. yt-dlp's HLS downloader can leave *.part,
+    *.ytdl and *.part-Frag* behind on a kill; unmerged session .ts files stay
+    when a merge fails or the process dies first.
+    """
+    # ponytail: report-only. Auto-merging .ts is deferred until shutdown is
+    # trustworthy, and .part fragments may be truncated mid-write, so merging
+    # those would produce broken video.
+    archive = Path.cwd() / StreamDownloader.ARCHIVE_DIR
+    if not archive.is_dir():
+        return
+
+    patterns = ("[0-9]*_*.ts", "*.part", "*.ytdl", "*.part-Frag*")
+    orphans = sorted({path for pattern in patterns for path in archive.glob(f"*/{pattern}")})
+    if not orphans:
+        return
+
+    logger.warning(f"Found {len(orphans)} file(s) left behind by interrupted recordings:")
+    for path in orphans[:10]:
+        logger.warning(f"  {path.relative_to(archive)}")
+    if len(orphans) > 10:
+        logger.warning(f"  ... and {len(orphans) - 10} more")
+
+
 def main() -> None:
     """Main entry point for the application."""
     load_dotenv()
@@ -37,6 +67,8 @@ def main() -> None:
             logger.info(f"Cleaned up {removed} old log file(s)")
     except Exception as e:
         logger.warning(f"Failed to cleanup old logs: {e}")
+
+    _warn_about_orphaned_downloads(logger)
 
     # Load environment configuration
     try:

--- a/poetry.lock
+++ b/poetry.lock
@@ -429,6 +429,41 @@ dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
+name = "psutil"
+version = "7.2.2"
+description = "Cross-platform lib for process and system monitoring."
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b"},
+    {file = "psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea"},
+    {file = "psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63"},
+    {file = "psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312"},
+    {file = "psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b"},
+    {file = "psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9"},
+    {file = "psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00"},
+    {file = "psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9"},
+    {file = "psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a"},
+    {file = "psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf"},
+    {file = "psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1"},
+    {file = "psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841"},
+    {file = "psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486"},
+    {file = "psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979"},
+    {file = "psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9"},
+    {file = "psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e"},
+    {file = "psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8"},
+    {file = "psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc"},
+    {file = "psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988"},
+    {file = "psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee"},
+    {file = "psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372"},
+]
+
+[package.extras]
+dev = ["abi3audit", "black", "check-manifest", "colorama ; os_name == \"nt\"", "coverage", "packaging", "psleak", "pylint", "pyperf", "pypinfo", "pyreadline3 ; os_name == \"nt\"", "pytest", "pytest-cov", "pytest-instafail", "pytest-xdist", "pywin32 ; os_name == \"nt\" and implementation_name != \"pypy\"", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "validate-pyproject[all]", "virtualenv", "vulture", "wheel", "wheel ; os_name == \"nt\" and implementation_name != \"pypy\"", "wmi ; os_name == \"nt\" and implementation_name != \"pypy\""]
+test = ["psleak", "pytest", "pytest-instafail", "pytest-xdist", "pywin32 ; os_name == \"nt\" and implementation_name != \"pypy\"", "setuptools", "wheel ; os_name == \"nt\" and implementation_name != \"pypy\"", "wmi ; os_name == \"nt\" and implementation_name != \"pypy\""]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 description = "Data validation using Python type hints"
@@ -960,4 +995,4 @@ secretstorage = ["secretstorage"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "d424aaa12a767a3d962b201406f5dbc61080fe26e3128dd1c53e2c33a5fcfd8b"
+content-hash = "30a70bbed9b69e31736d38084788d4f9ed121332e56f26154eb86cdfd6e09d3a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ pydantic-settings = "^2.12.0"
 pathvalidate = "^3.3.1"
 wcwidth = "^0.2.14"
 tenacity = ">=8,<10"
+psutil = "^7.2.2"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -346,14 +346,26 @@ class TestDownloadWorker:
         assert downloader._current_output_path is None
         assert downloader._download_start_time is None
 
-    def test_worker_file_not_found_logs_warning(self, mock_yt_dlp, tmp_path):
-        """Test warning logged when file not found after download."""
+    def test_worker_file_not_found_notifies_failure(self, mock_yt_dlp, tmp_path):
+        """Test a missing output file raises a failure event, not silence.
+
+        Without the failure notification the session never leaves RAW_RUNNING
+        and the creator's raw lock stays held until the process restarts.
+        """
         mock_ydl_class, mock_ydl = mock_yt_dlp
-        downloader = StreamDownloader("TestCreator")
+        failures = []
+        downloader = StreamDownloader(
+            "TestCreator",
+            session_key="creator1:2026-07-27T02:00:00",
+            on_download_failure=failures.append,
+        )
         output_path = tmp_path / "nonexistent.mp4"
         downloader._download_start_time = datetime.now()
         downloader._download_worker("http://example.com/stream.m3u8", {}, output_path)
         assert downloader._current_output_path is None
+        assert len(failures) == 1
+        assert failures[0].session_key == "creator1:2026-07-27T02:00:00"
+        assert "no output file" in failures[0].error_message
 
     def test_worker_download_error_handled(self, mock_yt_dlp, tmp_path):
         """Test DownloadError is caught and logged."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,46 @@
+"""Tests for application startup helpers."""
+
+import logging
+
+from main import _warn_about_orphaned_downloads
+
+
+def test_warns_about_each_kind_of_leftover(tmp_path, monkeypatch, caplog):
+    """Test startup reports each supported orphaned download file kind."""
+    monkeypatch.chdir(tmp_path)
+    archive_dir = tmp_path / "archive" / "Creator"
+    archive_dir.mkdir(parents=True)
+    for filename in (
+        "20260727_020000_#Creator x.ts",
+        "video.ts.part",
+        "video.ts.ytdl",
+        "video.ts.part-Frag3",
+    ):
+        (archive_dir / filename).write_bytes(b"leftover")
+
+    caplog.set_level(logging.WARNING)
+    _warn_about_orphaned_downloads(logging.getLogger("test_main"))
+
+    assert any("4 file(s)" in record.getMessage() for record in caplog.records)
+
+
+def test_silent_when_archive_is_clean(tmp_path, monkeypatch, caplog):
+    """Test startup does not warn when only completed files remain."""
+    monkeypatch.chdir(tmp_path)
+    archive_dir = tmp_path / "archive" / "Creator"
+    archive_dir.mkdir(parents=True)
+    (archive_dir / "final.mp4").write_bytes(b"complete")
+
+    caplog.set_level(logging.WARNING)
+    _warn_about_orphaned_downloads(logging.getLogger("test_main"))
+
+    assert not any(record.levelno >= logging.WARNING for record in caplog.records)
+
+
+def test_silent_when_archive_missing(tmp_path, monkeypatch, caplog):
+    """Test startup ignores a missing archive directory."""
+    monkeypatch.chdir(tmp_path)
+
+    _warn_about_orphaned_downloads(logging.getLogger("test_main"))
+
+    assert not caplog.records

--- a/tests/test_merge_flow.py
+++ b/tests/test_merge_flow.py
@@ -162,6 +162,50 @@ class TestMergeFlow:
         assert ts_file.exists()
         monitor.shutdown()
 
+    def test_ts_cleanup_failure_keeps_the_merged_mp4(self, tmp_path, monkeypatch):
+        """Test a locked .ts after a successful merge never deletes the mp4.
+
+        Regression guard: the cleanup loop used to share the failure handler,
+        so a locked .ts made the discard step delete a perfectly good mp4.
+        """
+        monkeypatch.chdir(tmp_path)
+        monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=None)
+        output_dir = tmp_path / "archive" / "Creator"
+        output_dir.mkdir(parents=True)
+        prefix = "20260306_120000_"
+        ts_file = output_dir / f"{prefix}#Creator 2026-03-06 123.ts"
+        ts_file.write_bytes(b"ts")
+
+        def fake_merge(ts_files, output_path):
+            output_path.write_bytes(b"mp4")
+
+        monitor._run_ffmpeg_merge = fake_merge
+
+        real_unlink = Path.unlink
+
+        def deny_ts_unlink(self, missing_ok=False):
+            if self.suffix == ".ts":
+                raise OSError("locked")
+            return real_unlink(self, missing_ok=missing_ok)
+
+        monkeypatch.setattr(Path, "unlink", deny_ts_unlink)
+
+        event = monitor._merge_session_to_mp4(
+            MergeJobSpec(
+                session_key="creator1:2026-03-06T12:00:00",
+                creator_name="Creator",
+                title="123",
+                stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
+                output_dir=output_dir,
+                session_prefix=prefix,
+            )
+        )
+
+        assert isinstance(event, MergeCompleted)
+        assert event.output_path.exists()
+        assert ts_file.exists()
+        monitor.shutdown()
+
     def test_merge_timeout_returns_failure_event(self, tmp_path, monkeypatch):
         """Test ffmpeg timeout becomes a merge failure event."""
         monkeypatch.chdir(tmp_path)

--- a/tests/test_merge_flow.py
+++ b/tests/test_merge_flow.py
@@ -128,6 +128,40 @@ class TestMergeFlow:
         assert not (tmp_path / "archive" / "Creator" / "_failed").exists()
         monitor.shutdown()
 
+    def test_failed_merge_discards_partial_mp4_and_keeps_ts(self, tmp_path, monkeypatch):
+        """Test a failed merge removes partial mp4 output but keeps raw ts input."""
+        monkeypatch.chdir(tmp_path)
+        monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=None)
+        output_dir = tmp_path / "archive" / "Creator"
+        output_dir.mkdir(parents=True)
+        prefix = "20260306_120000_"
+        ts_file = output_dir / f"{prefix}#Creator 2026-03-06 123.ts"
+        ts_file.write_bytes(b"ts")
+        partial_mp4 = output_dir / "#Creator 2026-03-06 123.mp4"
+
+        def fake_merge(ts_files, output_path):
+            output_path.write_bytes(b"partial")
+            raise RuntimeError("boom")
+
+        monitor._run_ffmpeg_merge = fake_merge
+
+        event = monitor._merge_session_to_mp4(
+            MergeJobSpec(
+                session_key="creator1:2026-03-06T12:00:00",
+                creator_name="Creator",
+                title="123",
+                stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
+                output_dir=output_dir,
+                session_prefix=prefix,
+            )
+        )
+
+        assert isinstance(event, MergeFailed)
+        assert event.error_message == "boom"
+        assert not partial_mp4.exists()
+        assert ts_file.exists()
+        monitor.shutdown()
+
     def test_merge_timeout_returns_failure_event(self, tmp_path, monkeypatch):
         """Test ffmpeg timeout becomes a merge failure event."""
         monkeypatch.chdir(tmp_path)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import signal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -200,12 +200,19 @@ class TestStopScheduler:
         mock_scheduler_class.return_value = mock_scheduler
 
         scheduler = LiveStreamScheduler(env=mock_env, logger=mock_logger, version="1.0.0")
+        order = MagicMock()
         with patch("core.scheduler.terminate_child_processes") as mock_terminate:
+            # A real int keeps `if reaped:` from recording __bool__/__str__
+            # calls on the manager mock below.
+            mock_terminate.return_value = 0
+            order.attach_mock(scheduler.monitor.shutdown, "monitor_shutdown")
+            order.attach_mock(mock_terminate, "reap")
             scheduler.stop()
             scheduler.stop()
 
-        scheduler.monitor.shutdown.assert_called_once()
-        mock_terminate.assert_called_once()
+        # Draining the monitor must come first: only once the merge queue is
+        # empty is every surviving child a recording ffmpeg that needs reaping.
+        assert order.mock_calls == [call.monitor_shutdown(), call.reap()]
 
     def test_stop_shuts_monitor_down_even_when_scheduler_never_started(
         self, patched_scheduler_deps, mock_env, mock_logger

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -192,6 +192,36 @@ class TestStartScheduler:
 class TestStopScheduler:
     """Tests for stop method."""
 
+    def test_stop_is_idempotent(self, patched_scheduler_deps, mock_env, mock_logger):
+        """Test stop shuts down monitor and reaps children only once."""
+        mock_scheduler_class, _ = patched_scheduler_deps
+        mock_scheduler = MagicMock()
+        mock_scheduler.running = False
+        mock_scheduler_class.return_value = mock_scheduler
+
+        scheduler = LiveStreamScheduler(env=mock_env, logger=mock_logger, version="1.0.0")
+        with patch("core.scheduler.terminate_child_processes") as mock_terminate:
+            scheduler.stop()
+            scheduler.stop()
+
+        scheduler.monitor.shutdown.assert_called_once()
+        mock_terminate.assert_called_once()
+
+    def test_stop_shuts_monitor_down_even_when_scheduler_never_started(
+        self, patched_scheduler_deps, mock_env, mock_logger
+    ):
+        """Test stop shuts down the monitor before the scheduler has started."""
+        mock_scheduler_class, _ = patched_scheduler_deps
+        mock_scheduler = MagicMock()
+        mock_scheduler.running = False
+        mock_scheduler_class.return_value = mock_scheduler
+
+        scheduler = LiveStreamScheduler(env=mock_env, logger=mock_logger, version="1.0.0")
+        with patch("core.scheduler.terminate_child_processes"):
+            scheduler.stop()
+
+        scheduler.monitor.shutdown.assert_called_once()
+
     def test_stop_when_running(self, patched_scheduler_deps, mock_env, mock_logger):
         """Test stop shuts down scheduler when running."""
         mock_scheduler_class, mock_monitor_class = patched_scheduler_deps

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,11 @@
 """Tests for utility functions."""
 
+import subprocess
+import sys
+
 import pytest
 
-from core.utils import format_file_size
+from core.utils import format_file_size, terminate_child_processes
 
 
 class TestFormatFileSize:
@@ -54,3 +57,25 @@ class TestFormatFileSize:
     def test_format_file_size(self, size_bytes: int, expected: str):
         """Test formatting file sizes across all unit ranges."""
         assert format_file_size(size_bytes) == expected
+
+
+class TestTerminateChildProcesses:
+    """Tests for terminating child processes."""
+
+    def test_returns_zero_when_no_children(self):
+        """Test no-child cleanup returns zero."""
+        assert terminate_child_processes(timeout_seconds=1.0) == 0
+
+    def test_terminates_a_real_child_process(self):
+        """Test a real child process is terminated and reaped."""
+        proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+        try:
+            assert proc.poll() is None
+            assert terminate_child_processes(timeout_seconds=5.0) >= 1
+            proc.wait(timeout=5)
+            assert proc.returncode is not None
+        finally:
+            try:
+                proc.kill()
+            except OSError:
+                pass


### PR DESCRIPTION
## Summary

Shutdown and failure paths stopped losing data silently.

The headline defect was measured, not predicted: after `monitor.shutdown()` returned and the interpreter exited, the six ffmpeg processes yt-dlp had spawned kept downloading — the recording grew from 36 MB to 437 MB until they were killed by hand. yt-dlp's `FFmpegFD` keeps its `Popen` in a local variable and exposes no cancel API, and its progress hooks never fire while it waits on the process, so there is nothing to reach the child through from Python.

Four smaller silent failures ride along, each previously flagged by review or the council and verified against the code.

## Changes

**`core/utils.py` — child-process reaper (new dependency: psutil)**

`terminate_child_processes()` sends terminate to the recursive child tree, waits, then kills stragglers — the same tree-cleanup pattern Airflow uses. Per-child failures catch `psutil.Error`, so an `AccessDenied` on one child cannot abort the sweep, and a second pass closes the window where a still-running download thread spawns a fresh ffmpeg between snapshot and kill. The no-dependency alternative is one worker process per recording plus process groups / job objects, a far larger change for the same effect.

**`core/scheduler.py` — `stop()` is idempotent and always drains**

`stop()` only shut the monitor down when the scheduler was running, so an early exit leaked the monitor's control thread. It now always drains the monitor, closes the API session, and then reaps remaining children. Ordering matters: by the time the monitor has shut down, the merge queue is empty, so any child still alive is a recording ffmpeg that would otherwise outlive the process. The test asserts that ordering, and the `KeyboardInterrupt` path goes through the same `stop()`.

**`core/downloader.py` — a download with no output file reports failure**

A download that finished without producing a file and without sibling fragments returned silently: no completion event, no failure event, session parked in `RAW_RUNNING`, and the creator's raw lock held until restart. It now emits `RawDownloadFailed`, so the next poll retries. The old test asserted only the *absence* of a completion event — an assertion that cannot fail — and now asserts the failure event fires with the right session key.

**`core/live_stream_monitor.py` — failed merges discard the half-written mp4**

ffmpeg failure or timeout left a partial mp4 sitting next to the preserved `.ts` inputs, and the next attempt would rename around it. The raw inputs are only deleted after a successful merge, so dropping the broken artifact loses nothing.

**`main.py` — startup lists files left behind by interrupted recordings**

Nothing in the codebase ever looked at leftover session `.ts`, `.part`, `.ytdl` or `.part-Frag*` files again, so they accumulated silently. Startup now warns with a bounded listing across three disjoint patterns (`*.part*` covers every fragment variant). Report-only on purpose: `.part` fragments can be truncated mid-write, so merging them automatically would produce broken video.

## Fixed during review

Review caught a data-loss path **this PR had introduced**: after a *successful* merge, a locked `.ts` raised out of the cleanup loop into the shared failure handler, which then discarded a perfectly good mp4 as a "partial". Before this PR the mp4 would have survived. Cleanup failures are now logged and left to the startup scan, a denied partial-discard is logged instead of silent, and a regression test pins the survival of the mp4.

Also from review: the reaper's per-child error handling widened from `NoSuchProcess` to `psutil.Error`, plus the second sweep pass; the orphan patterns collapsed from four to three; the stop-ordering assertion was added.

One reviewer suggestion was declined, recorded here: deleting the small behavioral tests (clean-archive, missing-archive, never-started scheduler, no-children reaper). They are already written, pass in milliseconds, and each pins a real edge — deleting passing guards saves nothing.

## Verification

```
$ poetry run pytest -q
run 1 : 310 passed, 1 skipped in 36.25s
run 2 : 310 passed, 1 skipped in 36.56s
run 3 : 310 passed, 1 skipped in 36.11s
```

The skip is the timezone guard from #28 (POSIX-only, exercised on the Linux CI runners).

## Acceptance

- [x] `test (3.11)` and `test (3.12)` green — both pass on run 30267522334
- [x] Three consecutive local runs green — 310 passed each time, output above
- [x] A real spawned child process is terminated by the reaper — `test_terminates_a_real_child_process` spawns a live `python -c "time.sleep(60)"` and asserts it dies; runs locally and on CI
- [x] `stop()` called twice shuts the monitor down exactly once, and drains before reaping — `test_stop_is_idempotent` asserts both the count and the order
- [x] A failed merge leaves the `.ts` inputs and no mp4 artifact — `test_failed_merge_discards_partial_mp4_and_keeps_ts`
- [x] A successful merge with a locked `.ts` keeps the mp4 — `test_ts_cleanup_failure_keeps_the_merged_mp4` (regression for the review finding)
- [x] Startup warns when the archive contains leftovers and stays silent otherwise — `tests/test_main.py`, three cases

## Not verified here

The reaper's end-to-end effect on real ffmpeg children requires a live recording plus SIGTERM; the measured 437 MB incident is the before picture, and the after picture needs a supervised run against a live stream.
