### PR TITLE
fix(deps): patch yt-dlp and pydantic-settings security advisories

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -620,14 +620,14 @@ typing-extensions = ">=4.14.1"
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.1"
+version = "2.14.2"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de"},
-    {file = "pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa"},
+    {file = "pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440"},
+    {file = "pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f"},
 ]
 
 [package.dependencies]
@@ -972,24 +972,24 @@ files = [
 
 [[package]]
 name = "yt-dlp"
-version = "2026.6.9"
+version = "2026.7.4"
 description = "A feature-rich command-line audio/video downloader"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "yt_dlp-2026.6.9-py3-none-any.whl", hash = "sha256:442ba4c75724b9496144c8434b617962ee08d0ee7c26ec663848fe9b78d5a3e4"},
-    {file = "yt_dlp-2026.6.9.tar.gz", hash = "sha256:d50fcb95f48d61bedde33e408c1881d4c279e51c31354a599ce09e96ba0f4b86"},
+    {file = "yt_dlp-2026.7.4-py3-none-any.whl", hash = "sha256:f11f2b11d5a8ac4059f9bdf29fa4407dc7c6bb00c5097e95ca22a7a9db518266"},
+    {file = "yt_dlp-2026.7.4.tar.gz", hash = "sha256:b094813404f87a9dd2186f00815231df32e5fd8a5403be0f807b3bb2d21a4432"},
 ]
 
 [package.extras]
 curl-cffi = ["curl-cffi (>=0.5.10,<0.6.dev0 || >=0.10.dev0,<0.16) ; implementation_name == \"cpython\""]
 default = ["brotli ; implementation_name == \"cpython\" and sys_platform != \"ios\"", "brotlicffi ; implementation_name != \"cpython\"", "certifi", "mutagen", "pycryptodomex", "requests (>=2.32.2,<3)", "urllib3 (>=2.0.2,<3)", "websockets (>=13.0)", "yt-dlp-ejs (==0.8.0)"]
 deno = ["deno (>=2.6.6)"]
-pin = ["brotli (==1.2.0) ; implementation_name == \"cpython\" and sys_platform != \"ios\"", "brotlicffi (==1.2.0.1) ; implementation_name != \"cpython\"", "certifi (==2026.5.20)", "charset-normalizer (==3.4.7)", "idna (==3.17)", "mutagen (==1.47.0)", "pycryptodomex (==3.23.0)", "requests (==2.34.2)", "urllib3 (==2.7.0)", "websockets (==16.0)", "yt-dlp-ejs (==0.8.0)"]
-pin-curl-cffi = ["certifi (==2026.5.20) ; implementation_name == \"cpython\"", "cffi (==2.0.0) ; implementation_name == \"cpython\"", "curl-cffi (==0.15.0) ; implementation_name == \"cpython\"", "markdown-it-py (==4.2.0) ; implementation_name == \"cpython\"", "mdurl (==0.1.2) ; implementation_name == \"cpython\"", "pycparser (==3.0) ; implementation_name == \"cpython\"", "pygments (==2.20.0) ; implementation_name == \"cpython\"", "rich (==15.0.0) ; implementation_name == \"cpython\""]
-pin-deno = ["deno (==2.8.1)"]
-pin-secretstorage = ["cffi (==2.0.0) ; platform_python_implementation != \"PyPy\"", "cryptography (==48.0.0)", "jeepney (==0.9.0)", "pycparser (==3.0) ; implementation_name != \"PyPy\" and platform_python_implementation != \"PyPy\"", "secretstorage (==3.5.0)", "typing-extensions (==4.15.0) ; python_full_version < \"3.11.0\""]
+pin = ["brotli (==1.2.0) ; implementation_name == \"cpython\" and sys_platform != \"ios\"", "brotlicffi (==1.2.0.1) ; implementation_name != \"cpython\"", "certifi (==2026.6.17)", "charset-normalizer (==3.4.7)", "idna (==3.18)", "mutagen (==1.48.1)", "pycryptodomex (==3.23.0)", "requests (==2.34.2)", "urllib3 (==2.7.0)", "websockets (==16.0)", "yt-dlp-ejs (==0.8.0)"]
+pin-curl-cffi = ["certifi (==2026.6.17) ; implementation_name == \"cpython\"", "cffi (==2.0.0) ; implementation_name == \"cpython\"", "curl-cffi (==0.15.0) ; implementation_name == \"cpython\"", "markdown-it-py (==4.2.0) ; implementation_name == \"cpython\"", "mdurl (==0.1.2) ; implementation_name == \"cpython\"", "pycparser (==3.0) ; implementation_name == \"cpython\"", "pygments (==2.20.0) ; implementation_name == \"cpython\"", "rich (==15.0.0) ; implementation_name == \"cpython\""]
+pin-deno = ["deno (==2.8.3)"]
+pin-secretstorage = ["cffi (==2.0.0) ; platform_python_implementation != \"PyPy\"", "cryptography (==49.0.0)", "jeepney (==0.9.0)", "pycparser (==3.0) ; implementation_name != \"PyPy\" and platform_python_implementation != \"PyPy\"", "secretstorage (==3.5.0)", "typing-extensions (==4.15.0) ; python_full_version < \"3.11.0\""]
 secretstorage = ["secretstorage"]
 
 [metadata]


### PR DESCRIPTION
## Summary
Patch two open Dependabot security alerts: yt-dlp 2026.6.9 → 2026.7.4 (HIGH, command injection via `--write-link`, GHSA-6v4j-43gg-vj32 / CVE-2026-55404) and pydantic-settings 2.14.1 → 2.14.2 (MEDIUM, `secrets_dir` symlink traversal). This project never uses `--write-link` and consumes yt-dlp only as a library, so exposure was low — bumped anyway to clear the advisories.

## Changes
- `poetry.lock` — `poetry update yt-dlp pydantic-settings`; both existing caret constraints already allow the patched versions, so `pyproject.toml` is untouched (+10/−10, lockfile only)

## Verification
```
$ poetry update yt-dlp pydantic-settings
Package operations: 0 installs, 2 updates, 0 removals
  - Updating pydantic-settings (2.14.1 -> 2.14.2)
  - Updating yt-dlp (2026.6.9 -> 2026.7.4)

$ poetry run pytest   # run three times
======================= 310 passed, 1 skipped in 37.20s =======================
======================= 310 passed, 1 skipped in 36.81s =======================
======================= 310 passed, 1 skipped in 36.82s =======================
```

Upstream drift check for the one release in range (2026.07.04):
- HTTP error text still `HTTP Error {status}: {reason}` — the downloader's `"HTTP Error 403"`/`"HTTP Error 404"` substring classification is unaffected (only an additive video-ID prefix was added to some request errors)
- `.part` / `.ytdl` partial-file naming unchanged (`FileDownloader.temp_name()` / `ytdl_filename()`)
- No `YoutubeDL` embedding API breaking changes; RTSP/MMS removal does not affect this project

## Acceptance
- [x] `poetry.lock` pins yt-dlp ≥ 2026.7.4 and pydantic-settings ≥ 2.14.2 (Dependabot alerts #24 and #23 clear)
- [x] Full test suite green locally 3x (310 passed, 1 skipped — POSIX-only tz guard, covered by CI)
- [x] Diff is lockfile-only; no constraint or code changes
- [x] Known yt-dlp couplings verified unchanged upstream (error-message substrings, partial-file suffixes)
