### PR TITLE
fix(logging): log tracebacks for unexpected errors and unify downloader log context

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -141,7 +141,7 @@ def read_app_config(config_path: str) -> AppConfig:
 
     except Exception as e:
         error_msg = f"Unexpected error while reading configuration: {e}"
-        _get_logger().error(error_msg)
+        _get_logger().exception(error_msg)
         raise ConfigError(error_msg) from e
 
 

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -372,7 +372,10 @@ class StreamDownloader:
 
         except yt_dlp.utils.DownloadError as e:
             error_message = str(e)
-            self.log.exception(
+            # ponytail: .error, not .exception — this handler mostly sees classified
+            # 401/403/404 access failures where the yt-dlp message says it all; the
+            # truly-unexpected path below keeps the traceback.
+            self.log.error(
                 "❌ Download error: "
                 f"{error_message}; session_key={self.session_key or 'none'}, "
                 f"{self._build_output_state_details(output_path)}",

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -25,7 +25,7 @@ from core.constants import (
     DEFAULT_HTTP_HEADERS,
     DEFAULT_MAX_RETRIES,
 )
-from core.logger import setup_logger
+from core.logger import bind, setup_logger
 from core.utils import format_file_size
 from models.download import (
     RawDownloadAuthFailed,
@@ -65,7 +65,7 @@ class _YtDlpLoggerBridge:
         normalized = str(message).strip()
         if not normalized:
             return
-        self._downloader._log("debug", f"yt-dlp: {normalized}")
+        self._downloader.log.debug(f"yt-dlp: {normalized}")
 
     def debug(self, message: Any) -> None:
         self._emit(message)
@@ -137,8 +137,8 @@ class StreamDownloader:
                 Called from the download thread.
         """
         self.creator_name = creator_name
-        self._log_prefix = f"[{creator_name}]"
         self.logger = setup_logger("Downloader")
+        self.log = bind(self.logger, creator_name)
         self.download_thread: Optional[threading.Thread] = None
         self._current_output_path: Optional[Path] = None
         self._download_start_time: Optional[datetime] = None
@@ -154,11 +154,6 @@ class StreamDownloader:
             self,
             enabled=_read_bool_env("LOG_YTDLP_INTERNAL", default=False),
         )
-
-    def _log(self, level: str, message: str) -> None:
-        """Log a message with creator name prefix."""
-        full_message = f"{self._log_prefix} {message}"
-        getattr(self.logger, level)(full_message)
 
     def download(self, stream_url: str, live_title: str) -> None:
         """
@@ -187,8 +182,7 @@ class StreamDownloader:
         # Configure yt-dlp options
         ydl_opts = self._build_ydl_options(output_path)
 
-        self._log(
-            "debug",
+        self.log.debug(
             f"session_key={self.session_key or 'none'}, output_path={output_path}",
         )
 
@@ -209,8 +203,7 @@ class StreamDownloader:
         # here (and again in the output filename) is what made one event span
         # three lines. The session prefix is what ties this log to a file on disk.
         session_prefix = (self.filename_prefix or "").rstrip("_")
-        self._log(
-            "info",
+        self.log.info(
             f"📥 Recording started (session {session_prefix})" if session_prefix
             else "📥 Recording started",
         )
@@ -357,14 +350,12 @@ class StreamDownloader:
             if output_path.exists():
                 file_size = output_path.stat().st_size
                 size_str = format_file_size(file_size)
-                self._log(
-                    "info",
+                self.log.info(
                     f"✅ Download completed: {output_path.name} "
                     f"({size_str}, {duration_str})",
                 )
             else:
-                self._log(
-                    "warning",
+                self.log.warning(
                     "⚠️  Download finished but file not found: "
                     f"{output_path}; {self._build_output_state_details(output_path)}",
                 )
@@ -381,8 +372,7 @@ class StreamDownloader:
 
         except yt_dlp.utils.DownloadError as e:
             error_message = str(e)
-            self._log(
-                "error",
+            self.log.exception(
                 "❌ Download error: "
                 f"{error_message}; session_key={self.session_key or 'none'}, "
                 f"{self._build_output_state_details(output_path)}",
@@ -395,8 +385,7 @@ class StreamDownloader:
                 self._notify_download_failure(error_message)
 
         except Exception as e:
-            self._log(
-                "error",
+            self.log.exception(
                 "❌ Unexpected download error: "
                 f"{e}; session_key={self.session_key or 'none'}, "
                 f"{self._build_output_state_details(output_path)}",
@@ -456,8 +445,7 @@ class StreamDownloader:
         output_state = "output_path=unknown"
         if self._current_output_path is not None:
             output_state = self._build_output_state_details(self._current_output_path)
-        self._log(
-            "warning",
+        self.log.warning(
             f"⚠️ Download attempt {retry_state.attempt_number}/"
             f"{self.DOWNLOAD_TASK_RETRY_ATTEMPTS} failed; retrying in "
             f"{wait_seconds:.1f}s: {exception}; "
@@ -480,13 +468,11 @@ class StreamDownloader:
                     # The first attempt is already implied by "Recording started".
                     # Only a retry is worth a line of its own.
                     if attempt_number > 1:
-                        self._log(
-                            "info",
+                        self.log.info(
                             f"🔁 Retry {attempt_number}/{self.DOWNLOAD_TASK_RETRY_ATTEMPTS}",
                         )
                     if self.logger.isEnabledFor(logging.DEBUG):
-                        self._log(
-                            "debug",
+                        self.log.debug(
                             f"attempt {attempt_number}/{self.DOWNLOAD_TASK_RETRY_ATTEMPTS}, "
                             f"session_key={self.session_key or 'none'}, "
                             f"output={output_path.name}, "
@@ -508,8 +494,7 @@ class StreamDownloader:
             raise yt_dlp.utils.DownloadError(str(exc)) from exc
 
         if attempt_number > 1:
-            self._log(
-                "info",
+            self.log.info(
                 f"✅ Download succeeded on retry attempt "
                 f"{attempt_number}/{self.DOWNLOAD_TASK_RETRY_ATTEMPTS}",
             )
@@ -528,7 +513,7 @@ class StreamDownloader:
             try:
                 self._on_download_error(error_message)
             except Exception as e:
-                self.logger.error(f"Error in download error callback: {e}")
+                self.log.exception(f"Error in download error callback: {e}")
 
     def _notify_auth_error(self, error_message: str) -> None:
         """Notify listeners that credentials appear invalid for this download."""
@@ -547,7 +532,7 @@ class StreamDownloader:
 
             self._on_download_auth_error(error_message)
         except Exception as e:
-            self.logger.error(f"Error in download auth callback: {e}")
+            self.log.exception(f"Error in download auth callback: {e}")
 
     def _notify_download_complete(self, output_path: Path) -> None:
         """Notify listeners that a raw download finished successfully."""
@@ -562,7 +547,7 @@ class StreamDownloader:
                 )
             )
         except Exception as e:
-            self.logger.error(f"Error in download complete callback: {e}")
+            self.log.exception(f"Error in download complete callback: {e}")
 
     def _notify_download_failure(self, error_message: str) -> None:
         """Notify listeners that a raw download failed for a non-blocked reason."""
@@ -577,5 +562,5 @@ class StreamDownloader:
                 )
             )
         except Exception as e:
-            self.logger.error(f"Error in download failure callback: {e}")
+            self.log.exception(f"Error in download failure callback: {e}")
 

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -169,7 +169,7 @@ class LiveStreamMonitor:
 
                 self._handle_monitor_event(event)
             except Exception as exc:
-                self.logger.error(f"Unexpected control-loop error: {exc}")
+                self.logger.exception(f"Unexpected control-loop error: {exc}")
                 if isinstance(event, _PollRequested):
                     event.done.set()
             finally:
@@ -206,7 +206,7 @@ class LiveStreamMonitor:
             self.logger.error(f"API error: {exc}")
             self._mark_check_failed()
         except Exception as exc:
-            self.logger.error(f"Unexpected error during monitoring: {exc}")
+            self.logger.exception(f"Unexpected error during monitoring: {exc}")
             self._mark_check_failed()
 
     def _mark_check_succeeded(self) -> None:
@@ -385,7 +385,7 @@ class LiveStreamMonitor:
             self.logger.warning(f"Failed to get stream URL for {creator_name}: {exc}")
             return
 
-        self.logger.error(f"Error starting download for {creator_name}: {exc}")
+        self.logger.error(f"Error starting download for {creator_name}: {exc}", exc_info=exc)
 
     def _log_status_summary(self, total_live: int, monitored_live: int) -> None:
         """Log a summary of the current monitoring status."""
@@ -832,6 +832,7 @@ class LiveStreamMonitor:
                 error_message=f"ffmpeg merge timeout after {timeout_value} seconds",
             )
         except Exception as exc:
+            self.logger.exception(f"Merge failed for session {merge_job.session_key}")
             self._discard_partial_merge_output(output_path)
             return MergeFailed(
                 session_key=merge_job.session_key,

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -832,8 +832,8 @@ class LiveStreamMonitor:
                 error_message=f"ffmpeg merge timeout after {timeout_value} seconds",
             )
         except Exception as exc:
-            self.logger.exception(f"Merge failed for session {merge_job.session_key}")
             self._discard_partial_merge_output(output_path)
+            self.logger.exception(f"Merge failed for session {merge_job.session_key}")
             return MergeFailed(
                 session_key=merge_job.session_key,
                 error_message=str(exc),

--- a/core/rplay.py
+++ b/core/rplay.py
@@ -207,7 +207,7 @@ class RPlayAPI:
             raise
 
         except Exception as exc:
-            self.logger.error(f"Unexpected error while fetching livestream status: {exc}")
+            self.logger.exception(f"Unexpected error while fetching livestream status: {exc}")
             raise RPlayAPIError(f"Unexpected error: {exc}")
 
         return []

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -72,7 +72,7 @@ class LiveStreamScheduler:
         try:
             self.monitor.check_live_streams_and_start_download()
         except Exception as e:
-            self.logger.error(f"Error while checking live streams: {e}")
+            self.logger.exception(f"Error while checking live streams: {e}")
 
     def start(self) -> None:
         """
@@ -103,7 +103,7 @@ class LiveStreamScheduler:
             self.logger.info("Monitoring system manually stopped")
             self.stop()
         except Exception as e:
-            self.logger.error(f"System runtime error: {e}")
+            self.logger.exception(f"System runtime error: {e}")
             raise
 
     def stop(self) -> None:

--- a/main.py
+++ b/main.py
@@ -83,14 +83,14 @@ def main() -> None:
         logger.error(f"Invalid configuration: {e}")
         sys.exit(1)
     except Exception as e:
-        logger.error(f"Unexpected error loading configuration: {e}")
+        logger.exception(f"Unexpected error loading configuration: {e}")
         sys.exit(1)
 
     # Start the scheduler
     try:
         run_scheduler(env=env, logger=logger, version=__version__)
     except Exception as e:
-        logger.error(f"Scheduler error: {e}")
+        logger.exception(f"Scheduler error: {e}")
         sys.exit(1)
 
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -32,9 +32,9 @@ class TestStreamDownloaderInit:
         assert downloader.creator_name == "TestCreator"
 
     def test_init_sets_log_prefix(self):
-        """Test that log prefix is set with creator name."""
+        """Test that the log adapter is bound to the creator name."""
         downloader = StreamDownloader("TestCreator")
-        assert downloader._log_prefix == "[TestCreator]"
+        assert downloader.log.extra["context"] == "TestCreator"
 
     def test_init_creates_logger(self):
         """Test that a logger is created on initialization."""
@@ -192,10 +192,10 @@ class TestYtDlpLoggerBridge:
         downloader = StreamDownloader("TestCreator", output_dir=tmp_path)
         logger_bridge = downloader._build_ydl_options(tmp_path / "test.ts")["logger"]
 
-        with patch.object(downloader.logger, "debug") as mock_debug:
+        with patch.object(downloader, "log") as mock_log:
             logger_bridge.debug("[generic] playlist: Downloading webpage")
 
-        assert any("yt-dlp" in str(call) for call in mock_debug.call_args_list)
+        assert any("yt-dlp" in str(call) for call in mock_log.debug.call_args_list)
 
 
 class TestBuildYdlOptions:
@@ -301,16 +301,15 @@ class TestDownloadMethod:
             session_key="creator1:1772880472",
         )
 
-        with patch.object(downloader, '_log') as mock_log:
+        with patch.object(downloader, 'log') as mock_log:
             downloader.download("http://example.com/stream.m3u8", "Test Stream")
             assert downloader.download_thread is not None
             downloader.download_thread.join(timeout=1)
 
         assert any(
-            call.args[0] == "debug"
-            and "session_key=creator1:1772880472" in call.args[1]
-            and "output_path=" in call.args[1]
-            for call in mock_log.call_args_list
+            "session_key=creator1:1772880472" in call.args[0]
+            and "output_path=" in call.args[0]
+            for call in mock_log.debug.call_args_list
         )
 
     def test_does_not_log_recording_started_when_thread_fails_to_start(
@@ -755,14 +754,14 @@ class TestDownloadErrorCallback:
         downloader._download_start_time = datetime.now()
         mock_ydl.download.side_effect = yt_dlp.utils.DownloadError("Some other error")
 
-        with patch.object(downloader.logger, "error") as mock_error:
+        with patch.object(downloader.logger, "log") as mock_log:
             downloader._download_worker("http://example.com/stream.m3u8", {}, output_path)
 
         assert any(
             "output_path=" in str(call)
             and "part_exists=True" in str(call)
             and "part_size=6.0 B" in str(call)
-            for call in mock_error.call_args_list
+            for call in mock_log.call_args_list
         )
 
     def test_worker_emits_failure_event_on_non_m3u8_error(self, mock_yt_dlp, tmp_path):

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -181,10 +181,10 @@ class TestYtDlpLoggerBridge:
         downloader = StreamDownloader("TestCreator", output_dir=tmp_path)
         logger_bridge = downloader._build_ydl_options(tmp_path / "test.ts")["logger"]
 
-        with patch.object(downloader.logger, "debug") as mock_debug:
+        with patch.object(downloader, "log") as mock_log:
             logger_bridge.debug("[generic] playlist: Downloading webpage")
 
-        mock_debug.assert_not_called()
+        mock_log.debug.assert_not_called()
 
     def test_internal_ytdlp_debug_logs_can_be_enabled(self, tmp_path, monkeypatch):
         """Test internal yt-dlp debug chatter can be surfaced for diagnosis."""
@@ -564,7 +564,7 @@ class TestDownloadErrorCallback:
         )
         output_path = tmp_path / "test.ts"
 
-        with patch.object(downloader.logger, "info") as mock_info:
+        with patch.object(downloader, "log") as mock_log:
             downloader._download_stream_with_retries(
                 "http://example.com/stream.m3u8",
                 downloader._build_ydl_options(output_path),
@@ -573,7 +573,7 @@ class TestDownloadErrorCallback:
 
         assert not any(
             "Retry" in str(call)
-            for call in mock_info.call_args_list
+            for call in mock_log.info.call_args_list
         )
 
     def test_worker_retries_transient_download_errors_within_same_task(

--- a/tests/test_live_stream_monitor.py
+++ b/tests/test_live_stream_monitor.py
@@ -905,11 +905,11 @@ class TestCheckLiveStreamsErrorHandling:
             api=mock_api,
         )
 
-        with patch.object(monitor.logger, 'error') as mock_error:
+        with patch.object(monitor.logger, 'exception') as mock_exception:
             monitor.check_live_streams_and_start_download()
 
-        assert mock_error.call_count == 1
-        assert mock_error.call_args.args[0] == 'Unexpected error during monitoring: boom'
+        assert mock_exception.call_count == 1
+        assert mock_exception.call_args.args[0] == 'Unexpected error during monitoring: boom'
 
 
 class TestGetActiveDownloads:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -86,8 +86,8 @@ class TestCheckAndDownload:
 
         # Should not raise
         scheduler.check_and_download()
-        mock_logger.error.assert_called_once()
-        assert "Test error" in str(mock_logger.error.call_args)
+        mock_logger.exception.assert_called_once()
+        assert "Test error" in str(mock_logger.exception.call_args)
 
 
 class TestStartScheduler:


### PR DESCRIPTION
## Summary
The daemon logged 36 ERROR sites with only `str(e)` — zero tracebacks anywhere in the codebase. When something unexpected broke, the log showed one line with no way to locate the source. This PR converts the unexpected-error sites (`except Exception` catch-alls and thread/event-loop swallow points) to `logger.exception`, while deliberately keeping expected errors (config validation, auth failures, timeouts, classified HTTP 401/403/404) at `logger.error` where a traceback is noise. It also deletes the hand-rolled `_log()` prefix mechanism in the downloader in favor of the existing stdlib `LoggerAdapter`-based `bind()`, so one prefixing mechanism remains and the four callback error sites that previously bypassed the `[creator]` prefix now carry it.

## Changes
- `main.py:86,93` — unexpected config-load error and scheduler crash → `logger.exception`; expected `EnvConfigError`/`ValueError` stay at `error`
- `core/scheduler.py:75,106` — poll-job and runtime catch-alls → `logger.exception` (the main event-loop swallow point)
- `core/config.py:144` — final `except Exception` in `read_app_config` → `exception`; deliberate validation reports stay at `error`
- `core/rplay.py:210` — final `except Exception` in `get_livestream_status` → `exception`; timeout/connection/HTTP-status sites stay at `error`
- `core/live_stream_monitor.py:172,209` — control-loop and poll-cycle catch-alls → `exception`; `:388` helper fallback uses `error(..., exc_info=exc)` (receives the exception as a parameter, must not depend on an active except block); `_merge_session_to_mp4` now logs the merge exception with traceback after discarding the partial output — previously `MergeFailed` carried only `str(exc)` and the traceback was lost
- `core/downloader.py` — deleted `_log()`/`_log_prefix`, bound `self.log = bind(self.logger, creator_name)`; all 12 prefix call sites plus the yt-dlp bridge now go through the adapter; 4 callback catch sites → `self.log.exception(...)` (gain prefix + traceback); unexpected worker errors → `exception`, classified `DownloadError`s stay at `error`
- `tests/` — mock assertions updated for the adapter delegation; fixed two negative-assertion tests that had become vacuous (patching `logger.debug`/`logger.info` which the adapter path never calls — they could no longer fail)

Messages keep their trailing `: {e}` so the message line stays greppable on its own in file logs; the traceback is appended below it.

## Verification
```
$ poetry run pytest -q   # run three times
======================= 310 passed, 1 skipped in 36.34s =======================
======================= 310 passed, 1 skipped in 36.83s =======================
======================= 310 passed, 1 skipped in 36.92s =======================
```
Two independent local review lanes (pragmatic L3 + over-engineering hunt) ran against the diff. Accepted and fixed: merge-failure log reordered after the partial-output discard so the data-loss guard can never be skipped by a logging failure; classified `DownloadError`s reverted to `error`; two vacuous adapter-era test mocks repaired. Declined with rationale: merging `self.logger`/`self.log` into one attribute (rename churn, zero behavior change) and rewriting pre-existing mock-style tests to caplog (behavioral `exc_info`/prefix coverage already exists in `tests/test_logger.py`).

## Acceptance
- [x] Every `except Exception` catch-all in `main`, `scheduler`, `config`, `rplay`, `live_stream_monitor`, and `downloader` now records a traceback (`logger.exception` or explicit `exc_info`)
- [x] Expected-error sites (validation, auth, timeout, classified HTTP errors) still log single-line `error` without traceback spam
- [x] Merge failures log the underlying exception with traceback; partial-output cleanup runs before logging
- [x] `_log()` is gone; `[creator]` prefixing has exactly one mechanism (`bind()`), and previously unprefixed callback errors now carry the prefix
- [x] Full suite green 3x locally (310 passed, 1 skipped — POSIX-only tz guard, covered by CI)
