### PR TITLE
chore: prepare v2.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ docker run -d \
   -v $(pwd)/config:/app/config \
   -v $(pwd)/archive:/app/archive \
   -v $(pwd)/logs:/app/logs \
-  paverz/rplay-live-dl:v2.1.1-vibe
+  paverz/rplay-live-dl:v2.2.0-vibe
 ```
 
 ### Directory Structure
@@ -467,7 +467,7 @@ poetry run pytest --cov --cov-report=xml
 rplay-live-dl/
 ├── .github/
 │   └── workflows/
-│       ├── coverage.yml
+│       ├── docker-smoke.yml
 │       ├── main.yaml
 │       └── test.yml
 ├── core/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   rplay-live-dl:
-    image: paverz/rplay-live-dl:v2.1.1-vibe
+    image: paverz/rplay-live-dl:v2.2.0-vibe
     container_name: rplay-live-dl
     env_file: .env
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rplay-live-dl"
-version = "2.1.1"
+version = "2.2.0"
 description = ""
 authors = ["paver(kevinsun)"]
 license = "MIT"


### PR DESCRIPTION
## Summary
Release metadata for v2.2.0: bump the single version source, point Compose/README image tags at the upcoming v2.2.0-vibe image, and correct the workflow listing after #34.

## Changes
- `pyproject.toml:3` — version 2.1.1 → 2.2.0 (main.py reports this at startup)
- `docker-compose.yaml:3`, `README.md:335` — image tag → v2.2.0-vibe
- `README.md:470` — workflows list: coverage.yml (deleted in #34) → docker-smoke.yml

## Verification
```
$ poetry run pytest -q
======================= 310 passed, 1 skipped in 36.53s =======================

$ poetry run python -c "import main; print(main.__version__)"
2.2.0
```

## Acceptance
- [x] Version single source reports 2.2.0
- [x] No remaining v2.1.1-vibe reference in Compose/README
- [x] Suite green locally; CI gates on this PR
