### PR TITLE
fix(logging): rotation crashed and silently killed file logging

### DIFF
--- a/core/logger.py
+++ b/core/logger.py
@@ -228,72 +228,6 @@ class ColoredAlignedFormatter(colorlog.ColoredFormatter):
         return result
 
 
-class LazyRotatingFileHandler(RotatingFileHandler):
-    """
-    A RotatingFileHandler that delays file creation until the first log is written.
-
-    This prevents empty log files from being created for loggers that never log anything.
-    """
-
-    def __init__(
-        self,
-        filename: str,
-        maxBytes: int = 0,
-        backupCount: int = 0,
-        encoding: Optional[str] = None,
-    ) -> None:
-        """
-        Initialize the handler without creating the file.
-
-        Args:
-            filename: Path to the log file
-            maxBytes: Maximum file size before rotation
-            backupCount: Number of backup files to keep
-            encoding: File encoding
-        """
-        self._log_filename = filename
-        self._file_created = False
-        self._maxBytes = maxBytes
-        self._backupCount = backupCount
-        self._encoding = encoding
-        # Initialize base Handler only, not StreamHandler or FileHandler
-        # This avoids file creation
-        logging.Handler.__init__(self)
-        # Set attributes needed by RotatingFileHandler
-        self.mode = "a"
-        self.encoding = encoding
-        self.maxBytes = maxBytes
-        self.backupCount = backupCount
-        self.stream: Any = None
-        self.baseFilename = os.path.abspath(filename)
-
-    def emit(self, record: logging.LogRecord) -> None:
-        """
-        Emit a record, creating the file if necessary.
-
-        Args:
-            record: The log record to emit
-        """
-        if not self._file_created:
-            self._create_file()
-        super().emit(record)
-
-    def _create_file(self) -> None:
-        """Create the log file and properly initialize file handling."""
-        # Ensure directory exists
-        log_dir = os.path.dirname(self._log_filename)
-        if log_dir:
-            os.makedirs(log_dir, exist_ok=True)
-
-        # Open the stream
-        self.stream = open(
-            self._log_filename,
-            mode=self.mode,
-            encoding=self.encoding,
-        )
-        self._file_created = True
-
-
 def get_logs_dir() -> Path:
     """Get the logs directory, creating it if necessary."""
     global _logs_dir
@@ -354,11 +288,15 @@ def setup_logger(
         logs_dir = get_logs_dir()
         log_file = logs_dir / f"{name}.log"
 
-        file_handler = LazyRotatingFileHandler(
+        # ponytail: delay=True gives lazy file creation for free (stdlib);
+        # relies on setup_logger's get_logs_dir() call above to mkdir the
+        # parent, since delay=True does not create directories.
+        file_handler = RotatingFileHandler(
             filename=str(log_file),
             maxBytes=_get_log_max_bytes(),
             backupCount=_get_log_backup_count(),
             encoding="utf-8",
+            delay=True,
         )
         file_handler.setLevel(resolved_level)
         file_formatter = AlignedFormatter(

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import time
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 import pytest
@@ -16,7 +17,6 @@ from core.logger import (
     setup_logger,
     AlignedFormatter,
     ColoredAlignedFormatter,
-    LazyRotatingFileHandler,
     LOGGER_NAME_WIDTH,
     LOG_LEVEL_WIDTH,
     LOG_TEXT_MAX_COLUMNS,
@@ -257,93 +257,72 @@ class TestColoredAlignedFormatter:
         assert record.name == "OriginalName"
 
 
-class TestLazyRotatingFileHandler:
-    """Tests for LazyRotatingFileHandler class."""
+class TestRotatingFileHandlerLazyCreation:
+    """Regression tests for the file handler setup_logger constructs.
 
-    def test_no_file_created_on_init(self, tmp_path):
-        """Test that no file is created during initialization."""
-        log_file = tmp_path / "test.log"
-        handler = LazyRotatingFileHandler(
+    LazyRotatingFileHandler used to hand-roll lazy creation by skipping
+    FileHandler.__init__, which left `delay`/`errors` unset and crashed
+    stdlib's doRollover() on the first rotation. Replaced with stock
+    RotatingFileHandler(delay=True), which gives lazy creation for free.
+    """
+
+    def _make_handler(
+        self, log_file: Path, max_bytes: int = 1024, backup_count: int = 3
+    ) -> RotatingFileHandler:
+        handler = RotatingFileHandler(
             filename=str(log_file),
-            maxBytes=1024,
-            backupCount=3,
+            maxBytes=max_bytes,
+            backupCount=backup_count,
+            encoding="utf-8",
+            delay=True,
         )
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        return handler
+
+    def test_no_file_created_until_first_emit(self, tmp_path):
+        """Test lazy creation: no file after construction, file after first emit."""
+        log_file = tmp_path / "test.log"
+        handler = self._make_handler(log_file)
         assert not log_file.exists()
+
+        handler.emit(logging.LogRecord(
+            name="Test", level=logging.INFO, pathname="", lineno=0,
+            msg="hello world", args=(), exc_info=None,
+        ))
         handler.close()
-
-    def test_file_created_on_first_emit(self, tmp_path):
-        """Test that file is created on first log emit."""
-        log_file = tmp_path / "test.log"
-        handler = LazyRotatingFileHandler(
-            filename=str(log_file),
-            maxBytes=1024,
-            backupCount=3,
-        )
-        handler.setFormatter(logging.Formatter("%(message)s"))
-
-        record = logging.LogRecord(
-            name="Test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg="test message",
-            args=(),
-            exc_info=None,
-        )
-        handler.emit(record)
 
         assert log_file.exists()
-        handler.close()
+        assert "hello world" in log_file.read_text()
 
-    def test_creates_parent_directory(self, tmp_path):
-        """Test that handler creates parent directories if needed."""
-        log_file = tmp_path / "subdir" / "nested" / "test.log"
-        handler = LazyRotatingFileHandler(
-            filename=str(log_file),
-            maxBytes=1024,
-            backupCount=3,
-        )
-        handler.setFormatter(logging.Formatter("%(message)s"))
-
-        record = logging.LogRecord(
-            name="Test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg="test message",
-            args=(),
-            exc_info=None,
-        )
-        handler.emit(record)
-
-        assert log_file.exists()
-        assert log_file.parent.exists()
-        handler.close()
-
-    def test_writes_log_content(self, tmp_path):
-        """Test that log content is written to file."""
+    def test_rollover_does_not_crash_or_lose_messages(self, tmp_path, capsys):
+        """Test the actual bug: rollover under delay=True must not raise/log an error."""
         log_file = tmp_path / "test.log"
-        handler = LazyRotatingFileHandler(
-            filename=str(log_file),
-            maxBytes=1024,
-            backupCount=3,
-        )
-        handler.setFormatter(logging.Formatter("%(message)s"))
+        # Tiny maxBytes forces rollover almost immediately; backupCount is
+        # generously large so no message is dropped by normal backup-count
+        # rotation (a separate, intentional behavior from the bug here).
+        handler = self._make_handler(log_file, max_bytes=50, backup_count=10)
 
-        record = logging.LogRecord(
-            name="Test",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg="hello world",
-            args=(),
-            exc_info=None,
-        )
-        handler.emit(record)
+        messages = [f"message number {i}" for i in range(6)]
+        for i, msg in enumerate(messages):
+            handler.emit(logging.LogRecord(
+                name="Test", level=logging.INFO, pathname="", lineno=0,
+                msg=msg, args=(), exc_info=None,
+            ))
         handler.close()
 
-        content = log_file.read_text()
-        assert "hello world" in content
+        backup_file = tmp_path / "test.log.1"
+        assert backup_file.exists(), "rollover should have produced a backup file"
+
+        all_content = "".join(
+            f.read_text() for f in tmp_path.glob("test.log*")
+        )
+        for msg in messages:
+            assert msg in all_content
+
+        # logging.Handler.handleError() prints "--- Logging error ---" to
+        # stderr on unhandled exceptions inside emit(); its absence is the
+        # regression check for the AttributeError this bug used to raise.
+        assert "--- Logging error ---" not in capsys.readouterr().err
 
 
 class TestContextAdapter:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -264,65 +264,72 @@ class TestRotatingFileHandlerLazyCreation:
     FileHandler.__init__, which left `delay`/`errors` unset and crashed
     stdlib's doRollover() on the first rotation. Replaced with stock
     RotatingFileHandler(delay=True), which gives lazy creation for free.
+
+    These go through setup_logger() itself (not a hand-built handler) so a
+    regression back to the old broken class actually fails them: this test
+    module imports setup_logger at module scope, before the autouse
+    disable_file_logging fixture monkeypatches the module attribute, so the
+    real function under test runs here regardless of that fixture.
     """
 
-    def _make_handler(
-        self, log_file: Path, max_bytes: int = 1024, backup_count: int = 3
-    ) -> RotatingFileHandler:
-        handler = RotatingFileHandler(
-            filename=str(log_file),
-            maxBytes=max_bytes,
-            backupCount=backup_count,
-            encoding="utf-8",
-            delay=True,
-        )
-        handler.setFormatter(logging.Formatter("%(message)s"))
-        return handler
+    def test_no_file_created_until_first_emit(self, tmp_path, monkeypatch):
+        from core import logger as logger_module
 
-    def test_no_file_created_until_first_emit(self, tmp_path):
-        """Test lazy creation: no file after construction, file after first emit."""
-        log_file = tmp_path / "test.log"
-        handler = self._make_handler(log_file)
-        assert not log_file.exists()
+        monkeypatch.setattr(logger_module, "_logs_dir", tmp_path)
 
-        handler.emit(logging.LogRecord(
-            name="Test", level=logging.INFO, pathname="", lineno=0,
-            msg="hello world", args=(), exc_info=None,
-        ))
-        handler.close()
+        logger_name = "test_lazy_creation_regression"
+        logger = setup_logger(logger_name, log_to_file=True, log_to_console=False)
+        try:
+            log_file = tmp_path / f"{logger_name}.log"
+            assert not log_file.exists()
 
-        assert log_file.exists()
-        assert "hello world" in log_file.read_text()
+            logger.info("hello world")
 
-    def test_rollover_does_not_crash_or_lose_messages(self, tmp_path, capsys):
-        """Test the actual bug: rollover under delay=True must not raise/log an error."""
-        log_file = tmp_path / "test.log"
-        # Tiny maxBytes forces rollover almost immediately; backupCount is
-        # generously large so no message is dropped by normal backup-count
-        # rotation (a separate, intentional behavior from the bug here).
-        handler = self._make_handler(log_file, max_bytes=50, backup_count=10)
+            assert "hello world" in log_file.read_text()
+        finally:
+            for handler in logger.handlers[:]:
+                handler.close()
+                logger.removeHandler(handler)
 
-        messages = [f"message number {i}" for i in range(6)]
-        for i, msg in enumerate(messages):
-            handler.emit(logging.LogRecord(
-                name="Test", level=logging.INFO, pathname="", lineno=0,
-                msg=msg, args=(), exc_info=None,
-            ))
-        handler.close()
+    def test_rollover_does_not_crash_or_lose_messages(self, tmp_path, monkeypatch, capsys):
+        from core import logger as logger_module
 
-        backup_file = tmp_path / "test.log.1"
-        assert backup_file.exists(), "rollover should have produced a backup file"
+        monkeypatch.setattr(logger_module, "_logs_dir", tmp_path)
 
-        all_content = "".join(
-            f.read_text() for f in tmp_path.glob("test.log*")
-        )
-        for msg in messages:
-            assert msg in all_content
+        logger_name = "test_rollover_regression"
+        logger = setup_logger(logger_name, log_to_file=True, log_to_console=False)
+        try:
+            file_handler = next(
+                (h for h in logger.handlers if isinstance(h, RotatingFileHandler)),
+                None,
+            )
+            assert file_handler is not None
 
-        # logging.Handler.handleError() prints "--- Logging error ---" to
-        # stderr on unhandled exceptions inside emit(); its absence is the
-        # regression check for the AttributeError this bug used to raise.
-        assert "--- Logging error ---" not in capsys.readouterr().err
+            # Shrink only the rotation threshold so rollover triggers almost
+            # immediately; keep the real construction (incl. delay=True) from
+            # setup_logger so this exercises the actual bug site.
+            file_handler.maxBytes = 50
+
+            messages = ["message one", "message two", "message three"]
+            for msg in messages:
+                logger.info(msg)
+
+            assert (tmp_path / f"{logger_name}.log.1").exists()
+
+            all_content = "".join(
+                f.read_text() for f in tmp_path.glob(f"{logger_name}.log*")
+            )
+            for msg in messages:
+                assert msg in all_content
+
+            # logging.Handler.handleError() prints "--- Logging error ---" to
+            # stderr on unhandled exceptions inside emit(); its absence is the
+            # regression check for the AttributeError this bug used to raise.
+            assert "--- Logging error ---" not in capsys.readouterr().err
+        finally:
+            for handler in logger.handlers[:]:
+                handler.close()
+                logger.removeHandler(handler)
 
 
 class TestContextAdapter:


### PR DESCRIPTION
## Summary

Deployment verification of `v2.2.0-vibe` (the last #28 acceptance item) exposed a latent bug: the moment any log file reached its rotation threshold, file logging for that logger **died silently for the rest of the process lifetime**. Console output (and therefore `docker logs`) was unaffected, which is exactly why it was never noticed.

## Root cause

`LazyRotatingFileHandler` skipped `FileHandler.__init__` (called `logging.Handler.__init__` directly and hand-set attributes) and never set `delay` or `errors`:

- first rollover: stdlib `doRollover()` → `AttributeError: 'LazyRotatingFileHandler' object has no attribute 'delay'` → that record lost
- every later emit: `FileHandler._open()` reads the missing `errors` attribute → `AttributeError` → all subsequent records lost
- `logging` swallows handler exceptions via `handleError()`, so nothing crashes — file output just stops

Observed in production (Docker, `v2.2.0-vibe`, `LOG_MAX_SIZE_MB=1`):

```
File ".../logging/handlers.py", line 74, in emit -> self.doRollover()
File ".../logging/handlers.py", line 180, in doRollover -> if not self.delay:
AttributeError: 'LazyRotatingFileHandler' object has no attribute 'delay'
```

## Fix

Delete the class. Stdlib `RotatingFileHandler(delay=True)` *is* lazy file creation — 67 lines replaced by one argument. Parent-directory creation at emit time is not re-added: `setup_logger` mkdirs the logs dir via `get_logs_dir()` before constructing the handler.

## Tests

- Rewrote the handler tests to exercise `setup_logger`'s real wiring — review caught that the first version built the handler directly and would still pass with the old broken class restored
- Lazy-creation regression: no file until first emit, content written after
- Rollover regression: forces rollover at a tiny threshold through the real handler; asserts the backup file exists, no message is lost, and no `--- Logging error ---` appears on stderr (the old failure signature)

Net: −83 lines.

## Acceptance

- [x] `poetry run pytest` locally 3x: `308 passed, 1 skipped` each run (310→308 by collapsing 4 handler tests into 2 targeted regressions)
- [x] Two-lane review (pragmatic + over-engineering hunt); lane 1's SUT-bypass finding fixed in the second commit, lane 2's trims applied
- [x] `test (3.11)` and `test (3.12)` green on this PR
- [x] In-container proof on the deployment host after release — verified 2026-07-28 running `paverz/rplay-live-dl:v2.2.1-vibe` with production settings (`LOG_MAX_SIZE_MB=5`): `Main.log` prefilled to 5.4 MB (used instead of `Monitor.log` because Main guarantees startup emits) rotated to a 5,401,836-byte `Main.log.1` on first emit, a fresh `Main.log` continued receiving records after rotation (contains `rplay-live-dl v2.2.1 (75dc282)`, zero filler lines), and container output shows zero `Logging error` occurrences — on `v2.2.0-vibe` this same scenario produced the `AttributeError` traceback above and killed file logging

