### PR TITLE
chore: prepare v2.2.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ docker run -d \
   -v $(pwd)/config:/app/config \
   -v $(pwd)/archive:/app/archive \
   -v $(pwd)/logs:/app/logs \
-  paverz/rplay-live-dl:v2.2.0-vibe
+  paverz/rplay-live-dl:v2.2.1-vibe
 ```
 
 ### Directory Structure

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   rplay-live-dl:
-    image: paverz/rplay-live-dl:v2.2.0-vibe
+    image: paverz/rplay-live-dl:v2.2.1-vibe
     container_name: rplay-live-dl
     env_file: .env
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rplay-live-dl"
-version = "2.2.0"
+version = "2.2.1"
 description = ""
 authors = ["paver(kevinsun)"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Release prep for `v2.2.1-vibe`, following the #36 rotation fix. Version/tag references only, mirroring #35's shape:

- `pyproject.toml`: `2.2.0` → `2.2.1`
- `docker-compose.yaml`: image tag `v2.2.0-vibe` → `v2.2.1-vibe`
- `README.md`: docker pull example `v2.2.0-vibe` → `v2.2.1-vibe`

## Acceptance

- [x] `poetry run pytest` local: 308 passed, 1 skipped (no behavior change)
- [ ] `test (3.11)` and `test (3.12)` green on this PR
- [ ] After merge: tag `v2.2.1-vibe` on the squash commit → release workflow pushes `:latest` + `:v2.2.1-vibe` to Docker Hub
