### PR TITLE
fix: route live HLS resilience through ffmpeg input args

### DIFF
--- a/core/downloader.py
+++ b/core/downloader.py
@@ -254,24 +254,13 @@ class StreamDownloader:
             "quiet": True,
             "no_progress": True,
             "no_warnings": True,
-            # A live HLS playlist is always downloaded by FFmpegFD: HlsFD.can_download
-            # rejects live playlists and hls_prefer_native is deprecated, so there is
-            # no way to reach the native downloader here. Under FFmpegFD the four
-            # options below are INERT — ffmpeg does the fetching, not yt-dlp. They are
-            # kept only for the non-live/native code paths yt-dlp may take. Tuning
-            # them will not make a live recording more resilient; tune the ffmpeg
-            # input args below instead.
+            # Inert for live HLS (FFmpegFD fetches); only apply on native paths.
             "retries": DEFAULT_DOWNLOAD_RETRIES,
             "fragment_retries": DEFAULT_FRAGMENT_RETRIES,
             "socket_timeout": DEFAULT_DOWNLOAD_SOCKET_TIMEOUT,
             "continuedl": True,
-            # The real resilience knobs for live recordings: ffmpeg INPUT args.
-            # -rw_timeout is in microseconds (30s) and bounds a stalled read, which
-            # otherwise hangs the recording forever. The reconnect flags let ffmpeg
-            # resume the same session after a dropped connection, a network error or
-            # a 429/5xx, instead of exiting and forcing a whole-task retry.
-            # -reconnect_at_eof is deliberately absent: HLS segment reads hit EOF by
-            # design, so it would reconnect on every normal segment boundary.
+            # The real mechanism for live: ffmpeg input args. -reconnect_at_eof is
+            # omitted on purpose — HLS segment reads hit EOF by design.
             "external_downloader_args": {
                 "ffmpeg_i": [
                     "-rw_timeout", "30000000",

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -248,17 +248,41 @@ class StreamDownloader:
         options = {
             "format": self.DEFAULT_FORMAT,
             "outtmpl": str(output_path),
+            # Honored under FFmpegFD too: yt-dlp serializes these to ffmpeg -headers.
             "http_headers": DEFAULT_HTTP_HEADERS.copy(),
             "logger": self._yt_dlp_logger,
             "quiet": True,
             "no_progress": True,
             "no_warnings": True,
-            # Retry settings for reliability
+            # A live HLS playlist is always downloaded by FFmpegFD: HlsFD.can_download
+            # rejects live playlists and hls_prefer_native is deprecated, so there is
+            # no way to reach the native downloader here. Under FFmpegFD the four
+            # options below are INERT — ffmpeg does the fetching, not yt-dlp. They are
+            # kept only for the non-live/native code paths yt-dlp may take. Tuning
+            # them will not make a live recording more resilient; tune the ffmpeg
+            # input args below instead.
             "retries": DEFAULT_DOWNLOAD_RETRIES,
             "fragment_retries": DEFAULT_FRAGMENT_RETRIES,
             "socket_timeout": DEFAULT_DOWNLOAD_SOCKET_TIMEOUT,
-            # Continue partial downloads
             "continuedl": True,
+            # The real resilience knobs for live recordings: ffmpeg INPUT args.
+            # -rw_timeout is in microseconds (30s) and bounds a stalled read, which
+            # otherwise hangs the recording forever. The reconnect flags let ffmpeg
+            # resume the same session after a dropped connection, a network error or
+            # a 429/5xx, instead of exiting and forcing a whole-task retry.
+            # -reconnect_at_eof is deliberately absent: HLS segment reads hit EOF by
+            # design, so it would reconnect on every normal segment boundary.
+            "external_downloader_args": {
+                "ffmpeg_i": [
+                    "-rw_timeout", "30000000",
+                    "-reconnect", "1",
+                    "-reconnect_streamed", "1",
+                    "-reconnect_on_network_error", "1",
+                    "-reconnect_on_http_error", "429,5xx",
+                    "-reconnect_delay_max", "30",
+                    "-seg_max_retry", "20",
+                ],
+            },
         }
 
         if self.output_extension == ".mp4":

--- a/core/utils.py
+++ b/core/utils.py
@@ -26,7 +26,9 @@ def terminate_child_processes(timeout_seconds: float = 10.0) -> int:
     """
     total = 0
     # Two passes: a still-running download thread can spawn a fresh ffmpeg
-    # between the snapshot and the kill (yt-dlp retry), so re-scan once.
+    # between the snapshot and the kill (the downloader's full-task retry starts
+    # a new FFmpegFD process; yt-dlp's own retries do not apply here), so
+    # re-scan once.
     for pass_timeout in (timeout_seconds, 2.0):
         try:
             children = psutil.Process().children(recursive=True)

--- a/core/utils.py
+++ b/core/utils.py
@@ -25,10 +25,7 @@ def terminate_child_processes(timeout_seconds: float = 10.0) -> int:
     still alive. Returns the number of children that had to be dealt with.
     """
     total = 0
-    # Two passes: a still-running download thread can spawn a fresh ffmpeg
-    # between the snapshot and the kill (the downloader's full-task retry starts
-    # a new FFmpegFD process; yt-dlp's own retries do not apply here), so
-    # re-scan once.
+    # A running download may spawn a child between passes, so re-scan once.
     for pass_timeout in (timeout_seconds, 2.0):
         try:
             children = psutil.Process().children(recursive=True)

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -9,7 +9,6 @@ import pytest
 import yt_dlp
 from freezegun import freeze_time
 
-from core.constants import DEFAULT_HTTP_HEADERS
 from core.downloader import StreamDownloader
 from models.download import RawDownloadCompleted, RawDownloadFailed
 
@@ -251,10 +250,10 @@ class TestBuildYdlOptions:
 
         Live HLS is always downloaded by FFmpegFD, so these input args are the
         only resilience settings that actually reach the network layer.
+        -reconnect_at_eof stays out: HLS segment reads hit EOF by design.
         """
         downloader = StreamDownloader("TestCreator")
-        path = tmp_path / "test.ts"
-        options = downloader._build_ydl_options(path)
+        options = downloader._build_ydl_options(tmp_path / "test.ts")
         assert options["external_downloader_args"] == {
             "ffmpeg_i": [
                 "-rw_timeout", "30000000",
@@ -266,45 +265,24 @@ class TestBuildYdlOptions:
                 "-seg_max_retry", "20",
             ],
         }
-
-    def test_options_omit_reconnect_at_eof(self, tmp_path):
-        """Test ffmpeg input args never enable reconnect_at_eof.
-
-        HLS segment reads hit EOF by design, so it would reconnect on every
-        normal segment boundary.
-        """
-        downloader = StreamDownloader("TestCreator")
-        options = downloader._build_ydl_options(tmp_path / "test.ts")
         assert "-reconnect_at_eof" not in options["external_downloader_args"]["ffmpeg_i"]
-
-    def test_options_preserve_http_headers(self, tmp_path):
-        """Test ydl options keeps RPlay headers, which FFmpegFD forwards to ffmpeg."""
-        downloader = StreamDownloader("TestCreator")
-        options = downloader._build_ydl_options(tmp_path / "test.ts")
-        assert options["http_headers"] == DEFAULT_HTTP_HEADERS
-
-    def test_options_http_headers_are_isolated_per_call(self, tmp_path):
-        """Test mutating built headers cannot leak into the shared defaults."""
-        downloader = StreamDownloader("TestCreator")
-        options = downloader._build_ydl_options(tmp_path / "test.ts")
-        options["http_headers"]["Referer"] = "https://example.invalid"
-        assert DEFAULT_HTTP_HEADERS["Referer"] != "https://example.invalid"
-        assert downloader._build_ydl_options(tmp_path / "test.ts")["http_headers"] == (
-            DEFAULT_HTTP_HEADERS
-        )
 
 
 class TestLiveHlsDownloaderSelection:
     """Premise check for the options above: live HLS always uses FFmpegFD."""
 
-    def test_live_m3u8_selects_ffmpeg_downloader(self):
-        """Test yt-dlp picks FFmpegFD for a live m3u8, making ffmpeg args the knob."""
+    def test_live_hls_forces_ffmpeg_over_native_downloader(self):
+        """Test is_live flips m3u8_native from the native HlsFD to FFmpegFD.
+
+        m3u8_native is the protocol that would otherwise pick HlsFD, so this
+        pins the live-specific branch our ffmpeg input args depend on.
+        """
         from yt_dlp.downloader import get_suitable_downloader
         from yt_dlp.downloader.external import FFmpegFD
 
         info_dict = {
             "url": "https://example.invalid/live.m3u8",
-            "protocol": "m3u8",
+            "protocol": "m3u8_native",
             "is_live": True,
         }
 

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -9,6 +9,7 @@ import pytest
 import yt_dlp
 from freezegun import freeze_time
 
+from core.constants import DEFAULT_HTTP_HEADERS
 from core.downloader import StreamDownloader
 from models.download import RawDownloadCompleted, RawDownloadFailed
 
@@ -232,7 +233,11 @@ class TestBuildYdlOptions:
         assert options["no_warnings"] is True
 
     def test_options_retry_settings(self, tmp_path):
-        """Test ydl options has retry settings and a short socket timeout."""
+        """Test ydl options keeps native-downloader retry settings.
+
+        These are inert for live HLS (FFmpegFD does the fetching); they only
+        matter on yt-dlp's native code paths.
+        """
         downloader = StreamDownloader("TestCreator")
         path = tmp_path / "test.mp4"
         options = downloader._build_ydl_options(path)
@@ -240,6 +245,70 @@ class TestBuildYdlOptions:
         assert "fragment_retries" in options
         assert options["continuedl"] is True
         assert options["socket_timeout"] == 10
+
+    def test_options_ffmpeg_input_args_for_live_resilience(self, tmp_path):
+        """Test ydl options passes reconnect/timeout args to the ffmpeg input.
+
+        Live HLS is always downloaded by FFmpegFD, so these input args are the
+        only resilience settings that actually reach the network layer.
+        """
+        downloader = StreamDownloader("TestCreator")
+        path = tmp_path / "test.ts"
+        options = downloader._build_ydl_options(path)
+        assert options["external_downloader_args"] == {
+            "ffmpeg_i": [
+                "-rw_timeout", "30000000",
+                "-reconnect", "1",
+                "-reconnect_streamed", "1",
+                "-reconnect_on_network_error", "1",
+                "-reconnect_on_http_error", "429,5xx",
+                "-reconnect_delay_max", "30",
+                "-seg_max_retry", "20",
+            ],
+        }
+
+    def test_options_omit_reconnect_at_eof(self, tmp_path):
+        """Test ffmpeg input args never enable reconnect_at_eof.
+
+        HLS segment reads hit EOF by design, so it would reconnect on every
+        normal segment boundary.
+        """
+        downloader = StreamDownloader("TestCreator")
+        options = downloader._build_ydl_options(tmp_path / "test.ts")
+        assert "-reconnect_at_eof" not in options["external_downloader_args"]["ffmpeg_i"]
+
+    def test_options_preserve_http_headers(self, tmp_path):
+        """Test ydl options keeps RPlay headers, which FFmpegFD forwards to ffmpeg."""
+        downloader = StreamDownloader("TestCreator")
+        options = downloader._build_ydl_options(tmp_path / "test.ts")
+        assert options["http_headers"] == DEFAULT_HTTP_HEADERS
+
+    def test_options_http_headers_are_isolated_per_call(self, tmp_path):
+        """Test mutating built headers cannot leak into the shared defaults."""
+        downloader = StreamDownloader("TestCreator")
+        options = downloader._build_ydl_options(tmp_path / "test.ts")
+        options["http_headers"]["Referer"] = "https://example.invalid"
+        assert DEFAULT_HTTP_HEADERS["Referer"] != "https://example.invalid"
+        assert downloader._build_ydl_options(tmp_path / "test.ts")["http_headers"] == (
+            DEFAULT_HTTP_HEADERS
+        )
+
+
+class TestLiveHlsDownloaderSelection:
+    """Premise check for the options above: live HLS always uses FFmpegFD."""
+
+    def test_live_m3u8_selects_ffmpeg_downloader(self):
+        """Test yt-dlp picks FFmpegFD for a live m3u8, making ffmpeg args the knob."""
+        from yt_dlp.downloader import get_suitable_downloader
+        from yt_dlp.downloader.external import FFmpegFD
+
+        info_dict = {
+            "url": "https://example.invalid/live.m3u8",
+            "protocol": "m3u8",
+            "is_live": True,
+        }
+
+        assert get_suitable_downloader(info_dict, params={}) is FFmpegFD
 
 
 class TestDownloadMethod:


### PR DESCRIPTION
## Problem

Live RPlay HLS recordings always go through yt-dlp's FFmpegFD (external ffmpeg). Under FFmpegFD the configured `retries`, `fragment_retries`, `socket_timeout` and `continuedl` options are silently inert (they only apply to native downloaders), so a mid-stream network blip kills the ffmpeg process outright and the recorder's only resilience was the coarse whole-task retry.

## Change

- `_build_ydl_options` now passes ffmpeg **input** args via `external_downloader_args["ffmpeg_i"]`: `-rw_timeout 30000000`, `-reconnect 1`, `-reconnect_streamed 1`, `-reconnect_on_network_error 1`, `-reconnect_on_http_error 429,5xx`, `-reconnect_delay_max 30`, `-seg_max_retry 20`. `-reconnect_at_eof` is deliberately omitted (HLS segments hit EOF by design).
- Inert native-only options kept for non-live paths but documented as inert for live HLS.
- Stale comment in `core/utils.py` corrected (respawn comes from the task retry, not a yt-dlp retry).

## Acceptance

- Built ydl options contain exactly the ffmpeg_i args above and never `-reconnect_at_eof`.
- Premise pinned by test: `protocol=m3u8_native, is_live=True` selects `FFmpegFD` (flips to `HlsFD` without `is_live`, so a yt-dlp behavior change will fail the test).
- No output container/extension/naming change; `http_headers` and outer task retry unchanged.

## Verification

```
poetry run pytest tests/test_downloader.py -v  -> 66 passed
poetry run pytest (full, 3x)                   -> 311 passed / 311 passed / 311 passed
```
