### PR TITLE
fix: wrap unexpected _get_stream_key errors as RPlayAPIError

### DIFF
--- a/core/rplay.py
+++ b/core/rplay.py
@@ -308,6 +308,10 @@ class RPlayAPI:
                 )
             raise RPlayAPIError(f"Failed to get stream key: {exc}")
 
+        except Exception as exc:
+            self.logger.exception(f"Unexpected error while getting stream key: {exc}")
+            raise RPlayAPIError(f"Unexpected error: {exc}")
+
     def close(self) -> None:
         """Close the API client session."""
         self._session.close()

--- a/core/rplay.py
+++ b/core/rplay.py
@@ -309,8 +309,10 @@ class RPlayAPI:
             raise RPlayAPIError(f"Failed to get stream key: {exc}")
 
         except Exception as exc:
-            self.logger.exception(f"Unexpected error while getting stream key: {exc}")
-            raise RPlayAPIError(f"Unexpected error: {exc}")
+            # ponytail: traceback and message suppressed - may embed the Authorization header
+            msg = f"Unexpected error while getting stream key: {type(exc).__name__}"
+            self.logger.error(msg)
+            raise RPlayAPIError(msg) from None
 
     def close(self) -> None:
         """Close the API client session."""

--- a/tests/test_rplay.py
+++ b/tests/test_rplay.py
@@ -214,15 +214,21 @@ class TestGetStreamKey:
             with pytest.raises(RPlayAPIError, match="Unexpected error"):
                 api._get_stream_key()
 
-    def test_unexpected_exception_raises_api_error(self):
-        """Test arbitrary errors inside the request loop raise RPlayAPIError."""
+    def test_unexpected_exception_does_not_leak_secret(self, caplog):
+        """Exception messages may embed Authorization; must not reach logs or RPlayAPIError."""
         api = RPlayAPI(auth_token="test", user_oid="test")
+        secret = "Bearer sekrit-token"
 
         with patch.object(
-            api._session, "get", side_effect=RuntimeError("boom")
+            api._session, "get", side_effect=RuntimeError(secret)
         ):
-            with pytest.raises(RPlayAPIError, match="Unexpected error"):
-                api._get_stream_key()
+            with caplog.at_level("ERROR"):
+                with pytest.raises(RPlayAPIError) as exc_info:
+                    api._get_stream_key()
+
+        assert secret not in str(exc_info.value)
+        assert all(secret not in record.getMessage() for record in caplog.records)
+        assert "RuntimeError" in str(exc_info.value)
 
 
 class TestCreatorStreamState:

--- a/tests/test_rplay.py
+++ b/tests/test_rplay.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
-from requests.exceptions import ConnectionError, HTTPError, Timeout
+from requests.exceptions import ConnectionError, HTTPError, JSONDecodeError, Timeout
 
 from core.rplay import (
     RPlayAPI,
@@ -198,6 +198,30 @@ class TestGetStreamKey:
 
         with patch.object(api._session, "get", side_effect=Timeout()):
             with pytest.raises(RPlayConnectionError, match="timed out"):
+                api._get_stream_key()
+
+    def test_json_decode_error_raises_api_error(self):
+        """Test malformed JSON body raises RPlayAPIError, not the raw decode error."""
+        api = RPlayAPI(auth_token="test", user_oid="test")
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.side_effect = JSONDecodeError(
+            "Expecting value", "doc", 0
+        )
+
+        with patch.object(api._session, "get", return_value=mock_response):
+            with pytest.raises(RPlayAPIError, match="Unexpected error"):
+                api._get_stream_key()
+
+    def test_unexpected_exception_raises_api_error(self):
+        """Test arbitrary errors inside the request loop raise RPlayAPIError."""
+        api = RPlayAPI(auth_token="test", user_oid="test")
+
+        with patch.object(
+            api._session, "get", side_effect=RuntimeError("boom")
+        ):
+            with pytest.raises(RPlayAPIError, match="Unexpected error"):
                 api._get_stream_key()
 
 


### PR DESCRIPTION
## Problem

`_get_stream_key` lacked the generic catch-all its sibling `get_livestream_status` has. A malformed JSON body raised `requests.exceptions.JSONDecodeError` past the documented `RPlayAPIError` contract, landing in the generic error branch with a full traceback. Worse, interpolating the raw exception could leak the `Authorization` header into persistent logs (e.g. `InvalidHeader` embeds the full header value).

## Change

Final `except Exception` in `_get_stream_key`: logs and raises a fixed message carrying only the exception type name, `raise ... from None` so no downstream traceback can reproduce the original message.

## Acceptance

- Malformed JSON / arbitrary unexpected errors surface as `RPlayAPIError`, never the raw exception.
- A secret embedded in an exception message reaches neither `str(RPlayAPIError)` nor any log record (pinned by test with a sentinel token).
- Existing 401/403 auth behavior unchanged; typed except branches keep their order.

## Verification

```
poetry run pytest tests/test_rplay.py -v  -> 22 passed
poetry run pytest (full, 3x)              -> 311 passed / 311 passed / 311 passed
```
