### PR TITLE
fix: finalize in-progress recordings on graceful shutdown

### DIFF
--- a/core/download_merge_executor.py
+++ b/core/download_merge_executor.py
@@ -1,8 +1,9 @@
 ﻿"""Dedicated executor for asynchronous merge jobs."""
 
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, wait as wait_for_futures
 from threading import Lock
-from typing import Callable
+from time import monotonic
+from typing import Callable, Optional, Set
 
 
 class DownloadMergeExecutor:
@@ -12,13 +13,51 @@ class DownloadMergeExecutor:
         self._executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="merge")
         self._lock = Lock()
         self._shutdown = False
+        self._pending: Set[Future] = set()
 
     def submit_merge(self, task: Callable[[], object]) -> Future:
         """Submit a merge task for asynchronous execution."""
         with self._lock:
             if self._shutdown:
                 raise RuntimeError("merge executor is shut down")
-            return self._executor.submit(task)
+            future = self._executor.submit(task)
+            self._pending.add(future)
+
+        # Outside the lock on purpose: an already-finished task runs this
+        # callback inline, and self._lock is not reentrant.
+        future.add_done_callback(self._forget_pending)
+        return future
+
+    def _forget_pending(self, future: Future) -> None:
+        """Drop a finished merge from the pending set."""
+        with self._lock:
+            self._pending.discard(future)
+
+    def drain(self, timeout: Optional[float] = None) -> bool:
+        """
+        Wait for submitted merges to finish while staying open for new work.
+
+        Shutdown needs this: closing the executor to flush it would reject the
+        merges that recordings stopped by that same shutdown are about to
+        submit. Re-checks after each wait because a late raw completion can
+        still queue a merge while this drains.
+
+        Returns:
+            True when nothing is pending anymore, False if timeout ran out.
+        """
+        deadline = None if timeout is None else monotonic() + timeout
+        while True:
+            with self._lock:
+                pending = set(self._pending)
+            if not pending:
+                return True
+            if deadline is None:
+                wait_for_futures(pending)
+                continue
+            remaining = deadline - monotonic()
+            if remaining <= 0:
+                return False
+            wait_for_futures(pending, timeout=remaining)
 
     def shutdown(self, wait: bool = False) -> None:
         """Stop accepting new work and shut down the executor."""

--- a/core/download_merge_executor.py
+++ b/core/download_merge_executor.py
@@ -1,9 +1,8 @@
 ﻿"""Dedicated executor for asynchronous merge jobs."""
 
-from concurrent.futures import Future, ThreadPoolExecutor, wait as wait_for_futures
+from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from threading import Lock
-from time import monotonic
-from typing import Callable, Optional, Set
+from typing import Callable, Optional
 
 
 class DownloadMergeExecutor:
@@ -12,57 +11,46 @@ class DownloadMergeExecutor:
     def __init__(self, max_workers: int = 1) -> None:
         self._executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="merge")
         self._lock = Lock()
-        self._shutdown = False
-        self._pending: Set[Future] = set()
+        self._closed = False
 
     def submit_merge(self, task: Callable[[], object]) -> Future:
-        """Submit a merge task for asynchronous execution."""
+        """
+        Submit a merge task for asynchronous execution.
+
+        Raises:
+            RuntimeError: If acceptance was already closed by drain/shutdown.
+                Callers must treat this as "too late to merge", not as a crash.
+        """
         with self._lock:
-            if self._shutdown:
+            if self._closed:
                 raise RuntimeError("merge executor is shut down")
-            future = self._executor.submit(task)
-            self._pending.add(future)
-
-        # Outside the lock on purpose: an already-finished task runs this
-        # callback inline, and self._lock is not reentrant.
-        future.add_done_callback(self._forget_pending)
-        return future
-
-    def _forget_pending(self, future: Future) -> None:
-        """Drop a finished merge from the pending set."""
-        with self._lock:
-            self._pending.discard(future)
+            return self._executor.submit(task)
 
     def drain(self, timeout: Optional[float] = None) -> bool:
         """
-        Wait for submitted merges to finish while staying open for new work.
+        Close acceptance, then wait for already-queued merges to finish.
 
-        Shutdown needs this: closing the executor to flush it would reject the
-        merges that recordings stopped by that same shutdown are about to
-        submit. Re-checks after each wait because a late raw completion can
-        still queue a merge while this drains.
+        The pool is FIFO with a single worker, so a no-op enqueued under the
+        same lock that closes acceptance is necessarily the last task in the
+        queue: once it runs, every merge submitted before it has finished.
+        That barrier is what makes the wait bounded — the previous pending-set
+        re-check could be extended indefinitely by late submissions.
 
         Returns:
-            True when nothing is pending anymore, False if timeout ran out.
+            True when queued merges finished, False if the timeout ran out.
         """
-        deadline = None if timeout is None else monotonic() + timeout
-        while True:
-            with self._lock:
-                pending = set(self._pending)
-            if not pending:
-                return True
-            if deadline is None:
-                wait_for_futures(pending)
-                continue
-            remaining = deadline - monotonic()
-            if remaining <= 0:
-                return False
-            wait_for_futures(pending, timeout=remaining)
+        with self._lock:
+            self._closed = True
+            barrier = self._executor.submit(lambda: None)
 
-    def shutdown(self, wait: bool = False) -> None:
+        try:
+            barrier.result(timeout=timeout)
+            return True
+        except FutureTimeoutError:
+            return False
+
+    def shutdown(self, wait: bool = False, cancel_futures: bool = False) -> None:
         """Stop accepting new work and shut down the executor."""
         with self._lock:
-            if self._shutdown:
-                return
-            self._shutdown = True
-        self._executor.shutdown(wait=wait)
+            self._closed = True
+        self._executor.shutdown(wait=wait, cancel_futures=cancel_futures)

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -229,11 +229,6 @@ class StreamDownloader:
         """
         self._stop_requested.set()
 
-    @property
-    def stop_requested(self) -> bool:
-        """Check whether shutdown asked this recording to stop."""
-        return self._stop_requested.is_set()
-
     def _build_output_path(self, safe_title: str) -> Path:
         """
         Construct the output file path.
@@ -407,7 +402,24 @@ class StreamDownloader:
                 # this "failure" is expected. Classifying it as blocked or
                 # retryable would drop the session and orphan whatever raw
                 # output already reached disk.
-                self._notify_stopped_download(output_path, error_message)
+                session_prefix = (self.filename_prefix or "").rstrip("_")
+                if output_path.exists() or self._has_sibling_fragment_outputs(output_path):
+                    self.log.info(
+                        f"⏹️ Recording stopped for shutdown (session {session_prefix}); "
+                        f"handing raw output to merge: {output_path.name}",
+                    )
+                    self._notify_download_complete(output_path)
+                    return
+
+                # No finished raw file: yt-dlp leaves a truncated .part behind,
+                # which is the startup orphan scan's job to report, not the
+                # merge step's.
+                self.log.warning(
+                    f"⏹️ Recording stopped for shutdown (session {session_prefix}) with no "
+                    f"finished raw output: {error_message}; "
+                    f"{self._build_output_state_details(output_path)}",
+                )
+                self._notify_download_failure(error_message)
                 return
 
             # ponytail: .error, not .exception — this handler mostly sees classified
@@ -551,26 +563,6 @@ class StreamDownloader:
                 f"✅ Download succeeded on retry attempt "
                 f"{attempt_number}/{self.DOWNLOAD_TASK_RETRY_ATTEMPTS}",
             )
-
-    def _notify_stopped_download(self, output_path: Path, error_message: str) -> None:
-        """Report a shutdown-stopped recording, preferring completion over failure."""
-        session_prefix = (self.filename_prefix or "").rstrip("_")
-        if output_path.exists() or self._has_sibling_fragment_outputs(output_path):
-            self.log.info(
-                f"⏹️ Recording stopped for shutdown (session {session_prefix}); "
-                f"handing raw output to merge: {output_path.name}",
-            )
-            self._notify_download_complete(output_path)
-            return
-
-        # No finished raw file: yt-dlp leaves a truncated .part behind, which is
-        # the startup orphan scan's job to report, not the merge step's.
-        self.log.warning(
-            f"⏹️ Recording stopped for shutdown (session {session_prefix}) with no "
-            f"finished raw output: {error_message}; "
-            f"{self._build_output_state_details(output_path)}",
-        )
-        self._notify_download_failure(error_message)
 
     def _notify_download_error(self, error_message: str) -> None:
         """

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -140,6 +140,7 @@ class StreamDownloader:
         self.logger = setup_logger("Downloader")
         self.log = bind(self.logger, creator_name)
         self.download_thread: Optional[threading.Thread] = None
+        self._stop_requested = threading.Event()
         self._current_output_path: Optional[Path] = None
         self._download_start_time: Optional[datetime] = None
         self._on_download_error = on_download_error
@@ -216,6 +217,22 @@ class StreamDownloader:
             True if download is in progress, False otherwise
         """
         return self.download_thread is not None and self.download_thread.is_alive()
+
+    def request_stop(self) -> None:
+        """
+        Ask this recording to wind down instead of retrying.
+
+        Shutdown reaps the recording ffmpeg out from under yt-dlp, which looks
+        exactly like a transient failure. Without this flag the task would burn
+        its whole retry budget re-running a download nobody is waiting for, and
+        its terminal event would arrive after the merge executor had closed.
+        """
+        self._stop_requested.set()
+
+    @property
+    def stop_requested(self) -> bool:
+        """Check whether shutdown asked this recording to stop."""
+        return self._stop_requested.is_set()
 
     def _build_output_path(self, safe_title: str) -> Path:
         """
@@ -385,6 +402,14 @@ class StreamDownloader:
 
         except yt_dlp.utils.DownloadError as e:
             error_message = str(e)
+            if self._stop_requested.is_set():
+                # Shutdown pulled the recording ffmpeg out from under yt-dlp, so
+                # this "failure" is expected. Classifying it as blocked or
+                # retryable would drop the session and orphan whatever raw
+                # output already reached disk.
+                self._notify_stopped_download(output_path, error_message)
+                return
+
             # ponytail: .error, not .exception — this handler mostly sees classified
             # 401/403/404 access failures where the yt-dlp message says it all; the
             # truly-unexpected path below keeps the traceback.
@@ -447,10 +472,16 @@ class StreamDownloader:
             reraise=True,
             stop=stop_after_attempt(max(1, self.DOWNLOAD_TASK_RETRY_ATTEMPTS)),
             wait=wait_exponential(multiplier=self.DOWNLOAD_TASK_RETRY_BACKOFF_FACTOR),
-            retry=retry_if_exception_type(_RetryableDownloadTaskError),
+            retry=self._should_retry_download,
             sleep=time.sleep,
             before_sleep=self._log_before_retry,
         )
+
+    def _should_retry_download(self, retry_state) -> bool:
+        """Retry transient yt-dlp failures unless shutdown asked this task to stop."""
+        if self._stop_requested.is_set():
+            return False
+        return retry_if_exception_type(_RetryableDownloadTaskError)(retry_state)
 
     def _log_before_retry(self, retry_state) -> None:
         """Log one retry attempt before sleeping."""
@@ -481,6 +512,12 @@ class StreamDownloader:
             for attempt in self._build_download_retrying():
                 with attempt:
                     attempt_number = attempt.retry_state.attempt_number
+                    if self._stop_requested.is_set():
+                        # Set while the previous backoff was sleeping; a fresh
+                        # yt-dlp run here would only be killed again.
+                        raise yt_dlp.utils.DownloadError(
+                            "recording stopped for shutdown"
+                        )
                     # The first attempt is already implied by "Recording started".
                     # Only a retry is worth a line of its own.
                     if attempt_number > 1:
@@ -514,6 +551,26 @@ class StreamDownloader:
                 f"✅ Download succeeded on retry attempt "
                 f"{attempt_number}/{self.DOWNLOAD_TASK_RETRY_ATTEMPTS}",
             )
+
+    def _notify_stopped_download(self, output_path: Path, error_message: str) -> None:
+        """Report a shutdown-stopped recording, preferring completion over failure."""
+        session_prefix = (self.filename_prefix or "").rstrip("_")
+        if output_path.exists() or self._has_sibling_fragment_outputs(output_path):
+            self.log.info(
+                f"⏹️ Recording stopped for shutdown (session {session_prefix}); "
+                f"handing raw output to merge: {output_path.name}",
+            )
+            self._notify_download_complete(output_path)
+            return
+
+        # No finished raw file: yt-dlp leaves a truncated .part behind, which is
+        # the startup orphan scan's job to report, not the merge step's.
+        self.log.warning(
+            f"⏹️ Recording stopped for shutdown (session {session_prefix}) with no "
+            f"finished raw output: {error_message}; "
+            f"{self._build_output_state_details(output_path)}",
+        )
+        self._notify_download_failure(error_message)
 
     def _notify_download_error(self, error_message: str) -> None:
         """

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -88,11 +88,15 @@ class LiveStreamMonitor:
 
     DEFAULT_MERGE_TIMEOUT_SECONDS = 7200
     POLL_WAIT_TIMEOUT_SECONDS = 30.0
-    # Shutdown budgets. Every wait below is bounded so a wedged recording or
-    # merge can never turn a SIGTERM into a hang.
-    SHUTDOWN_EVENT_DRAIN_TIMEOUT_SECONDS = 30.0
-    SHUTDOWN_RECORDING_JOIN_TIMEOUT_SECONDS = 30.0
-    SHUTDOWN_MERGE_DRAIN_TIMEOUT_SECONDS = 600.0
+    # One aggregate budget for the whole shutdown, not a per-step timeout that
+    # the next step can extend: every wait below draws from the same deadline,
+    # so SIGTERM to returned is bounded end to end. docker-compose.yaml's
+    # stop_grace_period is set from this value plus margin.
+    # ponytail: one budget for all phases; split it per phase only if a slow
+    # merge is ever seen starving the recording joins.
+    SHUTDOWN_BUDGET_SECONDS = 600.0
+    # Cap for the fast phases so they cannot eat the merge's share of the budget.
+    SHUTDOWN_PHASE_TIMEOUT_SECONDS = 30.0
     TERMINAL_SESSION_STATES = {
         SessionState.BLOCKED,
         SessionState.DONE,
@@ -136,7 +140,7 @@ class LiveStreamMonitor:
         # Pids of merge ffmpeg children this monitor owns. Reaping recordings
         # skips these, otherwise shutdown would kill a merge in progress.
         self._merge_process_pids: Set[int] = set()
-        self._merge_submission_closed = False
+        self._shutdown_deadline: Optional[float] = None
         self._control_thread = Thread(
             target=self._event_loop,
             name="monitor-control",
@@ -411,10 +415,23 @@ class LiveStreamMonitor:
 
         # Registered before the thread starts: shutdown snapshots this map, and
         # a recording it cannot see is a recording it cannot stop or merge.
-        # The control loop is the only writer here and it is the same thread
-        # that runs the in-flight poll shutdown waits for.
+        # Rechecked here rather than only at poll entry: get_stream_url blocks on
+        # the network, and shutdown can take its recording snapshot while this
+        # poll sits in that call. Starting afterwards would create a recording
+        # nobody stops and a merge nobody accepts.
         with self._state_lock:
-            self._active_downloaders[session.session_key] = active_downloader
+            shutdown_started = self._shutdown_requested
+            if not shutdown_started:
+                self._active_downloaders[session.session_key] = active_downloader
+
+        if shutdown_started:
+            self._remove_session(session.session_key)
+            self.logger.warning(
+                f"Dropped pending session for {session.creator_name} "
+                f"({session.session_key}): shutdown started while this poll was "
+                "fetching the stream URL"
+            )
+            return
 
         # The downloader logs "Recording started" itself; repeating it here added
         # a line that carried no information the previous one did not already have.
@@ -694,6 +711,21 @@ class LiveStreamMonitor:
 
     def _handle_monitor_event(self, event: SessionEvent) -> None:
         """Apply one monitor event on the control loop."""
+        if isinstance(
+            event,
+            (
+                RawDownloadCompleted,
+                RawDownloadBlocked,
+                RawDownloadAuthFailed,
+                RawDownloadFailed,
+            ),
+        ):
+            # One pop for every raw terminal outcome: whichever of the four
+            # arrived, that session's downloader is done and shutdown must not
+            # keep it in the set of recordings it waits on.
+            with self._state_lock:
+                self._active_downloaders.pop(event.session_key, None)
+
         if isinstance(event, RawDownloadCompleted):
             self._handle_raw_download_completed(event)
             return
@@ -749,7 +781,6 @@ class LiveStreamMonitor:
     def _handle_raw_download_completed(self, event: RawDownloadCompleted) -> None:
         """Queue merge work as soon as raw download completes."""
         with self._state_lock:
-            self._active_downloaders.pop(event.session_key, None)
             session = self.sessions.get(event.session_key)
             if session is None:
                 return
@@ -767,19 +798,28 @@ class LiveStreamMonitor:
                 session_prefix=session.session_prefix,
             )
 
-            # Submitted under the same lock that shutdown uses to close
-            # submission, so a merge can never be handed to an executor that is
-            # already draining towards closure.
-            if self._merge_submission_closed:
+            try:
+                self.merge_executor.submit_merge(lambda: self._run_merge_job(merge_job))
+            except RuntimeError:
+                # A recording that outlived shutdown's join budget reports here
+                # after the executor closed. Ignoring it idempotently is the
+                # contract: re-raising would crash the control loop, and
+                # re-queueing would wait on an executor that never reopens.
+                # ponytail: late (>join budget) completions stay orphaned;
+                # startup recovery lane will merge them.
                 session.state = SessionState.MERGE_FAILED
                 session.last_error = "merge submission closed by shutdown"
-                self.logger.warning(
-                    f"⚠️ Raw download for {session.creator_name} finished after shutdown "
-                    f"closed merge submission. Raw .ts files left in: {session.output_dir}"
-                )
-                return
+                late_creator_name = session.creator_name
+                late_output_dir = session.output_dir
+            else:
+                late_output_dir = None
 
-            self.merge_executor.submit_merge(lambda: self._run_merge_job(merge_job))
+        if late_output_dir is not None:
+            self.logger.warning(
+                f"⚠️ Raw download for {late_creator_name} finished after shutdown "
+                f"closed merge submission. Raw .ts files left in: {late_output_dir}"
+            )
+            return
 
         self.logger.info(
             f"🧩 Queued merge for {merge_job.creator_name}: "
@@ -789,7 +829,6 @@ class LiveStreamMonitor:
     def _handle_raw_download_auth_failed(self, event: RawDownloadAuthFailed) -> None:
         """Clear auth-failed raw sessions and surface credential guidance."""
         with self._state_lock:
-            self._active_downloaders.pop(event.session_key, None)
             session = self.sessions.pop(event.session_key, None)
             if session is not None:
                 active_session_key = self._active_raw_session_by_creator.get(
@@ -810,7 +849,6 @@ class LiveStreamMonitor:
     def _handle_raw_download_failed(self, event: RawDownloadFailed) -> None:
         """Clear failed raw sessions so the next poll can retry them."""
         with self._state_lock:
-            self._active_downloaders.pop(event.session_key, None)
             session = self.sessions.pop(event.session_key, None)
             if session is not None:
                 active_session_key = self._active_raw_session_by_creator.get(
@@ -830,7 +868,6 @@ class LiveStreamMonitor:
     def _handle_raw_download_blocked(self, event: RawDownloadBlocked) -> None:
         """Apply blocked-session state when downloader reports access failure."""
         with self._state_lock:
-            self._active_downloaders.pop(event.session_key, None)
             session = self.sessions.get(event.session_key)
             if session is None:
                 return
@@ -1028,24 +1065,38 @@ class LiveStreamMonitor:
         escaped_path = ts_file.resolve().as_posix().replace("'", r"'\''")
         return f"file '{escaped_path}'"
 
+    def _shutdown_time_left(self, cap: Optional[float] = None) -> float:
+        """Return the seconds left in the aggregate budget, capped for one phase."""
+        if self._shutdown_deadline is None:
+            return self.SHUTDOWN_BUDGET_SECONDS if cap is None else cap
+        left = max(0.0, self._shutdown_deadline - monotonic())
+        return left if cap is None else min(cap, left)
+
     def shutdown(self) -> None:
         """
         Stop monitoring, then hand every stopped recording to the merge step.
 
         Order is the whole point. Recordings are stopped and joined first so
         their terminal events can queue merge work while the executor is still
-        open; only then is the executor drained and closed. Closing it earlier
-        makes submit_merge raise for whatever was still recording, which
+        open; only then is the executor closed and its queue flushed. Closing it
+        earlier makes submit_merge raise for whatever was still recording, which
         orphans that session's raw .ts files.
+
+        Bounded end to end: every wait draws from one deadline, and a merge that
+        outlives it is abandoned rather than allowed to hold up the process.
         """
         with self._state_lock:
             if self._shutdown_requested:
                 return
             self._shutdown_requested = True
 
+        self._shutdown_deadline = monotonic() + self.SHUTDOWN_BUDGET_SECONDS
+
         # 1. No new polls. Draining also lets an in-flight poll finish, so every
         #    recording it started is registered before step 2 snapshots them.
-        self._drain_monitor_events(self.SHUTDOWN_EVENT_DRAIN_TIMEOUT_SECONDS)
+        self._drain_monitor_events(
+            self._shutdown_time_left(self.SHUTDOWN_PHASE_TIMEOUT_SECONDS)
+        )
 
         # 2. Stop recordings: kill their ffmpeg, spare any merge ffmpeg, and
         #    wait for the downloader threads to emit their terminal events.
@@ -1053,27 +1104,40 @@ class LiveStreamMonitor:
 
         # 3. Apply those events. This is where a stopped recording's merge is
         #    submitted, and it must happen while the executor still accepts work.
-        self._drain_monitor_events(self.SHUTDOWN_EVENT_DRAIN_TIMEOUT_SECONDS)
+        self._drain_monitor_events(
+            self._shutdown_time_left(self.SHUTDOWN_PHASE_TIMEOUT_SECONDS)
+        )
 
-        # 4. Let queued merges finish before closing anything.
-        if not self.merge_executor.drain(
-            timeout=self.SHUTDOWN_MERGE_DRAIN_TIMEOUT_SECONDS
-        ):
-            self.logger.warning(
-                "Merge work did not drain before shutdown timeout; closing executor"
-            )
+        # 4. Close acceptance and flush the merge queue with whatever budget is
+        #    left. Anything arriving after this is late by definition and is
+        #    refused in _handle_raw_download_completed.
+        self._close_merge_executor()
 
-        # 5. Refuse late submissions, then close. wait=True still lets a merge
-        #    that is already running finish rather than dying with the process.
-        with self._state_lock:
-            self._merge_submission_closed = True
-        self.merge_executor.shutdown(wait=True)
-
-        # 6. Merge result events, then the control loop and the API client.
-        self._drain_monitor_events(self.SHUTDOWN_EVENT_DRAIN_TIMEOUT_SECONDS)
+        # 5. Merge result events, then the control loop and the API client.
+        self._drain_monitor_events(
+            self._shutdown_time_left(self.SHUTDOWN_PHASE_TIMEOUT_SECONDS)
+        )
         self._event_queue.put(_ShutdownRequested())
-        self._control_thread.join(timeout=self.SHUTDOWN_EVENT_DRAIN_TIMEOUT_SECONDS)
+        self._control_thread.join(
+            timeout=self._shutdown_time_left(self.SHUTDOWN_PHASE_TIMEOUT_SECONDS)
+        )
         self.api.close()
+
+    def _close_merge_executor(self) -> None:
+        """Flush queued merges within the remaining budget, then close the pool."""
+        if self.merge_executor.drain(timeout=self._shutdown_time_left()):
+            # Nothing is queued behind the barrier, so this cannot block.
+            self.merge_executor.shutdown(wait=True)
+            return
+
+        # Waiting on wait=True here is what used to make the budget a lie: a
+        # wedged ffmpeg merge would hold shutdown open with no deadline at all.
+        self.logger.warning(
+            f"⚠️ A merge was still running after the {self.SHUTDOWN_BUDGET_SECONDS:.0f}s "
+            "shutdown budget; abandoning it instead of blocking exit. Its raw .ts "
+            "files stay on disk."
+        )
+        self.merge_executor.shutdown(wait=False, cancel_futures=True)
 
     def _stop_active_recordings(self) -> None:
         """Stop recording downloads and wait for their terminal events."""
@@ -1084,11 +1148,12 @@ class LiveStreamMonitor:
 
             # Reaped under the state lock: _run_merge_subprocess takes the same
             # lock around its Popen, so no merge child can appear unprotected
-            # between the pid snapshot and the sweep.
+            # between the pid snapshot and the sweep. One merge worker means at
+            # most one pid to spare.
             reaped = 0
             if any(downloader.is_alive() for downloader in downloaders):
                 reaped = terminate_child_processes(
-                    exclude_pids=set(self._merge_process_pids)
+                    exclude_pid=next(iter(self._merge_process_pids), None)
                 )
 
         if reaped:
@@ -1100,7 +1165,8 @@ class LiveStreamMonitor:
 
     def _join_recording_threads(self, downloaders: List[StreamDownloader]) -> None:
         """Give stopped downloader threads a bounded window to report their outcome."""
-        deadline = monotonic() + self.SHUTDOWN_RECORDING_JOIN_TIMEOUT_SECONDS
+        join_budget = self._shutdown_time_left(self.SHUTDOWN_PHASE_TIMEOUT_SECONDS)
+        deadline = monotonic() + join_budget
         unfinished: List[str] = []
 
         for downloader in downloaders:
@@ -1112,10 +1178,11 @@ class LiveStreamMonitor:
                 unfinished.append(downloader.creator_name)
 
         if unfinished:
+            # Whatever these report later is past the join budget: the merge
+            # executor will refuse it and their raw .ts stay on disk.
             self.logger.warning(
                 f"{len(unfinished)} recording(s) did not stop within "
-                f"{self.SHUTDOWN_RECORDING_JOIN_TIMEOUT_SECONDS:.0f}s: "
-                f"{', '.join(unfinished)}"
+                f"{join_budget:.0f}s: {', '.join(unfinished)}"
             )
 
     def _make_session_download_error_callback(self, session_key: str) -> Callable[[str], None]:

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -31,6 +31,7 @@ from .download_merge_executor import DownloadMergeExecutor
 from .downloader import StreamDownloader
 from .logger import bind, clip, setup_logger
 from .rplay import RPlayAPI, RPlayAPIError, RPlayAuthError, RPlayConnectionError
+from .utils import terminate_child_processes
 
 __all__ = [
     "LiveStreamMonitor",
@@ -40,6 +41,13 @@ __all__ = [
 @dataclass(frozen=True)
 class _PollRequested:
     """Internal control-loop event requesting one monitor poll."""
+
+    done: Event
+
+
+@dataclass(frozen=True)
+class _DrainRequested:
+    """Internal control-loop marker signalling that earlier events were handled."""
 
     done: Event
 
@@ -63,6 +71,7 @@ SessionEvent = Union[
 MonitorRuntimeEvent = Union[
     SessionEvent,
     _PollRequested,
+    _DrainRequested,
     _ShutdownRequested,
 ]
 
@@ -79,6 +88,11 @@ class LiveStreamMonitor:
 
     DEFAULT_MERGE_TIMEOUT_SECONDS = 7200
     POLL_WAIT_TIMEOUT_SECONDS = 30.0
+    # Shutdown budgets. Every wait below is bounded so a wedged recording or
+    # merge can never turn a SIGTERM into a hang.
+    SHUTDOWN_EVENT_DRAIN_TIMEOUT_SECONDS = 30.0
+    SHUTDOWN_RECORDING_JOIN_TIMEOUT_SECONDS = 30.0
+    SHUTDOWN_MERGE_DRAIN_TIMEOUT_SECONDS = 600.0
     TERMINAL_SESSION_STATES = {
         SessionState.BLOCKED,
         SessionState.DONE,
@@ -116,6 +130,13 @@ class LiveStreamMonitor:
         self._state_lock = RLock()
         self._event_queue: Queue[MonitorRuntimeEvent] = Queue()
         self._shutdown_requested = False
+        # Recording downloaders, so shutdown can stop them and wait for their
+        # terminal events instead of discovering them as orphaned ffmpeg pids.
+        self._active_downloaders: Dict[str, StreamDownloader] = {}
+        # Pids of merge ffmpeg children this monitor owns. Reaping recordings
+        # skips these, otherwise shutdown would kill a merge in progress.
+        self._merge_process_pids: Set[int] = set()
+        self._merge_submission_closed = False
         self._control_thread = Thread(
             target=self._event_loop,
             name="monitor-control",
@@ -167,10 +188,16 @@ class LiveStreamMonitor:
                         event.done.set()
                     continue
 
+                if isinstance(event, _DrainRequested):
+                    # FIFO: reaching this marker means everything queued ahead
+                    # of it has already been applied.
+                    event.done.set()
+                    continue
+
                 self._handle_monitor_event(event)
             except Exception as exc:
                 self.logger.exception(f"Unexpected control-loop error: {exc}")
-                if isinstance(event, _PollRequested):
+                if isinstance(event, (_PollRequested, _DrainRequested)):
                     event.done.set()
             finally:
                 self._event_queue.task_done()
@@ -181,6 +208,23 @@ class LiveStreamMonitor:
             return False
         self._event_queue.put(event)
         return True
+
+    def _drain_monitor_events(self, timeout: float) -> bool:
+        """
+        Wait until events queued so far have been applied by the control loop.
+
+        Uses an ordered marker rather than Queue.join() so the wait is bounded:
+        shutdown must never block forever on a control loop that is wedged.
+        """
+        done = Event()
+        self._event_queue.put(_DrainRequested(done=done))
+        if done.wait(timeout=timeout):
+            return True
+
+        self.logger.warning(
+            f"Monitor events did not drain within {timeout:.0f}s; continuing shutdown"
+        )
+        return False
 
     def _run_poll_cycle(self) -> None:
         """Check active streams and start new downloads on the control loop."""
@@ -315,6 +359,10 @@ class LiveStreamMonitor:
     def _start_download(self, stream: LiveStream) -> None:
         """Start downloading a live stream on the control loop."""
         with self._state_lock:
+            if self._shutdown_requested:
+                # Shutdown already snapshotted the recordings it has to stop; a
+                # session started now would never be stopped or merged.
+                return
             creator_profile = self.monitored_creators.get(stream.creator_oid)
         if creator_profile is None:
             return
@@ -346,7 +394,7 @@ class LiveStreamMonitor:
         stream_url: str,
         title: str,
     ) -> None:
-        """Create and start the session-scoped downloader thread."""
+        """Create, register, and start the session-scoped downloader thread."""
         active_downloader = StreamDownloader(
             creator_name=session.creator_name,
             on_download_error=self._make_session_download_error_callback(
@@ -360,6 +408,13 @@ class LiveStreamMonitor:
             on_download_complete=self._on_raw_download_complete,
             on_download_failure=self._on_raw_download_failed,
         )
+
+        # Registered before the thread starts: shutdown snapshots this map, and
+        # a recording it cannot see is a recording it cannot stop or merge.
+        # The control loop is the only writer here and it is the same thread
+        # that runs the in-flight poll shutdown waits for.
+        with self._state_lock:
+            self._active_downloaders[session.session_key] = active_downloader
 
         # The downloader logs "Recording started" itself; repeating it here added
         # a line that carried no information the previous one did not already have.
@@ -595,6 +650,7 @@ class LiveStreamMonitor:
     def _remove_session(self, session_key: str) -> None:
         """Remove a session that failed before raw download started."""
         with self._state_lock:
+            self._active_downloaders.pop(session_key, None)
             session = self.sessions.pop(session_key, None)
             if session is not None:
                 active_session_key = self._active_raw_session_by_creator.get(
@@ -693,6 +749,7 @@ class LiveStreamMonitor:
     def _handle_raw_download_completed(self, event: RawDownloadCompleted) -> None:
         """Queue merge work as soon as raw download completes."""
         with self._state_lock:
+            self._active_downloaders.pop(event.session_key, None)
             session = self.sessions.get(event.session_key)
             if session is None:
                 return
@@ -710,7 +767,20 @@ class LiveStreamMonitor:
                 session_prefix=session.session_prefix,
             )
 
-        self.merge_executor.submit_merge(lambda: self._run_merge_job(merge_job))
+            # Submitted under the same lock that shutdown uses to close
+            # submission, so a merge can never be handed to an executor that is
+            # already draining towards closure.
+            if self._merge_submission_closed:
+                session.state = SessionState.MERGE_FAILED
+                session.last_error = "merge submission closed by shutdown"
+                self.logger.warning(
+                    f"⚠️ Raw download for {session.creator_name} finished after shutdown "
+                    f"closed merge submission. Raw .ts files left in: {session.output_dir}"
+                )
+                return
+
+            self.merge_executor.submit_merge(lambda: self._run_merge_job(merge_job))
+
         self.logger.info(
             f"🧩 Queued merge for {merge_job.creator_name}: "
             f"session_key={merge_job.session_key}, output_dir={merge_job.output_dir}"
@@ -719,6 +789,7 @@ class LiveStreamMonitor:
     def _handle_raw_download_auth_failed(self, event: RawDownloadAuthFailed) -> None:
         """Clear auth-failed raw sessions and surface credential guidance."""
         with self._state_lock:
+            self._active_downloaders.pop(event.session_key, None)
             session = self.sessions.pop(event.session_key, None)
             if session is not None:
                 active_session_key = self._active_raw_session_by_creator.get(
@@ -739,6 +810,7 @@ class LiveStreamMonitor:
     def _handle_raw_download_failed(self, event: RawDownloadFailed) -> None:
         """Clear failed raw sessions so the next poll can retry them."""
         with self._state_lock:
+            self._active_downloaders.pop(event.session_key, None)
             session = self.sessions.pop(event.session_key, None)
             if session is not None:
                 active_session_key = self._active_raw_session_by_creator.get(
@@ -758,6 +830,7 @@ class LiveStreamMonitor:
     def _handle_raw_download_blocked(self, event: RawDownloadBlocked) -> None:
         """Apply blocked-session state when downloader reports access failure."""
         with self._state_lock:
+            self._active_downloaders.pop(event.session_key, None)
             session = self.sessions.get(event.session_key)
             if session is None:
                 return
@@ -890,7 +963,7 @@ class LiveStreamMonitor:
 
         try:
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            subprocess.run(
+            self._run_merge_subprocess(
                 [
                     "ffmpeg",
                     "-y",
@@ -903,14 +976,52 @@ class LiveStreamMonitor:
                     "-c",
                     "copy",
                     str(output_path),
-                ],
-                check=True,
-                capture_output=True,
-                text=True,
-                timeout=self.merge_timeout_seconds,
+                ]
             )
         finally:
             list_path.unlink(missing_ok=True)
+
+    def _run_merge_subprocess(self, command: List[str]) -> None:
+        """
+        Run one ffmpeg merge as a child this monitor can identify by pid.
+
+        subprocess.run() hides the pid, and without it shutdown cannot tell a
+        merge ffmpeg from a recording ffmpeg: both are plain children of this
+        process, because yt-dlp spawns its own recording ffmpeg directly.
+        Registering the pid is what lets the recording sweep spare this child.
+
+        Raises:
+            subprocess.TimeoutExpired: If the merge outlives merge_timeout_seconds
+            subprocess.CalledProcessError: If ffmpeg exits non-zero
+        """
+        # Spawned under the state lock so the recording sweep, which holds the
+        # same lock, can never run between this Popen and its registration.
+        with self._state_lock:
+            process = subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            self._merge_process_pids.add(process.pid)
+
+        try:
+            with process:
+                try:
+                    stdout, stderr = process.communicate(
+                        timeout=self.merge_timeout_seconds
+                    )
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.communicate()
+                    raise
+                if process.returncode != 0:
+                    raise subprocess.CalledProcessError(
+                        process.returncode, command, output=stdout, stderr=stderr
+                    )
+        finally:
+            with self._state_lock:
+                self._merge_process_pids.discard(process.pid)
 
     def _format_ffconcat_input_path(self, ts_file: Path) -> str:
         """Format one concat-demuxer input line with apostrophe-safe escaping."""
@@ -918,17 +1029,94 @@ class LiveStreamMonitor:
         return f"file '{escaped_path}'"
 
     def shutdown(self) -> None:
-        """Shut down background monitor and merge work."""
-        if self._shutdown_requested:
-            return
+        """
+        Stop monitoring, then hand every stopped recording to the merge step.
 
-        self._shutdown_requested = True
-        self._event_queue.join()
+        Order is the whole point. Recordings are stopped and joined first so
+        their terminal events can queue merge work while the executor is still
+        open; only then is the executor drained and closed. Closing it earlier
+        makes submit_merge raise for whatever was still recording, which
+        orphans that session's raw .ts files.
+        """
+        with self._state_lock:
+            if self._shutdown_requested:
+                return
+            self._shutdown_requested = True
+
+        # 1. No new polls. Draining also lets an in-flight poll finish, so every
+        #    recording it started is registered before step 2 snapshots them.
+        self._drain_monitor_events(self.SHUTDOWN_EVENT_DRAIN_TIMEOUT_SECONDS)
+
+        # 2. Stop recordings: kill their ffmpeg, spare any merge ffmpeg, and
+        #    wait for the downloader threads to emit their terminal events.
+        self._stop_active_recordings()
+
+        # 3. Apply those events. This is where a stopped recording's merge is
+        #    submitted, and it must happen while the executor still accepts work.
+        self._drain_monitor_events(self.SHUTDOWN_EVENT_DRAIN_TIMEOUT_SECONDS)
+
+        # 4. Let queued merges finish before closing anything.
+        if not self.merge_executor.drain(
+            timeout=self.SHUTDOWN_MERGE_DRAIN_TIMEOUT_SECONDS
+        ):
+            self.logger.warning(
+                "Merge work did not drain before shutdown timeout; closing executor"
+            )
+
+        # 5. Refuse late submissions, then close. wait=True still lets a merge
+        #    that is already running finish rather than dying with the process.
+        with self._state_lock:
+            self._merge_submission_closed = True
         self.merge_executor.shutdown(wait=True)
-        self._event_queue.join()
+
+        # 6. Merge result events, then the control loop and the API client.
+        self._drain_monitor_events(self.SHUTDOWN_EVENT_DRAIN_TIMEOUT_SECONDS)
         self._event_queue.put(_ShutdownRequested())
-        self._control_thread.join()
+        self._control_thread.join(timeout=self.SHUTDOWN_EVENT_DRAIN_TIMEOUT_SECONDS)
         self.api.close()
+
+    def _stop_active_recordings(self) -> None:
+        """Stop recording downloads and wait for their terminal events."""
+        with self._state_lock:
+            downloaders = list(self._active_downloaders.values())
+            for downloader in downloaders:
+                downloader.request_stop()
+
+            # Reaped under the state lock: _run_merge_subprocess takes the same
+            # lock around its Popen, so no merge child can appear unprotected
+            # between the pid snapshot and the sweep.
+            reaped = 0
+            if any(downloader.is_alive() for downloader in downloaders):
+                reaped = terminate_child_processes(
+                    exclude_pids=set(self._merge_process_pids)
+                )
+
+        if reaped:
+            self.logger.warning(
+                f"Terminated {reaped} recording subprocess(es) left running by yt-dlp"
+            )
+
+        self._join_recording_threads(downloaders)
+
+    def _join_recording_threads(self, downloaders: List[StreamDownloader]) -> None:
+        """Give stopped downloader threads a bounded window to report their outcome."""
+        deadline = monotonic() + self.SHUTDOWN_RECORDING_JOIN_TIMEOUT_SECONDS
+        unfinished: List[str] = []
+
+        for downloader in downloaders:
+            thread = downloader.download_thread
+            if thread is None:
+                continue
+            thread.join(timeout=max(0.0, deadline - monotonic()))
+            if thread.is_alive():
+                unfinished.append(downloader.creator_name)
+
+        if unfinished:
+            self.logger.warning(
+                f"{len(unfinished)} recording(s) did not stop within "
+                f"{self.SHUTDOWN_RECORDING_JOIN_TIMEOUT_SECONDS:.0f}s: "
+                f"{', '.join(unfinished)}"
+            )
 
     def _make_session_download_error_callback(self, session_key: str) -> Callable[[str], None]:
         """Create a callback for a specific session download failure."""

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -117,11 +117,14 @@ class LiveStreamScheduler:
 
         # Always shut the monitor down, even when the scheduler never started:
         # its control thread and merge executor exist from construction.
+        # The monitor owns recording subprocess lifecycle: it stops recordings
+        # while sparing merge children, then merges what they left behind.
         self.monitor.shutdown()
 
-        # The monitor has drained the merge queue by now, so any child process
-        # still alive is a recording ffmpeg spawned by yt-dlp's FFmpegFD. Those
-        # outlive the interpreter and keep downloading unless reaped here.
+        # Safety net only. The monitor has closed its merge executor by now, so
+        # nothing here can be a merge ffmpeg; anything still alive is a
+        # recording child that escaped the monitor's sweep (a yt-dlp retry that
+        # respawned after it). Those outlive the interpreter unless reaped.
         reaped = terminate_child_processes()
         if reaped:
             self.logger.warning(

--- a/core/utils.py
+++ b/core/utils.py
@@ -4,7 +4,7 @@ Utility functions for rplay-live-dl.
 Provides common helper functions used across multiple modules.
 """
 
-from typing import Iterable, Optional, Set
+from typing import Optional
 
 import psutil
 
@@ -14,22 +14,9 @@ __all__ = [
 ]
 
 
-def _expand_protected_pids(exclude_pids: Optional[Iterable[int]]) -> Set[int]:
-    """Expand protected pids to cover their descendants at snapshot time."""
-    protected = set(exclude_pids or ())
-    for pid in list(protected):
-        try:
-            protected.update(
-                child.pid for child in psutil.Process(pid).children(recursive=True)
-            )
-        except psutil.Error:
-            continue
-    return protected
-
-
 def terminate_child_processes(
     timeout_seconds: float = 10.0,
-    exclude_pids: Optional[Iterable[int]] = None,
+    exclude_pid: Optional[int] = None,
 ) -> int:
     """
     Terminate child processes of this process, politely then firmly.
@@ -44,19 +31,22 @@ def terminate_child_processes(
 
     Args:
         timeout_seconds: Grace period before killing survivors of the first pass
-        exclude_pids: Children this caller owns deliberately (a running merge
-            ffmpeg) plus their descendants. They are left completely alone, so
-            shutdown can reap recordings without killing an active merge.
+        exclude_pid: The one child this caller owns deliberately — the merge
+            ffmpeg, of which there is at most one because the merge executor
+            runs a single worker. It is left alone, so shutdown can reap
+            recordings without killing an active merge. ffmpeg spawns no
+            children of its own, so the pid alone is the whole exclusion.
     """
-    protected = _expand_protected_pids(exclude_pids)
     total = 0
     # A running download may spawn a child between passes, so re-scan once.
+    # ponytail: one re-scan covers the single respawn yt-dlp does; hand the
+    # sweep tracked child handles if recordings ever outrun two passes.
     for pass_timeout in (timeout_seconds, 2.0):
         try:
             children = [
                 child
                 for child in psutil.Process().children(recursive=True)
-                if child.pid not in protected
+                if child.pid != exclude_pid
             ]
         except psutil.Error:
             break

--- a/core/utils.py
+++ b/core/utils.py
@@ -4,6 +4,8 @@ Utility functions for rplay-live-dl.
 Provides common helper functions used across multiple modules.
 """
 
+from typing import Iterable, Optional, Set
+
 import psutil
 
 __all__ = [
@@ -12,9 +14,25 @@ __all__ = [
 ]
 
 
-def terminate_child_processes(timeout_seconds: float = 10.0) -> int:
+def _expand_protected_pids(exclude_pids: Optional[Iterable[int]]) -> Set[int]:
+    """Expand protected pids to cover their descendants at snapshot time."""
+    protected = set(exclude_pids or ())
+    for pid in list(protected):
+        try:
+            protected.update(
+                child.pid for child in psutil.Process(pid).children(recursive=True)
+            )
+        except psutil.Error:
+            continue
+    return protected
+
+
+def terminate_child_processes(
+    timeout_seconds: float = 10.0,
+    exclude_pids: Optional[Iterable[int]] = None,
+) -> int:
     """
-    Terminate every child process of this process, politely then firmly.
+    Terminate child processes of this process, politely then firmly.
 
     yt-dlp downloads HLS through FFmpegFD, which spawns ffmpeg as a subprocess
     and keeps the Popen object in a local variable, so there is no handle to
@@ -23,12 +41,23 @@ def terminate_child_processes(timeout_seconds: float = 10.0) -> int:
 
     Sends terminate to the whole child tree, waits, then kills whatever is
     still alive. Returns the number of children that had to be dealt with.
+
+    Args:
+        timeout_seconds: Grace period before killing survivors of the first pass
+        exclude_pids: Children this caller owns deliberately (a running merge
+            ffmpeg) plus their descendants. They are left completely alone, so
+            shutdown can reap recordings without killing an active merge.
     """
+    protected = _expand_protected_pids(exclude_pids)
     total = 0
     # A running download may spawn a child between passes, so re-scan once.
     for pass_timeout in (timeout_seconds, 2.0):
         try:
-            children = psutil.Process().children(recursive=True)
+            children = [
+                child
+                for child in psutil.Process().children(recursive=True)
+                if child.pid not in protected
+            ]
         except psutil.Error:
             break
         if not children:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,3 +11,7 @@ services:
       - ./archive:/app/archive
       - ./logs:/app/logs
     restart: unless-stopped
+    # LiveStreamMonitor.SHUTDOWN_BUDGET_SECONDS (600s) plus margin for the
+    # child-process sweep. Docker's 10s default would SIGKILL mid-merge and
+    # leave the raw .ts unmerged.
+    stop_grace_period: 11m

--- a/tests/test_download_merge_executor.py
+++ b/tests/test_download_merge_executor.py
@@ -1,5 +1,7 @@
 ﻿"""Tests for the download merge executor."""
 
+from threading import Event
+
 import pytest
 
 from core.download_merge_executor import DownloadMergeExecutor
@@ -27,3 +29,60 @@ class TestDownloadMergeExecutor:
 
         with pytest.raises(RuntimeError):
             executor.submit_merge(lambda: None)
+
+    def test_drain_waits_for_running_merge_and_stays_open(self):
+        """Test drain flushes in-flight merges without closing the executor."""
+        release = Event()
+        finished = []
+        executor = DownloadMergeExecutor(max_workers=1)
+
+        def slow_merge():
+            release.wait(timeout=2)
+            finished.append("merge")
+
+        executor.submit_merge(slow_merge)
+        release.set()
+
+        assert executor.drain(timeout=5) is True
+        assert finished == ["merge"]
+
+        # Staying open is the point: a recording stopped by shutdown still has
+        # to be able to queue its merge after this drain.
+        executor.submit_merge(lambda: finished.append("late")).result(timeout=5)
+        executor.shutdown(wait=True)
+
+        assert finished == ["merge", "late"]
+
+    def test_drain_returns_false_when_merge_outlasts_timeout(self):
+        """Test drain reports failure instead of hanging on a stuck merge."""
+        release = Event()
+        executor = DownloadMergeExecutor(max_workers=1)
+        executor.submit_merge(lambda: release.wait(timeout=5))
+
+        try:
+            assert executor.drain(timeout=0.1) is False
+        finally:
+            release.set()
+            executor.shutdown(wait=True)
+
+    def test_drain_covers_merge_submitted_while_draining(self):
+        """Test drain re-checks so a late submission is not left unflushed."""
+        finished = []
+        executor = DownloadMergeExecutor(max_workers=1)
+
+        def first_merge():
+            finished.append("first")
+            executor.submit_merge(lambda: finished.append("second"))
+
+        executor.submit_merge(first_merge)
+
+        assert executor.drain(timeout=5) is True
+        assert finished == ["first", "second"]
+        executor.shutdown(wait=True)
+
+    def test_drain_returns_immediately_when_nothing_pending(self):
+        """Test drain on an idle executor is a no-op."""
+        executor = DownloadMergeExecutor(max_workers=1)
+
+        assert executor.drain(timeout=0) is True
+        executor.shutdown(wait=True)

--- a/tests/test_download_merge_executor.py
+++ b/tests/test_download_merge_executor.py
@@ -30,28 +30,29 @@ class TestDownloadMergeExecutor:
         with pytest.raises(RuntimeError):
             executor.submit_merge(lambda: None)
 
-    def test_drain_waits_for_running_merge_and_stays_open(self):
-        """Test drain flushes in-flight merges without closing the executor."""
+    def test_drain_waits_for_queued_merges_then_refuses_new_work(self):
+        """Test the drain barrier flushes queued merges and closes acceptance."""
         release = Event()
         finished = []
         executor = DownloadMergeExecutor(max_workers=1)
 
         def slow_merge():
-            release.wait(timeout=2)
+            release.wait(timeout=5)
             finished.append("merge")
 
         executor.submit_merge(slow_merge)
         release.set()
 
+        # FIFO with one worker: the barrier cannot run before the merge queued
+        # ahead of it, so True here means that merge is finished.
         assert executor.drain(timeout=5) is True
         assert finished == ["merge"]
 
-        # Staying open is the point: a recording stopped by shutdown still has
-        # to be able to queue its merge after this drain.
-        executor.submit_merge(lambda: finished.append("late")).result(timeout=5)
-        executor.shutdown(wait=True)
+        with pytest.raises(RuntimeError):
+            executor.submit_merge(lambda: finished.append("late"))
 
-        assert finished == ["merge", "late"]
+        executor.shutdown(wait=True)
+        assert finished == ["merge"]
 
     def test_drain_returns_false_when_merge_outlasts_timeout(self):
         """Test drain reports failure instead of hanging on a stuck merge."""
@@ -65,24 +66,9 @@ class TestDownloadMergeExecutor:
             release.set()
             executor.shutdown(wait=True)
 
-    def test_drain_covers_merge_submitted_while_draining(self):
-        """Test drain re-checks so a late submission is not left unflushed."""
-        finished = []
+    def test_drain_on_idle_executor_returns_true(self):
+        """Test the barrier completes right away when no merge is queued."""
         executor = DownloadMergeExecutor(max_workers=1)
-
-        def first_merge():
-            finished.append("first")
-            executor.submit_merge(lambda: finished.append("second"))
-
-        executor.submit_merge(first_merge)
 
         assert executor.drain(timeout=5) is True
-        assert finished == ["first", "second"]
-        executor.shutdown(wait=True)
-
-    def test_drain_returns_immediately_when_nothing_pending(self):
-        """Test drain on an idle executor is a no-op."""
-        executor = DownloadMergeExecutor(max_workers=1)
-
-        assert executor.drain(timeout=0) is True
         executor.shutdown(wait=True)

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -789,6 +789,95 @@ class TestDownloadErrorCallback:
         assert len(failed_events) == 1
         assert failed_events[0].error_message == "ERROR: ffmpeg exited with code 8"
 
+    def test_worker_stops_retrying_once_shutdown_requests_stop(
+        self, mock_yt_dlp, tmp_path
+    ):
+        """Test a stopped recording gives up its retry budget instead of stalling shutdown."""
+        mock_ydl_class, mock_ydl = mock_yt_dlp
+        failed_events = []
+        downloader = StreamDownloader(
+            "TestCreator",
+            session_key="creator1:stream1",
+            on_download_failure=lambda event: failed_events.append(event),
+        )
+        output_path = tmp_path / "test.ts"
+        downloader._download_start_time = datetime.now()
+
+        def kill_recording_mid_download(*args, **kwargs):
+            # What shutdown actually does: reap the recording ffmpeg while
+            # yt-dlp is running, which surfaces as a retryable failure.
+            downloader.request_stop()
+            raise yt_dlp.utils.DownloadError("ERROR: ffmpeg exited with code 8")
+
+        mock_ydl.download.side_effect = kill_recording_mid_download
+
+        with patch("core.downloader.time.sleep") as mock_sleep:
+            downloader._download_worker("http://example.com/stream.m3u8", {}, output_path)
+
+        # One attempt, no backoff: shutdown has a bounded window to collect the
+        # terminal event before the merge executor closes.
+        assert mock_ydl.download.call_count == 1
+        mock_sleep.assert_not_called()
+        assert len(failed_events) == 1
+
+    def test_worker_reports_stopped_recording_with_output_as_completed(
+        self, mock_yt_dlp, tmp_path
+    ):
+        """Test a shutdown-stopped recording hands existing raw output to the merge step."""
+        mock_ydl_class, mock_ydl = mock_yt_dlp
+        completed_events = []
+        failed_events = []
+        downloader = StreamDownloader(
+            "TestCreator",
+            session_key="creator1:stream1",
+            on_download_complete=lambda event: completed_events.append(event),
+            on_download_failure=lambda event: failed_events.append(event),
+        )
+        output_path = tmp_path / "test.ts"
+        output_path.write_bytes(b"raw recording")
+        downloader._download_start_time = datetime.now()
+
+        def kill_recording_mid_download(*args, **kwargs):
+            downloader.request_stop()
+            raise yt_dlp.utils.DownloadError("ERROR: ffmpeg exited with code 8")
+
+        mock_ydl.download.side_effect = kill_recording_mid_download
+
+        downloader._download_worker("http://example.com/stream.m3u8", {}, output_path)
+
+        # Reporting this as a failure would drop the session and orphan the .ts.
+        assert failed_events == []
+        assert len(completed_events) == 1
+        assert completed_events[0].session_key == "creator1:stream1"
+
+    def test_worker_reports_stopped_recording_without_output_as_failed(
+        self, mock_yt_dlp, tmp_path
+    ):
+        """Test a stopped recording that left only a .part is not passed off as complete."""
+        mock_ydl_class, mock_ydl = mock_yt_dlp
+        completed_events = []
+        failed_events = []
+        downloader = StreamDownloader(
+            "TestCreator",
+            session_key="creator1:stream1",
+            on_download_complete=lambda event: completed_events.append(event),
+            on_download_failure=lambda event: failed_events.append(event),
+        )
+        output_path = tmp_path / "test.ts"
+        Path(f"{output_path}.part").write_bytes(b"truncated")
+        downloader._download_start_time = datetime.now()
+
+        def kill_recording_mid_download(*args, **kwargs):
+            downloader.request_stop()
+            raise yt_dlp.utils.DownloadError("ERROR: ffmpeg exited with code 8")
+
+        mock_ydl.download.side_effect = kill_recording_mid_download
+
+        downloader._download_worker("http://example.com/stream.m3u8", {}, output_path)
+
+        assert completed_events == []
+        assert len(failed_events) == 1
+
     def test_worker_logs_partial_output_details_on_failure(self, mock_yt_dlp, tmp_path):
         """Test final download error logs include .part output details."""
         mock_ydl_class, mock_ydl = mock_yt_dlp

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -850,34 +850,6 @@ class TestDownloadErrorCallback:
         assert len(completed_events) == 1
         assert completed_events[0].session_key == "creator1:stream1"
 
-    def test_worker_reports_stopped_recording_without_output_as_failed(
-        self, mock_yt_dlp, tmp_path
-    ):
-        """Test a stopped recording that left only a .part is not passed off as complete."""
-        mock_ydl_class, mock_ydl = mock_yt_dlp
-        completed_events = []
-        failed_events = []
-        downloader = StreamDownloader(
-            "TestCreator",
-            session_key="creator1:stream1",
-            on_download_complete=lambda event: completed_events.append(event),
-            on_download_failure=lambda event: failed_events.append(event),
-        )
-        output_path = tmp_path / "test.ts"
-        Path(f"{output_path}.part").write_bytes(b"truncated")
-        downloader._download_start_time = datetime.now()
-
-        def kill_recording_mid_download(*args, **kwargs):
-            downloader.request_stop()
-            raise yt_dlp.utils.DownloadError("ERROR: ffmpeg exited with code 8")
-
-        mock_ydl.download.side_effect = kill_recording_mid_download
-
-        downloader._download_worker("http://example.com/stream.m3u8", {}, output_path)
-
-        assert completed_events == []
-        assert len(failed_events) == 1
-
     def test_worker_logs_partial_output_details_on_failure(self, mock_yt_dlp, tmp_path):
         """Test final download error logs include .part output details."""
         mock_ydl_class, mock_ydl = mock_yt_dlp

--- a/tests/test_merge_flow.py
+++ b/tests/test_merge_flow.py
@@ -1,6 +1,7 @@
 """Tests for session merge flow."""
 
 import subprocess
+import sys
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -288,10 +289,40 @@ class TestMergeFlow:
         def fake_run(cmd, **kwargs):
             captured["content"] = Path(cmd[7]).read_text(encoding="utf-8")
 
-        with patch("core.live_stream_monitor.subprocess.run", side_effect=fake_run):
+        # Patched at the tracked-subprocess seam: the merge spawns ffmpeg through
+        # Popen now so shutdown can spare it by pid.
+        with patch.object(monitor, "_run_merge_subprocess", side_effect=fake_run):
             monitor._run_ffmpeg_merge([ts_file], output_path)
 
         assert r"it'\''s live.ts" in captured["content"]
+        monitor.shutdown()
+
+    def test_run_merge_subprocess_matches_checked_run_semantics(self, tmp_path, monkeypatch):
+        """Test the tracked merge child keeps subprocess.run(check=True) behavior."""
+        monkeypatch.chdir(tmp_path)
+        monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=None)
+
+        monitor._run_merge_subprocess([sys.executable, "-c", "print('ok')"])
+
+        with pytest.raises(subprocess.CalledProcessError) as exit_error:
+            monitor._run_merge_subprocess(
+                [sys.executable, "-c", "import sys; sys.stderr.write('boom'); sys.exit(3)"]
+            )
+
+        assert exit_error.value.returncode == 3
+        assert exit_error.value.stderr == "boom"
+
+        # _merge_session_to_mp4 reads exc.timeout, so it has to survive the
+        # switch from subprocess.run to Popen.communicate.
+        monitor.merge_timeout_seconds = 0.3
+        with pytest.raises(subprocess.TimeoutExpired) as timeout_error:
+            monitor._run_merge_subprocess(
+                [sys.executable, "-c", "import time; time.sleep(30)"]
+            )
+
+        assert timeout_error.value.timeout == 0.3
+        # A leaked pid would make a later shutdown spare a recording forever.
+        assert monitor._merge_process_pids == set()
         monitor.shutdown()
 
     def test_reserve_final_output_path_uses_local_timezone_for_date(

--- a/tests/test_merge_flow.py
+++ b/tests/test_merge_flow.py
@@ -297,20 +297,10 @@ class TestMergeFlow:
         assert r"it'\''s live.ts" in captured["content"]
         monitor.shutdown()
 
-    def test_run_merge_subprocess_matches_checked_run_semantics(self, tmp_path, monkeypatch):
-        """Test the tracked merge child keeps subprocess.run(check=True) behavior."""
+    def test_run_merge_subprocess_times_out_and_releases_its_pid(self, tmp_path, monkeypatch):
+        """Test a timed-out merge child raises with its timeout and leaves no tracked pid."""
         monkeypatch.chdir(tmp_path)
         monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=None)
-
-        monitor._run_merge_subprocess([sys.executable, "-c", "print('ok')"])
-
-        with pytest.raises(subprocess.CalledProcessError) as exit_error:
-            monitor._run_merge_subprocess(
-                [sys.executable, "-c", "import sys; sys.stderr.write('boom'); sys.exit(3)"]
-            )
-
-        assert exit_error.value.returncode == 3
-        assert exit_error.value.stderr == "boom"
 
         # _merge_session_to_mp4 reads exc.timeout, so it has to survive the
         # switch from subprocess.run to Popen.communicate.

--- a/tests/test_monitor_events.py
+++ b/tests/test_monitor_events.py
@@ -3,12 +3,14 @@
 import inspect
 
 from threading import Event as ThreadEvent, Thread
+from time import monotonic
 
 from models.download import MergeCompleted
 
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
+from core.downloader import StreamDownloader
 from core.live_stream_monitor import LiveStreamMonitor
 from models.config import CreatorProfile
 from core.rplay import RPlayAPI
@@ -226,7 +228,10 @@ def test_shutdown_drains_pending_raw_completion_before_executor_shutdown(tmp_pat
         shutdown_thread = Thread(target=monitor.shutdown)
         shutdown_thread.start()
         release_handle.set()
-        shutdown_thread.join(timeout=2)
+        shutdown_thread.join(timeout=5)
+        # A shutdown still running here would make the state assertion below
+        # pass for the wrong reason.
+        assert not shutdown_thread.is_alive()
         monitor._event_queue.join()
 
     assert monitor.sessions[session_key].state == SessionState.DONE
@@ -240,12 +245,11 @@ class _FakeRecording:
     until asked to stop, and only then reports its terminal event.
     """
 
-    def __init__(self, monitor, session_key, output_dir, terminal_event=None):
+    def __init__(self, monitor, session_key, output_dir):
         self.creator_name = "Creator1"
         self._monitor = monitor
         self._session_key = session_key
         self._output_dir = output_dir
-        self._terminal_event = terminal_event
         self._stop_requested = ThreadEvent()
         self.stop_calls = 0
         self.download_thread = Thread(target=self._run, daemon=True)
@@ -262,13 +266,12 @@ class _FakeRecording:
 
     def _run(self):
         self._stop_requested.wait(timeout=5)
-        event = self._terminal_event
-        if event is None:
-            event = RawDownloadCompleted(
+        self._monitor._on_raw_download_complete(
+            RawDownloadCompleted(
                 session_key=self._session_key,
                 output_dir=self._output_dir,
             )
-        self._monitor._on_raw_download_complete(event)
+        )
 
 
 def _make_running_session(monitor, tmp_path, session_key="creator1:2026-03-06T12:00:00"):
@@ -329,8 +332,8 @@ def test_shutdown_spares_a_running_merge_from_the_recording_sweep(tmp_path):
     monitor._merge_process_pids.add(merge_pid)
     captured = {}
 
-    def fake_terminate(timeout_seconds=10.0, exclude_pids=None):
-        captured["exclude_pids"] = set(exclude_pids or ())
+    def fake_terminate(timeout_seconds=10.0, exclude_pid=None):
+        captured["exclude_pid"] = exclude_pid
         return 0
 
     with (
@@ -349,18 +352,7 @@ def test_shutdown_spares_a_running_merge_from_the_recording_sweep(tmp_path):
     ):
         monitor.shutdown()
 
-    assert merge_pid in captured["exclude_pids"]
-
-
-def test_shutdown_does_not_sweep_when_no_recording_is_active(tmp_path):
-    """Test an idle monitor shuts down without reaping unrelated child processes."""
-    mock_api = MagicMock(spec=RPlayAPI)
-    monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
-
-    with patch("core.live_stream_monitor.terminate_child_processes") as mock_terminate:
-        monitor.shutdown()
-
-    mock_terminate.assert_not_called()
+    assert captured["exclude_pid"] == merge_pid
 
 
 def test_shutdown_is_idempotent(tmp_path):
@@ -396,8 +388,8 @@ def test_shutdown_rejects_new_download_sessions(tmp_path):
     mock_api.get_stream_url.assert_not_called()
 
 
-def test_merge_submission_after_shutdown_is_refused_not_raised(tmp_path):
-    """Test a straggler raw completion is recorded instead of crashing the loop."""
+def test_late_terminal_event_after_drain_is_ignored_idempotently(tmp_path):
+    """Test a recording reporting after the join budget warns instead of raising."""
     mock_api = MagicMock(spec=RPlayAPI)
     monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
 
@@ -406,10 +398,116 @@ def test_merge_submission_after_shutdown_is_refused_not_raised(tmp_path):
 
     session_key = _make_running_session(monitor, tmp_path)
 
-    # Straight through the handler: the state-lock gate must turn this into a
-    # recorded failure, not the RuntimeError the control loop used to swallow.
-    monitor._handle_raw_download_completed(
-        RawDownloadCompleted(session_key=session_key, output_dir=tmp_path)
-    )
+    # What a recording that outlived the join budget actually does: report a
+    # terminal event into a monitor whose merge executor is already closed.
+    # The executor's RuntimeError must be absorbed here, not re-raised and not
+    # re-queued for an executor that never reopens.
+    with patch.object(monitor.logger, "warning") as mock_warning:
+        monitor._handle_raw_download_completed(
+            RawDownloadCompleted(session_key=session_key, output_dir=tmp_path)
+        )
+        # Idempotent: a repeat of the same late event changes nothing.
+        monitor._handle_raw_download_completed(
+            RawDownloadCompleted(session_key=session_key, output_dir=tmp_path)
+        )
 
     assert monitor.sessions[session_key].state == SessionState.MERGE_FAILED
+    # The raw .ts are only recoverable if the log says where they are.
+    assert all(str(tmp_path) in call.args[0] for call in mock_warning.call_args_list)
+    assert mock_warning.call_count == 2
+
+
+def test_in_flight_poll_does_not_start_recording_after_shutdown(tmp_path, monkeypatch):
+    """Test a poll blocked on the stream URL during shutdown starts nothing."""
+    monkeypatch.chdir(tmp_path)
+    mock_api = MagicMock(spec=RPlayAPI)
+    monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
+    monitor.monitored_creators["creator1"] = CreatorProfile(
+        creator_name="Creator1",
+        creator_oid="creator1",
+    )
+    stream = MagicMock()
+    stream.creator_oid = "creator1"
+    stream.oid = "stream1"
+    stream.stream_start_time = datetime(2026, 3, 6, 12, 0, 0)
+    stream.title = "Test Stream"
+
+    at_stream_url = ThreadEvent()
+    resume_poll = ThreadEvent()
+
+    def blocking_stream_url(creator_oid):
+        at_stream_url.set()
+        assert resume_poll.wait(timeout=5)
+        return "http://example.com/stream.m3u8"
+
+    mock_api.get_stream_url.side_effect = blocking_stream_url
+
+    with patch.object(StreamDownloader, "download") as mock_download:
+        poll = Thread(target=monitor._start_download, args=(stream,), daemon=True)
+        poll.start()
+        assert at_stream_url.wait(timeout=5)
+
+        # Shutdown takes its recording snapshot while the poll is still inside
+        # get_stream_url, so the recheck before registration is the only thing
+        # standing between this and a recording nobody stops.
+        with patch("core.live_stream_monitor.terminate_child_processes"):
+            monitor.shutdown()
+
+        resume_poll.set()
+        poll.join(timeout=5)
+
+    assert not poll.is_alive()
+    mock_download.assert_not_called()
+    assert monitor._active_downloaders == {}
+    assert monitor.sessions == {}
+    assert monitor._active_raw_session_by_creator == {}
+
+
+class _StuckMergeExecutor:
+    """Merge executor whose queued merge never finishes, only times out."""
+
+    def __init__(self) -> None:
+        self.shutdown_calls = []
+        self._never = ThreadEvent()
+
+    def submit_merge(self, task):
+        raise AssertionError("no merge should be submitted in this test")
+
+    def drain(self, timeout=None):
+        # A merge stuck inside ffmpeg: the barrier can only run out of budget.
+        self._never.wait(timeout=timeout)
+        return False
+
+    def shutdown(self, wait=False, cancel_futures=False):
+        self.shutdown_calls.append((wait, cancel_futures))
+
+
+def test_shutdown_returns_within_budget_when_merge_never_finishes(tmp_path):
+    """Test the aggregate deadline bounds shutdown even with a wedged merge."""
+    mock_api = MagicMock(spec=RPlayAPI)
+    monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
+    monitor.SHUTDOWN_BUDGET_SECONDS = 0.5
+    stuck_executor = _StuckMergeExecutor()
+    monitor.merge_executor = stuck_executor
+
+    finished = ThreadEvent()
+
+    def run_shutdown():
+        monitor.shutdown()
+        finished.set()
+
+    started_at = monotonic()
+    shutdown_thread = Thread(target=run_shutdown, daemon=True)
+    with patch("core.live_stream_monitor.terminate_child_processes"):
+        shutdown_thread.start()
+        # Generous ceiling: the point is that shutdown returns at all, and the
+        # elapsed assertion below is what pins it to the budget.
+        assert finished.wait(timeout=10)
+        shutdown_thread.join(timeout=5)
+
+    assert not shutdown_thread.is_alive()
+    assert monotonic() - started_at < 5
+
+    # wait=True here would hand the wedged merge veto power over process exit.
+    assert stuck_executor.shutdown_calls == [(False, True)]
+    mock_api.close.assert_called_once()

--- a/tests/test_monitor_events.py
+++ b/tests/test_monitor_events.py
@@ -230,3 +230,186 @@ def test_shutdown_drains_pending_raw_completion_before_executor_shutdown(tmp_pat
         monitor._event_queue.join()
 
     assert monitor.sessions[session_key].state == SessionState.DONE
+
+
+class _FakeRecording:
+    """
+    Stand-in for a StreamDownloader whose thread is still recording.
+
+    Mirrors the parts of the real downloader that shutdown drives: it is alive
+    until asked to stop, and only then reports its terminal event.
+    """
+
+    def __init__(self, monitor, session_key, output_dir, terminal_event=None):
+        self.creator_name = "Creator1"
+        self._monitor = monitor
+        self._session_key = session_key
+        self._output_dir = output_dir
+        self._terminal_event = terminal_event
+        self._stop_requested = ThreadEvent()
+        self.stop_calls = 0
+        self.download_thread = Thread(target=self._run, daemon=True)
+        self.download_thread.start()
+
+    def request_stop(self):
+        """Record the stop request and let the recording thread finish."""
+        self.stop_calls += 1
+        self._stop_requested.set()
+
+    def is_alive(self):
+        """Report liveness the way StreamDownloader does."""
+        return self.download_thread.is_alive()
+
+    def _run(self):
+        self._stop_requested.wait(timeout=5)
+        event = self._terminal_event
+        if event is None:
+            event = RawDownloadCompleted(
+                session_key=self._session_key,
+                output_dir=self._output_dir,
+            )
+        self._monitor._on_raw_download_complete(event)
+
+
+def _make_running_session(monitor, tmp_path, session_key="creator1:2026-03-06T12:00:00"):
+    """Register a RAW_RUNNING session for shutdown tests."""
+    monitor.sessions[session_key] = DownloadSession(
+        session_key=session_key,
+        creator_oid="creator1",
+        creator_name="Creator1",
+        title="Test Stream",
+        stream_start_time=datetime(2026, 3, 6, 12, 0, 0),
+        state=SessionState.RAW_RUNNING,
+        output_dir=tmp_path,
+        session_prefix="20260306_120000_",
+    )
+    return session_key
+
+
+def test_shutdown_merges_recording_that_was_active_at_shutdown(tmp_path):
+    """Test a recording stopped by shutdown still gets its raw output merged."""
+    mock_api = MagicMock(spec=RPlayAPI)
+    monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
+    session_key = _make_running_session(monitor, tmp_path)
+    recording = _FakeRecording(monitor, session_key, tmp_path)
+    monitor._active_downloaders[session_key] = recording
+
+    with (
+        patch(
+            "core.live_stream_monitor.terminate_child_processes", return_value=1
+        ) as mock_terminate,
+        patch.object(
+            monitor,
+            "_merge_session_to_mp4",
+            return_value=MergeCompleted(
+                session_key=session_key,
+                output_path=tmp_path / "final.mp4",
+            ),
+        ),
+    ):
+        monitor.shutdown()
+
+    # The recording had to be stopped, and its merge had to reach the executor
+    # while it was still open: MERGE_QUEUED or MERGE_FAILED here would mean the
+    # session .ts was orphaned.
+    assert recording.stop_calls == 1
+    mock_terminate.assert_called_once()
+    assert monitor.sessions[session_key].state == SessionState.DONE
+
+
+def test_shutdown_spares_a_running_merge_from_the_recording_sweep(tmp_path):
+    """Test the recording sweep excludes pids of merges that are still running."""
+    mock_api = MagicMock(spec=RPlayAPI)
+    monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
+    session_key = _make_running_session(monitor, tmp_path)
+    monitor._active_downloaders[session_key] = _FakeRecording(
+        monitor, session_key, tmp_path
+    )
+    merge_pid = 424242
+    monitor._merge_process_pids.add(merge_pid)
+    captured = {}
+
+    def fake_terminate(timeout_seconds=10.0, exclude_pids=None):
+        captured["exclude_pids"] = set(exclude_pids or ())
+        return 0
+
+    with (
+        patch(
+            "core.live_stream_monitor.terminate_child_processes",
+            side_effect=fake_terminate,
+        ),
+        patch.object(
+            monitor,
+            "_merge_session_to_mp4",
+            return_value=MergeCompleted(
+                session_key=session_key,
+                output_path=tmp_path / "final.mp4",
+            ),
+        ),
+    ):
+        monitor.shutdown()
+
+    assert merge_pid in captured["exclude_pids"]
+
+
+def test_shutdown_does_not_sweep_when_no_recording_is_active(tmp_path):
+    """Test an idle monitor shuts down without reaping unrelated child processes."""
+    mock_api = MagicMock(spec=RPlayAPI)
+    monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
+
+    with patch("core.live_stream_monitor.terminate_child_processes") as mock_terminate:
+        monitor.shutdown()
+
+    mock_terminate.assert_not_called()
+
+
+def test_shutdown_is_idempotent(tmp_path):
+    """Test a second shutdown neither raises nor repeats the teardown."""
+    mock_api = MagicMock(spec=RPlayAPI)
+    monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
+
+    with patch("core.live_stream_monitor.terminate_child_processes"):
+        monitor.shutdown()
+        monitor.shutdown()
+
+    mock_api.close.assert_called_once()
+
+
+def test_shutdown_rejects_new_download_sessions(tmp_path):
+    """Test no session is started once shutdown has begun."""
+    mock_api = MagicMock(spec=RPlayAPI)
+    monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
+    monitor.monitored_creators["creator1"] = CreatorProfile(
+        creator_name="Creator1",
+        creator_oid="creator1",
+    )
+    stream = MagicMock()
+    stream.creator_oid = "creator1"
+    stream.stream_start_time = datetime(2026, 3, 6, 12, 0, 0)
+    stream.title = "Test Stream"
+
+    with patch("core.live_stream_monitor.terminate_child_processes"):
+        monitor.shutdown()
+        monitor._start_download(stream)
+
+    assert monitor.sessions == {}
+    mock_api.get_stream_url.assert_not_called()
+
+
+def test_merge_submission_after_shutdown_is_refused_not_raised(tmp_path):
+    """Test a straggler raw completion is recorded instead of crashing the loop."""
+    mock_api = MagicMock(spec=RPlayAPI)
+    monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
+
+    with patch("core.live_stream_monitor.terminate_child_processes"):
+        monitor.shutdown()
+
+    session_key = _make_running_session(monitor, tmp_path)
+
+    # Straight through the handler: the state-lock gate must turn this into a
+    # recorded failure, not the RuntimeError the control loop used to swallow.
+    monitor._handle_raw_download_completed(
+        RawDownloadCompleted(session_key=session_key, output_dir=tmp_path)
+    )
+
+    assert monitor.sessions[session_key].state == SessionState.MERGE_FAILED

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -215,24 +215,6 @@ class TestStopScheduler:
         # surviving child safe to reap, because none of them can be a merge.
         assert order.mock_calls == [call.monitor_shutdown(), call.reap()]
 
-    def test_stop_reaps_without_exclusions_after_monitor_shutdown(
-        self, patched_scheduler_deps, mock_env, mock_logger
-    ):
-        """Test the scheduler sweep is an unrestricted net, safe once merges are closed."""
-        mock_scheduler_class, _ = patched_scheduler_deps
-        mock_scheduler = MagicMock()
-        mock_scheduler.running = False
-        mock_scheduler_class.return_value = mock_scheduler
-
-        scheduler = LiveStreamScheduler(env=mock_env, logger=mock_logger, version="1.0.0")
-        with patch("core.scheduler.terminate_child_processes") as mock_terminate:
-            mock_terminate.return_value = 0
-            scheduler.stop()
-
-        # No exclude_pids: discriminating recordings from merges is the
-        # monitor's job, and by now its merge executor is already closed.
-        mock_terminate.assert_called_once_with()
-
     def test_stop_shuts_monitor_down_even_when_scheduler_never_started(
         self, patched_scheduler_deps, mock_env, mock_logger
     ):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -210,9 +210,28 @@ class TestStopScheduler:
             scheduler.stop()
             scheduler.stop()
 
-        # Draining the monitor must come first: only once the merge queue is
-        # empty is every surviving child a recording ffmpeg that needs reaping.
+        # The monitor must come first: it stops recordings while sparing merge
+        # children and closes its merge executor. Only after that is every
+        # surviving child safe to reap, because none of them can be a merge.
         assert order.mock_calls == [call.monitor_shutdown(), call.reap()]
+
+    def test_stop_reaps_without_exclusions_after_monitor_shutdown(
+        self, patched_scheduler_deps, mock_env, mock_logger
+    ):
+        """Test the scheduler sweep is an unrestricted net, safe once merges are closed."""
+        mock_scheduler_class, _ = patched_scheduler_deps
+        mock_scheduler = MagicMock()
+        mock_scheduler.running = False
+        mock_scheduler_class.return_value = mock_scheduler
+
+        scheduler = LiveStreamScheduler(env=mock_env, logger=mock_logger, version="1.0.0")
+        with patch("core.scheduler.terminate_child_processes") as mock_terminate:
+            mock_terminate.return_value = 0
+            scheduler.stop()
+
+        # No exclude_pids: discriminating recordings from merges is the
+        # monitor's job, and by now its merge executor is already closed.
+        mock_terminate.assert_called_once_with()
 
     def test_stop_shuts_monitor_down_even_when_scheduler_never_started(
         self, patched_scheduler_deps, mock_env, mock_logger

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -66,6 +66,27 @@ class TestTerminateChildProcesses:
         """Test no-child cleanup returns zero."""
         assert terminate_child_processes(timeout_seconds=1.0) == 0
 
+    def test_excluded_child_survives_the_sweep(self):
+        """Test a protected pid is left running while everything else is reaped."""
+        protected = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+        doomed = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+        try:
+            reaped = terminate_child_processes(
+                timeout_seconds=5.0, exclude_pids=[protected.pid]
+            )
+
+            # This is the merge-vs-recording discrimination: shutdown reaps the
+            # recording ffmpeg while an active merge ffmpeg keeps running.
+            assert reaped >= 1
+            doomed.wait(timeout=5)
+            assert protected.poll() is None
+        finally:
+            for proc in (protected, doomed):
+                try:
+                    proc.kill()
+                except OSError:
+                    pass
+
     def test_terminates_a_real_child_process(self):
         """Test a real child process is terminated and reaped."""
         proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -72,7 +72,7 @@ class TestTerminateChildProcesses:
         doomed = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
         try:
             reaped = terminate_child_processes(
-                timeout_seconds=5.0, exclude_pids=[protected.pid]
+                timeout_seconds=5.0, exclude_pid=protected.pid
             )
 
             # This is the merge-vs-recording discrimination: shutdown reaps the


### PR DESCRIPTION
## Problem

Graceful shutdown always orphaned in-progress recordings: the merge executor was shut down before recording ffmpeg processes were killed, so when a dying download thread finally emitted its completion event, the merge submission hit a closed executor and the session's raw `.ts` was silently left behind. Every deploy/restart during a live stream cost a manual merge.

## Change

- Shutdown now: rejects new sessions → stops recordings (recording ffmpeg only) and joins downloader threads → drains their terminal events so merges get submitted → drains the merge executor (FIFO sentinel barrier) → only then closes it.
- A stopped recording with existing raw output reports completed (not failed), so its session merges instead of being dropped; the stop flag short-circuits the retry loop so shutdown is not spent on retry backoff.
- `terminate_child_processes` gained `exclude_pid`: the active merge ffmpeg is never reaped; spawn+register and the sweep share the state lock.
- One aggregate shutdown budget (600s) bounds every phase; on expiry the executor closes without waiting and queued merges are cancelled with a clear warning. `docker-compose.yaml` sets `stop_grace_period: 11m` so Docker does not SIGKILL mid-merge.
- Late terminal events after the budget are handled idempotently (warning naming the raw dir) instead of raising into the control loop.
- In-flight polls recheck the shutdown flag under the state lock right before registering a downloader, closing the race where a recording could start after the shutdown snapshot.

## Acceptance

- A recording active at shutdown emits its terminal event before executor closure and its completed output is merged.
- An already-running merge is never killed by shutdown.
- Shutdown is idempotent and bounded; a stuck merge cannot hang the process past the budget.
- A poll blocked mid-start during shutdown cannot register a new recording.
- A shutdown-kill of ffmpeg is never misclassified as a 401/403 auth/blocked failure.

## Verification

```
poetry run pytest tests/test_monitor_events.py tests/test_download_merge_executor.py \
  tests/test_scheduler.py tests/test_downloader.py tests/test_merge_flow.py -v -> 128 passed
poetry run pytest (full, 3x) -> 327 passed / 327 passed / 327 passed
```

Known limits: a merge exceeding the 600s budget is abandoned (raw `.ts` survives and is reported by the startup orphan scan); startup auto-recovery of orphans is a separate planned change.
