### PR TITLE
ci: expand Python test matrix and bump action versions

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -14,7 +14,7 @@ jobs:
   docker-smoke:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Build image
         run: docker build -t rplay-live-dl:smoke .

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,15 +10,15 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   fetch-depth: 0
 
             - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
+              uses: docker/setup-buildx-action@v4
 
             - name: Login to Docker Hub
-              uses: docker/login-action@v3
+              uses: docker/login-action@v4
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -30,7 +30,7 @@ jobs:
                     || { echo "::error::tag is not an ancestor of main"; exit 1; }
 
             - name: Build and push
-              uses: docker/build-push-action@v5
+              uses: docker/build-push-action@v7
               with:
                   context: .
                   push: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -28,7 +28,7 @@ jobs:
 
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
## Summary
Expand the pytest matrix to Python 3.11–3.14 and bump GitHub Actions to current majors across all three workflows.

- Matrix: `["3.11", "3.12"]` → `["3.11", "3.12", "3.13", "3.14"]`; job id/name pattern unchanged so the existing required status contexts keep their exact names.
- Bumps (all workflows): actions/checkout v4→v7, actions/setup-python v5→v7, actions/cache v4→v6, docker/setup-buildx-action v3→v4, docker/login-action v3→v4, docker/build-push-action v5→v7.
- No other workflow logic, triggers, or step ordering changed.

## Acceptance criteria
- [ ] CI runs the suite on 3.11/3.12/3.13/3.14
- [ ] Required status contexts (3.11/3.12) keep their current names
- [ ] All bumped actions resolve and run

## Verification
- YAML validated locally for all three files
- Local suite: `327 passed in 36.48s`
- This PR's CI run exercises the expanded matrix
