### PR TITLE
chore: maintain Docker build inputs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,6 +22,12 @@ __pycache__/
 # Project specific
 archive/
 logs/
+docs/
+.agent/
+.claude/
+AGENTS.md
+DASHBOARD_DESIGN.md
+images/
 
 # Development files
 *.egg-info/

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -21,3 +21,14 @@ jobs:
 
       - name: Assert no config directory is baked into the image
         run: docker run --rm rplay-live-dl:smoke sh -c '! test -e /app/config'
+
+      - name: Assert excluded paths are not baked into the image
+        run: |
+          docker run --rm rplay-live-dl:smoke sh -c '
+            test ! -e /app/docs &&
+            test ! -e /app/.agent &&
+            test ! -e /app/.claude &&
+            test ! -e /app/AGENTS.md &&
+            test ! -e /app/DASHBOARD_DESIGN.md &&
+            test ! -e /app/images
+          '

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
+ARG PYTHON_VERSION=3.11
+
 # Build stage
-FROM python:3.11-alpine AS builder
+FROM python:${PYTHON_VERSION}-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache \
@@ -11,7 +13,7 @@ RUN apk add --no-cache \
 WORKDIR /app
 
 # Install Poetry
-RUN pip install --no-cache-dir poetry
+RUN pip install --no-cache-dir poetry==2.4.1
 
 # Copy dependency files
 COPY pyproject.toml poetry.lock ./
@@ -21,8 +23,9 @@ RUN poetry config virtualenvs.create false && \
     poetry install --only main --no-interaction --no-ansi
 
 # Runtime stage
-FROM python:3.11-alpine AS runtime
+FROM python:${PYTHON_VERSION}-alpine AS runtime
 
+ARG PYTHON_VERSION
 ARG APP_GIT_SHA=""
 
 # Install runtime dependencies
@@ -35,7 +38,7 @@ RUN apk add --no-cache \
 WORKDIR /app
 
 # Copy installed packages from builder
-COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=builder /usr/local/lib/python${PYTHON_VERSION}/site-packages /usr/local/lib/python${PYTHON_VERSION}/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 
 # Copy application code


### PR DESCRIPTION
## Summary
Docker build maintenance: single-source the Python version, pin Poetry, and keep repo-internal files out of the image.

- `ARG PYTHON_VERSION=3.11` used in builder base image, runtime base image, and the `site-packages` copy path (previously three hardcoded spots; the site-packages path was the easy-to-miss one).
- Poetry pinned to `2.4.1` in the build stage.
- `.dockerignore` now excludes `docs/`, `.agent/`, `.claude/`, `AGENTS.md`, `DASHBOARD_DESIGN.md`, `images/`.
- docker-smoke workflow asserts those paths do not exist inside the built image.

## Acceptance criteria
- [ ] Built image behavior unchanged (still Python 3.11 by default)
- [ ] Bumping Python later = one-line ARG change
- [ ] Excluded paths absent from image (enforced by smoke step)

## Verification
- Local `docker build` succeeded and the smoke assertion passed against the built image
- Local suite: `327 passed in 36.46s`
