### PR TITLE
feat: re-poll immediately when a download fails mid-stream

### DIFF
--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -139,6 +139,10 @@ class LiveStreamMonitor:
         self._shutdown_requested = False
         # Creators the most recent poll saw actually live. A download failure
         # only earns an immediate re-poll while its creator is still in here.
+        # Not latest_stream_oid_by_creator: its cleanup checks the unfiltered
+        # live list, so a creator who moved to StreamState.TWITCH or YOUTUBE
+        # keeps their entry there and would earn a re-poll per failure for a
+        # stream this app cannot record.
         self._live_creator_oids: Set[str] = set()
         # True while a retry poll sits in the queue unstarted, so concurrent
         # failures merge into one extra poll instead of one poll each.
@@ -196,12 +200,20 @@ class LiveStreamMonitor:
 
                 if isinstance(event, _PollRequested):
                     if event.retry:
-                        # Reopened before the cycle, not after: a failure raised
-                        # while this poll runs must be able to earn the next
-                        # re-poll rather than merge into one that already read
-                        # the live list.
                         with self._state_lock:
+                            # Reopened before the cycle, not after: a failure
+                            # raised while this poll runs must be able to earn
+                            # the next re-poll rather than merge into one that
+                            # already read the live list.
                             self._retry_poll_queued = False
+                            shutdown_started = self._shutdown_requested
+                        if shutdown_started:
+                            # Queued before shutdown began. A recording it
+                            # started would be refused anyway, so serving it
+                            # only adds a live-list read to the window
+                            # api.close() is about to close.
+                            event.done.set()
+                            continue
                     try:
                         self._run_poll_cycle()
                     finally:
@@ -224,25 +236,24 @@ class LiveStreamMonitor:
 
     def _queue_monitor_event(self, event: MonitorRuntimeEvent) -> bool:
         """Enqueue work for the monitor control loop."""
-        if self._shutdown_requested and isinstance(event, _PollRequested):
-            return False
-        self._event_queue.put(event)
+        # Refusal and enqueue as one step, under the lock shutdown takes to set
+        # its flag. Checked unlocked, shutdown slips its whole drain in between
+        # and the poll is served after it: a live-list read racing api.close().
+        # Put on an unbounded Queue never blocks, so this holds the lock only
+        # for the append.
+        with self._state_lock:
+            if self._shutdown_requested and isinstance(event, _PollRequested):
+                return False
+            self._event_queue.put(event)
         return True
 
     def _request_retry_poll(self, creator_oid: str) -> bool:
-        """
-        Queue one extra poll for a creator whose raw download just failed.
-
-        Signals only. Calling the public blocking poll from here would wait on
-        the very control loop that has to serve the request, since failures are
-        handled on that loop.
-
-        Args:
-            creator_oid: Creator whose download failed
-
-        Returns:
-            True if this call queued the extra poll
-        """
+        """Queue at most one immediate retry poll."""
+        # Signals rather than polls: the public poll waits on the very loop that
+        # serves it, and failures are handled on that loop.
+        # One region for check, flag and enqueue, so a shutdown lands wholly
+        # before this (refused) or wholly after (skipped at dequeue), never in
+        # between. RLock, so the nested acquire below is free.
         with self._state_lock:
             if creator_oid not in self._live_creator_oids:
                 # Creator is offline; there is nothing left to record.
@@ -253,14 +264,13 @@ class LiveStreamMonitor:
                 return False
             self._retry_poll_queued = True
 
-        if self._queue_monitor_event(_PollRequested(done=Event(), retry=True)):
-            return True
+            if self._queue_monitor_event(_PollRequested(done=Event(), retry=True)):
+                return True
 
-        # Refused because shutdown started. Clear the marker so it cannot
-        # wedge deduplication for a monitor that keeps running.
-        with self._state_lock:
+            # Refused because shutdown started. Clear the marker so it cannot
+            # wedge deduplication for a monitor that keeps running.
             self._retry_poll_queued = False
-        return False
+            return False
 
     def _drain_monitor_events(self, timeout: float) -> bool:
         """
@@ -921,10 +931,12 @@ class LiveStreamMonitor:
         # to 3600s) of a stream that is still running. Requested only after the
         # session has been cleared above, so the extra poll sees the creator
         # free to start again rather than skipping it as already recording.
-        # ponytail: no separate retry budget here. The downloader has already
-        # spent its tenacity attempts with exponential backoff before this
-        # event exists, which is what keeps the extra poll off a hot loop. Add
-        # a budget if failures are ever seen recurring faster than that.
+        # ponytail: no separate retry budget here. Most of these arrive only
+        # after the downloader spent its tenacity attempts with exponential
+        # backoff, which keeps the extra poll off a hot loop. Not all:
+        # downloader.py's "finished but produced no output file" path reports
+        # with no backoff behind it, so that mode re-polls as fast as it fails.
+        # Add a budget if failures are seen recurring faster than the backoff.
         retried_now = self._request_retry_poll(session.creator_oid)
         next_attempt = "retrying immediately" if retried_now else "will retry on next poll"
         self.logger.warning(

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -43,6 +43,9 @@ class _PollRequested:
     """Internal control-loop event requesting one monitor poll."""
 
     done: Event
+    # Marks the extra poll queued after a download failure. The control loop
+    # uses it to reopen retry deduplication; nobody waits on its done event.
+    retry: bool = False
 
 
 @dataclass(frozen=True)
@@ -134,6 +137,12 @@ class LiveStreamMonitor:
         self._state_lock = RLock()
         self._event_queue: Queue[MonitorRuntimeEvent] = Queue()
         self._shutdown_requested = False
+        # Creators the most recent poll saw actually live. A download failure
+        # only earns an immediate re-poll while its creator is still in here.
+        self._live_creator_oids: Set[str] = set()
+        # True while a retry poll sits in the queue unstarted, so concurrent
+        # failures merge into one extra poll instead of one poll each.
+        self._retry_poll_queued = False
         # Recording downloaders, so shutdown can stop them and wait for their
         # terminal events instead of discovering them as orphaned ffmpeg pids.
         self._active_downloaders: Dict[str, StreamDownloader] = {}
@@ -186,6 +195,13 @@ class LiveStreamMonitor:
                     return
 
                 if isinstance(event, _PollRequested):
+                    if event.retry:
+                        # Reopened before the cycle, not after: a failure raised
+                        # while this poll runs must be able to earn the next
+                        # re-poll rather than merge into one that already read
+                        # the live list.
+                        with self._state_lock:
+                            self._retry_poll_queued = False
                     try:
                         self._run_poll_cycle()
                     finally:
@@ -213,6 +229,39 @@ class LiveStreamMonitor:
         self._event_queue.put(event)
         return True
 
+    def _request_retry_poll(self, creator_oid: str) -> bool:
+        """
+        Queue one extra poll for a creator whose raw download just failed.
+
+        Signals only. Calling the public blocking poll from here would wait on
+        the very control loop that has to serve the request, since failures are
+        handled on that loop.
+
+        Args:
+            creator_oid: Creator whose download failed
+
+        Returns:
+            True if this call queued the extra poll
+        """
+        with self._state_lock:
+            if creator_oid not in self._live_creator_oids:
+                # Creator is offline; there is nothing left to record.
+                return False
+            if self._retry_poll_queued:
+                # Concurrent failures merge: one poll re-reads the whole live
+                # list, so a second request would find the same work done.
+                return False
+            self._retry_poll_queued = True
+
+        if self._queue_monitor_event(_PollRequested(done=Event(), retry=True)):
+            return True
+
+        # Refused because shutdown started. Clear the marker so it cannot
+        # wedge deduplication for a monitor that keeps running.
+        with self._state_lock:
+            self._retry_poll_queued = False
+        return False
+
     def _drain_monitor_events(self, timeout: float) -> bool:
         """
         Wait until events queued so far have been applied by the control loop.
@@ -235,6 +284,14 @@ class LiveStreamMonitor:
         try:
             self._update_downloaders()
             live_streams = self.api.get_livestream_status()
+            # Recorded before any download starts, so a session that fails fast
+            # is judged against the list this very poll read.
+            with self._state_lock:
+                self._live_creator_oids = {
+                    stream.creator_oid
+                    for stream in live_streams
+                    if stream.stream_state == StreamState.LIVE
+                }
             monitored_live = self._process_live_streams(live_streams)
             live_creator_oids = {stream.creator_oid for stream in live_streams}
             self._cleanup_offline_creator_states(live_creator_oids)
@@ -847,7 +904,7 @@ class LiveStreamMonitor:
         )
 
     def _handle_raw_download_failed(self, event: RawDownloadFailed) -> None:
-        """Clear failed raw sessions so the next poll can retry them."""
+        """Clear the failed raw session and re-poll at once if the creator is still live."""
         with self._state_lock:
             session = self.sessions.pop(event.session_key, None)
             if session is not None:
@@ -860,8 +917,18 @@ class LiveStreamMonitor:
         if session is None:
             return
 
+        # Waiting for the next scheduled poll costs up to a whole INTERVAL (up
+        # to 3600s) of a stream that is still running. Requested only after the
+        # session has been cleared above, so the extra poll sees the creator
+        # free to start again rather than skipping it as already recording.
+        # ponytail: no separate retry budget here. The downloader has already
+        # spent its tenacity attempts with exponential backoff before this
+        # event exists, which is what keeps the extra poll off a hot loop. Add
+        # a budget if failures are ever seen recurring faster than that.
+        retried_now = self._request_retry_poll(session.creator_oid)
+        next_attempt = "retrying immediately" if retried_now else "will retry on next poll"
         self.logger.warning(
-            f"⚠️ Raw download failed for {session.creator_name}; will retry on next poll: "
+            f"⚠️ Raw download failed for {session.creator_name}; {next_attempt}: "
             f"{event.error_message}"
         )
 

--- a/tests/test_monitor_events.py
+++ b/tests/test_monitor_events.py
@@ -10,9 +10,12 @@ from models.download import MergeCompleted
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from core.downloader import StreamDownloader
 from core.live_stream_monitor import LiveStreamMonitor
-from models.config import CreatorProfile
+from models.config import AppConfig, CreatorProfile
+from models.env import EnvConfig
 from core.rplay import RPlayAPI
 from models.download import (
     DownloadSession,
@@ -20,6 +23,7 @@ from models.download import (
     RawDownloadFailed,
     SessionState,
 )
+from models.rplay import StreamState
 
 
 def test_raw_completion_event_immediately_submits_merge(tmp_path):
@@ -511,3 +515,196 @@ def test_shutdown_returns_within_budget_when_merge_never_finishes(tmp_path):
     # wait=True here would hand the wedged merge veto power over process exit.
     assert stuck_executor.shutdown_calls == [(False, True)]
     mock_api.close.assert_called_once()
+
+
+def _live_stream(creator_oid, stream_oid="stream-1"):
+    """Build a live-stream stand-in the monitor will accept as recordable."""
+    stream = MagicMock()
+    stream.oid = stream_oid
+    stream.creator_oid = creator_oid
+    stream.stream_state = StreamState.LIVE
+    stream.stream_start_time = datetime(2026, 3, 6, 12, 0, 0)
+    stream.title = f"Stream {creator_oid}"
+    return stream
+
+
+@pytest.fixture
+def repoll_env(tmp_path, monkeypatch):
+    """Serve a fixed creator config and keep the real downloader off the network."""
+    monkeypatch.chdir(tmp_path)
+    with (
+        patch("core.live_stream_monitor.read_config") as mock_read_config,
+        patch.object(StreamDownloader, "download"),
+    ):
+        mock_read_config.return_value = AppConfig(
+            api_base_url="https://api.rplay.live",
+            creators=[
+                CreatorProfile(creator_name="Creator1", creator_oid="creator1"),
+                CreatorProfile(creator_name="Creator2", creator_oid="creator2"),
+            ],
+        )
+        yield
+
+
+def test_failure_repoll_latency_is_far_below_the_poll_interval(repoll_env):
+    """V5: measure failure callback to next live-list read and pin it under INTERVAL."""
+    # The largest interval an operator may configure. Before this lane a
+    # mid-stream failure cost that whole window; the re-poll must not scale
+    # with it, so the interval only ever appears here as the bound to beat.
+    largest_interval = EnvConfig(
+        auth_token="token", user_oid="oid", interval=3600
+    ).interval
+
+    mock_api = MagicMock(spec=RPlayAPI)
+    live_list_reads = []
+    polled_again = ThreadEvent()
+
+    def read_live_list():
+        live_list_reads.append(monotonic())
+        if len(live_list_reads) > 1:
+            polled_again.set()
+        return [_live_stream("creator1")]
+
+    mock_api.get_livestream_status.side_effect = read_live_list
+    monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
+
+    monitor.check_live_streams_and_start_download()
+    session_key = next(iter(monitor.sessions))
+
+    failed_at = monotonic()
+    monitor._on_raw_download_failed(
+        RawDownloadFailed(session_key=session_key, error_message="ffmpeg exited 1")
+    )
+
+    # Bounded wait, not a bare one: a mechanism that deadlocked hangs here
+    # instead of failing the latency assertion below.
+    assert polled_again.wait(timeout=5)
+    repoll_latency = live_list_reads[-1] - failed_at
+
+    # Absolute bound, so it cannot pass by quietly tracking INTERVAL, and it
+    # sits far under even the shortest interval the app accepts.
+    assert repoll_latency < 1.0 < largest_interval
+    monitor.shutdown()
+
+
+def test_failure_while_creator_still_live_schedules_exactly_one_extra_poll(repoll_env):
+    """Test one failure on a still-live creator earns one extra poll, and only one."""
+    mock_api = MagicMock(spec=RPlayAPI)
+    mock_api.get_livestream_status.return_value = [_live_stream("creator1")]
+    monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
+
+    monitor.check_live_streams_and_start_download()
+    session_key = next(iter(monitor.sessions))
+
+    monitor._on_raw_download_failed(
+        RawDownloadFailed(session_key=session_key, error_message="ffmpeg exited 1")
+    )
+    # Quiescence barrier: the queue only empties once the failure and
+    # everything it queued have been applied, so an extra poll would count here.
+    monitor._event_queue.join()
+
+    assert mock_api.get_livestream_status.call_count == 2
+    monitor.shutdown()
+
+
+def test_failure_after_creator_went_offline_schedules_no_extra_poll(repoll_env):
+    """Test a failure for a creator no longer in the live list re-polls nothing."""
+    mock_api = MagicMock(spec=RPlayAPI)
+    mock_api.get_livestream_status.side_effect = [[_live_stream("creator1")], []]
+    monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
+
+    monitor.check_live_streams_and_start_download()
+    session_key = next(iter(monitor.sessions))
+    # The stream ended: the second poll sees an empty live list.
+    monitor.check_live_streams_and_start_download()
+
+    monitor._on_raw_download_failed(
+        RawDownloadFailed(session_key=session_key, error_message="ffmpeg exited 1")
+    )
+    monitor._event_queue.join()
+
+    # Still the two polls this test asked for. A third would also exhaust the
+    # side_effect list, so a stray re-poll cannot hide here.
+    assert mock_api.get_livestream_status.call_count == 2
+    monitor.shutdown()
+
+
+def test_concurrent_failures_merge_into_one_extra_poll(repoll_env):
+    """Test failures landing together share a single extra poll instead of one each."""
+    mock_api = MagicMock(spec=RPlayAPI)
+    mock_api.get_livestream_status.return_value = [
+        _live_stream("creator1", "stream-1"),
+        _live_stream("creator2", "stream-2"),
+    ]
+    monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
+
+    monitor.check_live_streams_and_start_download()
+    session_key_by_creator = {
+        session.creator_oid: key for key, session in monitor.sessions.items()
+    }
+    assert len(session_key_by_creator) == 2
+
+    reached_first_failure = ThreadEvent()
+    release_first_failure = ThreadEvent()
+    original_handle_monitor_event = monitor._handle_monitor_event
+
+    def gated_handle(event):
+        if isinstance(event, RawDownloadFailed) and not reached_first_failure.is_set():
+            reached_first_failure.set()
+            # Hold the control loop so the second failure is already queued
+            # before the first one gets to request its re-poll.
+            assert release_first_failure.wait(timeout=5)
+        return original_handle_monitor_event(event)
+
+    monitor._handle_monitor_event = gated_handle
+
+    monitor._on_raw_download_failed(
+        RawDownloadFailed(
+            session_key=session_key_by_creator["creator1"],
+            error_message="ffmpeg exited 1",
+        )
+    )
+    assert reached_first_failure.wait(timeout=5)
+    monitor._on_raw_download_failed(
+        RawDownloadFailed(
+            session_key=session_key_by_creator["creator2"],
+            error_message="ffmpeg exited 1",
+        )
+    )
+    release_first_failure.set()
+    monitor._event_queue.join()
+
+    # One re-poll re-reads the whole live list, so two failures must not buy
+    # two polls on top of the initial one.
+    assert mock_api.get_livestream_status.call_count == 2
+    monitor.shutdown()
+
+
+def test_failure_handling_never_calls_the_blocking_public_poll(repoll_env):
+    """Test the control loop signals for its re-poll rather than blocking on itself."""
+    mock_api = MagicMock(spec=RPlayAPI)
+    mock_api.get_livestream_status.return_value = [_live_stream("creator1")]
+    monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
+
+    monitor.check_live_streams_and_start_download()
+    session_key = next(iter(monitor.sessions))
+
+    blocking_calls = []
+
+    # Recorded rather than raised: the control loop logs exceptions, so raising
+    # here would be swallowed and the test would pass for the wrong reason.
+    with patch.object(
+        monitor,
+        "check_live_streams_and_start_download",
+        side_effect=lambda: blocking_calls.append("called"),
+    ):
+        monitor._on_raw_download_failed(
+            RawDownloadFailed(session_key=session_key, error_message="ffmpeg exited 1")
+        )
+        monitor._event_queue.join()
+
+    # The public poll waits on the very loop that serves it: calling it from a
+    # failure handler would stall the loop for POLL_WAIT_TIMEOUT_SECONDS.
+    assert blocking_calls == []
+    assert mock_api.get_livestream_status.call_count == 2
+    monitor.shutdown()

--- a/tests/test_monitor_events.py
+++ b/tests/test_monitor_events.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from core.downloader import StreamDownloader
-from core.live_stream_monitor import LiveStreamMonitor
+from core.live_stream_monitor import LiveStreamMonitor, _PollRequested
 from models.config import AppConfig, CreatorProfile
 from models.env import EnvConfig
 from core.rplay import RPlayAPI
@@ -546,8 +546,8 @@ def repoll_env(tmp_path, monkeypatch):
         yield
 
 
-def test_failure_repoll_latency_is_far_below_the_poll_interval(repoll_env):
-    """V5: measure failure callback to next live-list read and pin it under INTERVAL."""
+def test_failure_while_creator_still_live_earns_one_immediate_extra_poll(repoll_env):
+    """Test a still-live failure buys exactly one extra poll, promptly, without blocking."""
     # The largest interval an operator may configure. Before this lane a
     # mid-stream failure cost that whole window; the re-poll must not scale
     # with it, so the interval only ever appears here as the bound to beat.
@@ -571,39 +571,34 @@ def test_failure_repoll_latency_is_far_below_the_poll_interval(repoll_env):
     monitor.check_live_streams_and_start_download()
     session_key = next(iter(monitor.sessions))
 
-    failed_at = monotonic()
-    monitor._on_raw_download_failed(
-        RawDownloadFailed(session_key=session_key, error_message="ffmpeg exited 1")
-    )
+    blocking_calls = []
 
-    # Bounded wait, not a bare one: a mechanism that deadlocked hangs here
-    # instead of failing the latency assertion below.
-    assert polled_again.wait(timeout=5)
-    repoll_latency = live_list_reads[-1] - failed_at
+    # Recorded rather than raised: the control loop logs exceptions, so raising
+    # here would be swallowed and the test would pass for the wrong reason.
+    with patch.object(
+        monitor,
+        "check_live_streams_and_start_download",
+        side_effect=lambda: blocking_calls.append("called"),
+    ):
+        failed_at = monotonic()
+        monitor._on_raw_download_failed(
+            RawDownloadFailed(session_key=session_key, error_message="ffmpeg exited 1")
+        )
+        # Bounded wait, not a bare one: a mechanism that deadlocked hangs here
+        # instead of failing the latency assertion below.
+        assert polled_again.wait(timeout=5)
+        # Quiescence barrier: the queue only empties once the failure and
+        # everything it queued have been applied, so a second extra poll counts.
+        monitor._event_queue.join()
 
-    # Absolute bound, so it cannot pass by quietly tracking INTERVAL, and it
+    # V5: absolute bound, so it cannot pass by quietly tracking INTERVAL, and it
     # sits far under even the shortest interval the app accepts.
-    assert repoll_latency < 1.0 < largest_interval
-    monitor.shutdown()
-
-
-def test_failure_while_creator_still_live_schedules_exactly_one_extra_poll(repoll_env):
-    """Test one failure on a still-live creator earns one extra poll, and only one."""
-    mock_api = MagicMock(spec=RPlayAPI)
-    mock_api.get_livestream_status.return_value = [_live_stream("creator1")]
-    monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
-
-    monitor.check_live_streams_and_start_download()
-    session_key = next(iter(monitor.sessions))
-
-    monitor._on_raw_download_failed(
-        RawDownloadFailed(session_key=session_key, error_message="ffmpeg exited 1")
-    )
-    # Quiescence barrier: the queue only empties once the failure and
-    # everything it queued have been applied, so an extra poll would count here.
-    monitor._event_queue.join()
-
-    assert mock_api.get_livestream_status.call_count == 2
+    assert live_list_reads[1] - failed_at < 1.0 < largest_interval
+    # One re-poll re-reads the whole live list, so one failure earns one poll.
+    assert len(live_list_reads) == 2
+    # The public poll waits on the very loop that serves it: calling it from a
+    # failure handler would stall the loop for POLL_WAIT_TIMEOUT_SECONDS.
+    assert blocking_calls == []
     monitor.shutdown()
 
 
@@ -680,31 +675,148 @@ def test_concurrent_failures_merge_into_one_extra_poll(repoll_env):
     monitor.shutdown()
 
 
-def test_failure_handling_never_calls_the_blocking_public_poll(repoll_env):
-    """Test the control loop signals for its re-poll rather than blocking on itself."""
+def _signal_shutdown_begun(monitor):
+    """Wrap _drain_monitor_events so tests can see shutdown has set its flag."""
+    shutdown_begun = ThreadEvent()
+    original_drain = monitor._drain_monitor_events
+
+    def signalling_drain(timeout):
+        # Shutdown's first act after setting _shutdown_requested is this drain.
+        shutdown_begun.set()
+        return original_drain(timeout)
+
+    monitor._drain_monitor_events = signalling_drain
+    return shutdown_begun
+
+
+def _gate_poll_enqueue(monitor, shutdown_begun):
+    """
+    Hold the next poll enqueue open and invite a shutdown into that gap.
+
+    Returns the event signalling the gate was reached and the _shutdown_requested
+    readings taken at the moment of each poll's put.
+    """
+    reached = ThreadEvent()
+    shutdown_flags = []
+    real_put = monitor._event_queue.put
+
+    def gated_put(event, *args, **kwargs):
+        if isinstance(event, _PollRequested):
+            reached.set()
+            # Serialized under one lock this wait can only time out: shutdown
+            # cannot even set its flag until the put returns. Split across two
+            # lock regions it returns early, with the poll about to be queued
+            # behind the drain that was supposed to be the last one.
+            shutdown_begun.wait(timeout=1.0)
+            shutdown_flags.append(monitor._shutdown_requested)
+        return real_put(event, *args, **kwargs)
+
+    monitor._event_queue.put = gated_put
+    return reached, shutdown_flags
+
+
+def test_retry_enqueue_is_atomic_against_a_shutdown_landing_mid_request(repoll_env):
+    """Test a shutdown cannot slip between the retry request's refusal check and its enqueue."""
     mock_api = MagicMock(spec=RPlayAPI)
-    mock_api.get_livestream_status.return_value = [_live_stream("creator1")]
+    shutdown_flag_at_read = []
+
+    def read_live_list():
+        shutdown_flag_at_read.append(monitor._shutdown_requested)
+        return [_live_stream("creator1")]
+
+    mock_api.get_livestream_status.side_effect = read_live_list
     monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
+    shutdown_begun = _signal_shutdown_begun(monitor)
 
     monitor.check_live_streams_and_start_download()
     session_key = next(iter(monitor.sessions))
 
-    blocking_calls = []
+    reached_enqueue, shutdown_flag_at_enqueue = _gate_poll_enqueue(monitor, shutdown_begun)
+    monitor._on_raw_download_failed(
+        RawDownloadFailed(session_key=session_key, error_message="ffmpeg exited 1")
+    )
+    assert reached_enqueue.wait(timeout=5)
 
-    # Recorded rather than raised: the control loop logs exceptions, so raising
-    # here would be swallowed and the test would pass for the wrong reason.
-    with patch.object(
-        monitor,
-        "check_live_streams_and_start_download",
-        side_effect=lambda: blocking_calls.append("called"),
-    ):
-        monitor._on_raw_download_failed(
-            RawDownloadFailed(session_key=session_key, error_message="ffmpeg exited 1")
-        )
-        monitor._event_queue.join()
+    shutdown_thread = Thread(target=monitor.shutdown, daemon=True)
+    shutdown_thread.start()
+    shutdown_thread.join(timeout=30)
 
-    # The public poll waits on the very loop that serves it: calling it from a
-    # failure handler would stall the loop for POLL_WAIT_TIMEOUT_SECONDS.
-    assert blocking_calls == []
-    assert mock_api.get_livestream_status.call_count == 2
-    monitor.shutdown()
+    assert not shutdown_thread.is_alive()
+    # The check that admitted this poll must still hold when it is queued;
+    # otherwise the poll lands behind a drain that was meant to be the last one.
+    assert shutdown_flag_at_enqueue == [False]
+    # And no retry poll may read the live list once shutdown has begun: that
+    # prolongs shutdown and can still be in flight when api.close() lands.
+    assert True not in shutdown_flag_at_read
+
+
+def test_scheduler_poll_enqueue_is_atomic_against_a_shutdown_landing_mid_request(repoll_env):
+    """Test the refusal window is closed for every poll requester, not just the retry."""
+    mock_api = MagicMock(spec=RPlayAPI)
+    mock_api.get_livestream_status.return_value = [_live_stream("creator1")]
+    monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
+    shutdown_begun = _signal_shutdown_begun(monitor)
+
+    monitor.check_live_streams_and_start_download()
+
+    reached_enqueue, shutdown_flag_at_enqueue = _gate_poll_enqueue(monitor, shutdown_begun)
+    # The scheduler asking for its next poll at the worst possible moment. Both
+    # requesters share one enqueue, which is where the window has to be closed:
+    # guarding only the retry path leaves this one racing api.close().
+    scheduler = Thread(target=monitor.check_live_streams_and_start_download, daemon=True)
+    scheduler.start()
+    assert reached_enqueue.wait(timeout=5)
+
+    shutdown_thread = Thread(target=monitor.shutdown, daemon=True)
+    shutdown_thread.start()
+    shutdown_thread.join(timeout=30)
+    scheduler.join(timeout=5)
+
+    assert not shutdown_thread.is_alive()
+    assert not scheduler.is_alive()
+    assert shutdown_flag_at_enqueue == [False]
+
+
+def test_retry_poll_queued_before_shutdown_is_skipped_when_dequeued(repoll_env):
+    """Test the control loop drops an already-queued retry poll once shutdown has begun."""
+    mock_api = MagicMock(spec=RPlayAPI)
+    mock_api.get_livestream_status.return_value = [_live_stream("creator1")]
+    monitor = LiveStreamMonitor(auth_token="token", user_oid="oid", api=mock_api)
+    shutdown_begun = _signal_shutdown_begun(monitor)
+
+    monitor.check_live_streams_and_start_download()
+
+    loop_parked = ThreadEvent()
+    release_loop = ThreadEvent()
+    original_handle_monitor_event = monitor._handle_monitor_event
+
+    def gated_handle(event):
+        if not loop_parked.is_set():
+            loop_parked.set()
+            assert release_loop.wait(timeout=5)
+        return original_handle_monitor_event(event)
+
+    monitor._handle_monitor_event = gated_handle
+    # Parks the control loop on an event it will discard, so the retry poll
+    # queued below is still waiting when shutdown starts.
+    monitor._on_raw_download_failed(
+        RawDownloadFailed(session_key="no-such-session", error_message="parks the loop")
+    )
+    assert loop_parked.wait(timeout=5)
+
+    # Queued while shutdown had not begun, so the enqueue is legitimate: only
+    # the dequeue can tell that serving it is no longer wanted.
+    assert monitor._request_retry_poll("creator1")
+
+    shutdown_thread = Thread(target=monitor.shutdown, daemon=True)
+    shutdown_thread.start()
+    assert shutdown_begun.wait(timeout=5)
+    release_loop.set()
+    shutdown_thread.join(timeout=30)
+
+    assert not shutdown_thread.is_alive()
+    # Still only the poll this test asked for: the queued retry poll was
+    # dropped rather than served after shutdown began.
+    assert mock_api.get_livestream_status.call_count == 1
+    # Dropped, not wedged: the marker reopens so a live monitor could retry.
+    assert monitor._retry_poll_queued is False


### PR DESCRIPTION
## Summary
When a raw download fails mid-stream, the monitor previously waited for the next scheduled interval before noticing the creator is still live — losing up to INTERVAL seconds of recording. Now a failure earns exactly one immediate extra poll when the creator is still in the most recent live list.

- Failure handler signals via an internal `_PollRequested(retry=True)` event; the control loop performs the poll. The blocking public poll is never called from the handler (it waits on the very loop that serves it — deadlock).
- Concurrent failures deduplicate into one extra poll (`_retry_poll_queued` flag under `_state_lock`); the flag reopens at poll start so a failure during the retry poll can earn the next one.
- Offline creators (absent from the latest live list, `LIVE`-state filtered) schedule nothing.
- Enqueue is serialized against shutdown: refusal check + put share one `_state_lock` region, and a retry poll dequeued after shutdown began is dropped — no live-list read racing `api.close()`. This closes the same unlocked check-then-put window for the scheduler's poll path.
- Scope: `RawDownloadFailed` only. Blocked (paid) and AuthFailed events do not re-poll.

## Acceptance criteria
- [ ] Still-live failure → exactly one immediate extra poll
- [ ] Offline failure → no extra poll
- [ ] Concurrent failures merge into one poll
- [ ] Blocking public poll never invoked from the failure handler
- [ ] Re-poll latency independent of poll INTERVAL (measured via monotonic/Event against interval=3600: < 1s)
- [ ] Retry enqueue/dequeue cannot race graceful shutdown; PR #40 shutdown tests unchanged and green

## Verification
- Full suite 3 consecutive runs: `333 passed in 38.47s` / `333 passed in 38.48s` / `333 passed in 38.47s`
- Mutation checks: 8 targeted mutations (drop lock, drop dequeue skip, drop dedup, drop still-live gate, call blocking poll, delay retry, double enqueue, revert impl) — every one caught by at least one test; each required invariant has a uniquely-owning test
- Dual independent review (L3-calibrated pragmatic + over-engineering pass) + fix round addressing both
