### PR TITLE
chore: sync compose timezone and release metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,10 +482,6 @@ rplay-live-dl/
 │   ├── rplay.py
 │   ├── scheduler.py
 │   └── utils.py
-├── docs/
-│   └── plans/
-│       ├── 2026-03-09-m3u8-retry-timeout-design.md
-│       └── 2026-03-09-m3u8-retry-timeout.md
 ├── models/
 │   ├── config.py
 │   ├── download.py

--- a/README.md
+++ b/README.md
@@ -482,6 +482,10 @@ rplay-live-dl/
 │   ├── rplay.py
 │   ├── scheduler.py
 │   └── utils.py
+├── docs/
+│   └── plans/
+│       ├── 2026-03-09-m3u8-retry-timeout-design.md
+│       └── 2026-03-09-m3u8-retry-timeout.md
 ├── models/
 │   ├── config.py
 │   ├── download.py
@@ -497,6 +501,7 @@ rplay-live-dl/
 │   ├── test_env.py
 │   ├── test_live_stream_monitor.py
 │   ├── test_logger.py
+│   ├── test_main.py
 │   ├── test_merge_flow.py
 │   ├── test_models.py
 │   ├── test_monitor_events.py

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     env_file: .env
     environment:
       - PYTHONUNBUFFERED=1
-      - TZ=Asia/Taipei
+      - TZ=${TZ:-Asia/Taipei}
     volumes:
       - ./config:/app/config
       - ./archive:/app/archive

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 
 import main
 
@@ -12,3 +13,31 @@ def test_version_is_readable():
 def test_version_is_valid_semver():
     """Test that __version__ follows semver (major.minor.patch) format."""
     assert re.match(r"^\d+\.\d+\.\d+", main.__version__)
+
+
+def test_release_version_is_consistent():
+    """Test that release metadata uses the same version in every published location."""
+    root = Path(__file__).resolve().parents[1]
+    versions = {
+        "pyproject.toml": re.search(
+            r'^\s*version\s*=\s*"(\d+\.\d+\.\d+)',
+            (root / "pyproject.toml").read_text(),
+            re.MULTILINE,
+        ).group(1),
+        "docker-compose.yaml": re.search(
+            r"^\s*image:\s+\S+:v?(\d+\.\d+\.\d+)",
+            (root / "docker-compose.yaml").read_text(),
+            re.MULTILINE,
+        ).group(1),
+        "README.md": re.search(
+            r"paverz/rplay-live-dl:v?(\d+\.\d+\.\d+)",
+            (root / "README.md").read_text(),
+        ).group(1),
+    }
+    expected = versions["pyproject.toml"]
+
+    for filename, version in versions.items():
+        assert version == expected, (
+            f"{filename} version {version!r} disagrees with "
+            f"pyproject.toml version {expected!r}"
+        )


### PR DESCRIPTION
## Summary
- `docker-compose.yaml`: timezone is now overridable — `TZ=${TZ:-Asia/Taipei}` (default unchanged).
- `tests/test_release_metadata.py`: new consistency test asserting the release version is identical in `pyproject.toml`, the compose image tag, and the README image tag; failure message names the disagreeing file.
- README project tree updated to the current layout (adds `test_main.py`).

## Acceptance criteria
- [ ] `TZ` env passthrough works; default remains Asia/Taipei
- [ ] Version drift between pyproject/compose/README fails the suite with a file-naming message
- [ ] README tree matches the actual repository layout

## Verification
- Local suite: `337 passed in 38.86s`
