### PR TITLE
fix: validate credentials at startup and dedupe auth-error logs

### DIFF
--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -165,6 +165,8 @@ class LiveStreamMonitor:
         self._monitored_count = 0
         self._check_count = 0
         self._last_status: Dict[str, int] = {"active_downloads": 0, "monitored_live": 0}
+        # ponytail: one bool; re-armed on successful key2 (get_stream_url).
+        self._auth_error_notified = False
 
         # Track per-creator stream session state for M3U8 404 handling
         self._creator_states: Dict[str, CreatorStreamState] = {}
@@ -311,8 +313,10 @@ class LiveStreamMonitor:
             self.logger.warning("Skipping check due to config file error")
             self._mark_check_failed()
         except RPlayAuthError as exc:
-            self.logger.error(f"Authentication error: {exc}")
-            self.logger.error("Please update your AUTH_TOKEN in .env file")
+            self._log_auth_error(
+                f"Authentication error: {exc}",
+                "Please update your AUTH_TOKEN in .env file",
+            )
             self._mark_check_failed()
         except RPlayConnectionError as exc:
             self.logger.warning(f"Connection error (will retry): {exc}")
@@ -451,9 +455,12 @@ class LiveStreamMonitor:
         bind(self.logger, creator_name).info(f'🔴 Live: "{clip(stream.title)}"')
 
         try:
+            stream_url = self.api.get_stream_url(creator_oid)
+            # Successful key2 re-arms auth-error logging for the next failure streak.
+            self._auth_error_notified = False
             self._launch_session_downloader(
                 session=session,
-                stream_url=self.api.get_stream_url(creator_oid),
+                stream_url=stream_url,
                 title=stream.title,
             )
         except Exception as exc:
@@ -514,7 +521,7 @@ class LiveStreamMonitor:
         self._remove_session(session_key)
 
         if isinstance(exc, RPlayAuthError):
-            self.logger.error(
+            self._log_auth_error(
                 f"Auth error for {creator_name}: {exc}. "
                 "Please verify AUTH_TOKEN and USER_OID credentials."
             )
@@ -908,10 +915,20 @@ class LiveStreamMonitor:
             return
 
         self._mark_check_failed()
-        self.logger.error(
+        self._log_auth_error(
             f"🔐 Authentication error while downloading {session.creator_name}: "
             f"{event.error_message}. Please verify AUTH_TOKEN and USER_OID credentials."
         )
+
+    def _log_auth_error(self, *messages: str) -> None:
+        """Log auth errors once per failure streak; repeats go to DEBUG."""
+        if self._auth_error_notified:
+            for message in messages:
+                self.logger.debug(message)
+            return
+        self._auth_error_notified = True
+        for message in messages:
+            self.logger.error(message)
 
     def _handle_raw_download_failed(self, event: RawDownloadFailed) -> None:
         """Clear the failed raw session and re-poll at once if the creator is still live."""

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -314,8 +314,8 @@ class LiveStreamMonitor:
             self._mark_check_failed()
         except RPlayAuthError as exc:
             self._log_auth_error(
-                f"Authentication error: {exc}",
-                "Please update your AUTH_TOKEN in .env file",
+                f"Authentication error: {exc}. "
+                "Please update your AUTH_TOKEN in .env file"
             )
             self._mark_check_failed()
         except RPlayConnectionError as exc:
@@ -920,15 +920,11 @@ class LiveStreamMonitor:
             f"{event.error_message}. Please verify AUTH_TOKEN and USER_OID credentials."
         )
 
-    def _log_auth_error(self, *messages: str) -> None:
+    def _log_auth_error(self, message: str) -> None:
         """Log auth errors once per failure streak; repeats go to DEBUG."""
-        if self._auth_error_notified:
-            for message in messages:
-                self.logger.debug(message)
-            return
+        log = self.logger.debug if self._auth_error_notified else self.logger.error
         self._auth_error_notified = True
-        for message in messages:
-            self.logger.error(message)
+        log(message)
 
     def _handle_raw_download_failed(self, event: RawDownloadFailed) -> None:
         """Clear the failed raw session and re-poll at once if the creator is still live."""

--- a/core/rplay.py
+++ b/core/rplay.py
@@ -235,6 +235,18 @@ class RPlayAPI:
 
         return f"{self.base_url}/live/stream/playlist.m3u8?{params}"
 
+    def validate_credentials(self) -> None:
+        """
+        Verify AUTH_TOKEN/USER_OID by fetching a stream key once.
+
+        Raises:
+            RPlayAuthError: If credentials are invalid or expired
+            RPlayConnectionError: If the request times out or loses connection
+            RPlayAPIError: If the API returns a non-retryable non-auth failure
+        """
+        # ponytail: key2 is the cheapest authenticated call; no parallel health endpoint.
+        self._get_stream_key()
+
     def _get_stream_key(self) -> str:
         """
         Retrieve the authentication key required for stream access.

--- a/core/rplay.py
+++ b/core/rplay.py
@@ -282,7 +282,7 @@ class RPlayAPI:
                     status_code = getattr(response, "status_code", None)
 
                     if self._is_auth_status_code(status_code):
-                        self.logger.error("Authentication failed - token may be expired")
+                        # Caller logs expected auth failures (startup / monitor dedup).
                         raise RPlayAuthError(
                             "Authentication failed. Please check your AUTH_TOKEN."
                         )
@@ -293,7 +293,7 @@ class RPlayAPI:
                     response.raise_for_status()
                     data = response.json()
                     if "authKey" not in data:
-                        self.logger.error("Invalid response: missing authKey")
+                        # Caller logs expected auth failures (startup / monitor dedup).
                         raise RPlayAuthError("Invalid authentication response")
                     return data["authKey"]
 
@@ -314,7 +314,7 @@ class RPlayAPI:
 
         except requests.exceptions.HTTPError as exc:
             if exc.response is not None and exc.response.status_code in (401, 403):
-                self.logger.error("Authentication failed - token may be expired")
+                # Caller logs expected auth failures (startup / monitor dedup).
                 raise RPlayAuthError(
                     "Authentication failed. Please check your AUTH_TOKEN."
                 )

--- a/main.py
+++ b/main.py
@@ -12,8 +12,9 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 from core.downloader import StreamDownloader
-from core.env import EnvConfigError, load_env
+from core.env import EnvConfig, EnvConfigError, load_env
 from core.logger import cleanup_old_logs, configure_logging, setup_logger
+from core.rplay import RPlayAPI, RPlayAPIError, RPlayAuthError, RPlayConnectionError
 from core.scheduler import run_scheduler
 
 
@@ -25,6 +26,43 @@ def _read_version() -> str:
 
 
 __version__ = _read_version()
+
+
+def _validate_startup_credentials(env: EnvConfig, logger: logging.Logger) -> bool:
+    """
+    Validate API credentials once after logging is configured.
+
+    Returns:
+        False when credentials are invalid (caller should exit non-zero).
+        True on success, or when only transient network/API errors occur so the
+        monitor's normal retry loop can own those failures.
+    """
+    api = RPlayAPI(env.auth_token, env.user_oid)
+    try:
+        api.validate_credentials()
+        logger.info("API credentials validated successfully")
+        return True
+    except RPlayAuthError as exc:
+        logger.error(f"Authentication failed: {exc}")
+        logger.error(
+            "Please update AUTH_TOKEN and USER_OID in your .env file, then restart."
+        )
+        return False
+    except RPlayConnectionError as exc:
+        # ponytail: network blips must not block startup; monitor retries.
+        logger.warning(
+            f"Could not verify credentials due to network error "
+            f"(continuing; will retry while running): {exc}"
+        )
+        return True
+    except RPlayAPIError as exc:
+        logger.warning(
+            f"Could not verify credentials due to API error "
+            f"(continuing; will retry while running): {exc}"
+        )
+        return True
+    finally:
+        api.close()
 
 
 def _warn_about_orphaned_downloads(logger: logging.Logger) -> None:
@@ -88,6 +126,9 @@ def main() -> None:
         logger.warning(f"Failed to cleanup old logs: {e}")
 
     _warn_about_orphaned_downloads(logger)
+
+    if not _validate_startup_credentials(env, logger):
+        sys.exit(1)
 
     # Start the scheduler
     try:

--- a/main.py
+++ b/main.py
@@ -11,10 +11,12 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
+from core.config import DEFAULT_CONFIG_PATH, ConfigError, read_app_config
+from core.constants import DEFAULT_RPLAY_API_BASE_URL
 from core.downloader import StreamDownloader
 from core.env import EnvConfig, EnvConfigError, load_env
 from core.logger import cleanup_old_logs, configure_logging, setup_logger
-from core.rplay import RPlayAPI, RPlayAPIError, RPlayAuthError, RPlayConnectionError
+from core.rplay import RPlayAPI, RPlayAPIError, RPlayAuthError
 from core.scheduler import run_scheduler
 
 
@@ -26,43 +28,6 @@ def _read_version() -> str:
 
 
 __version__ = _read_version()
-
-
-def _validate_startup_credentials(env: EnvConfig, logger: logging.Logger) -> bool:
-    """
-    Validate API credentials once after logging is configured.
-
-    Returns:
-        False when credentials are invalid (caller should exit non-zero).
-        True on success, or when only transient network/API errors occur so the
-        monitor's normal retry loop can own those failures.
-    """
-    api = RPlayAPI(env.auth_token, env.user_oid)
-    try:
-        api.validate_credentials()
-        logger.info("API credentials validated successfully")
-        return True
-    except RPlayAuthError as exc:
-        logger.error(f"Authentication failed: {exc}")
-        logger.error(
-            "Please update AUTH_TOKEN and USER_OID in your .env file, then restart."
-        )
-        return False
-    except RPlayConnectionError as exc:
-        # ponytail: network blips must not block startup; monitor retries.
-        logger.warning(
-            f"Could not verify credentials due to network error "
-            f"(continuing; will retry while running): {exc}"
-        )
-        return True
-    except RPlayAPIError as exc:
-        logger.warning(
-            f"Could not verify credentials due to API error "
-            f"(continuing; will retry while running): {exc}"
-        )
-        return True
-    finally:
-        api.close()
 
 
 def _warn_about_orphaned_downloads(logger: logging.Logger) -> None:
@@ -127,8 +92,35 @@ def main() -> None:
 
     _warn_about_orphaned_downloads(logger)
 
-    if not _validate_startup_credentials(env, logger):
+    # Same apiBaseUrl the monitor applies from config.yaml on each poll.
+    try:
+        api_base_url = read_app_config(DEFAULT_CONFIG_PATH).api_base_url
+    except ConfigError as exc:
+        # ponytail: scheduler owns hard config failures; probe with default URL.
+        logger.warning(
+            f"Could not load config for credential check "
+            f"(using default API URL): {exc}"
+        )
+        api_base_url = DEFAULT_RPLAY_API_BASE_URL
+
+    api = RPlayAPI(env.auth_token, env.user_oid, base_url=api_base_url)
+    try:
+        api.validate_credentials()
+        logger.info("API credentials validated successfully")
+    except RPlayAuthError as exc:
+        logger.error(
+            f"Authentication failed: {exc}. "
+            "Please update AUTH_TOKEN and USER_OID in your .env file, then restart."
+        )
         sys.exit(1)
+    except RPlayAPIError as exc:
+        # RPlayConnectionError is an RPlayAPIError; monitor owns retries.
+        logger.warning(
+            f"Could not verify credentials due to API error "
+            f"(continuing; will retry while running): {exc}"
+        )
+    finally:
+        api.close()
 
     # Start the scheduler
     try:

--- a/tests/test_live_stream_monitor.py
+++ b/tests/test_live_stream_monitor.py
@@ -1,5 +1,6 @@
 """Tests for live stream monitor module."""
 
+import logging
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -910,6 +911,116 @@ class TestCheckLiveStreamsErrorHandling:
 
         assert mock_exception.call_count == 1
         assert mock_exception.call_args.args[0] == 'Unexpected error during monitoring: boom'
+
+
+class TestAuthErrorDedup:
+    """Tests for auth-error log deduplication across poll failures."""
+
+    @patch("core.live_stream_monitor.read_config")
+    def test_repeat_auth_failures_log_error_once(self, mock_read_config, caplog):
+        """Test repeated auth failures log ERROR once; repeats are DEBUG."""
+        mock_api = MagicMock(spec=RPlayAPI)
+        mock_read_config.return_value = _runtime_config([])
+        mock_api.get_livestream_status.side_effect = RPlayAuthError("Unauthorized")
+        monitor = LiveStreamMonitor(
+            auth_token="test_token",
+            user_oid="test_oid",
+            api=mock_api,
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="Monitor"):
+            monitor.check_live_streams_and_start_download()
+            monitor.check_live_streams_and_start_download()
+
+        error_auth = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.ERROR and "Authentication error" in r.getMessage()
+        ]
+        debug_auth = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.DEBUG and "Authentication error" in r.getMessage()
+        ]
+        assert len(error_auth) == 1
+        assert len(debug_auth) >= 1
+
+    @patch("core.live_stream_monitor.read_config")
+    def test_successful_key2_rearms_auth_error_logging(
+        self, mock_read_config, mock_api, caplog
+    ):
+        """Test a successful key2 fetch re-arms the next auth-failure ERROR log."""
+        mock_read_config.return_value = _runtime_config(
+            [CreatorProfile(creator_name="TestCreator", creator_oid="test_oid")]
+        )
+        live_stream = MagicMock()
+        live_stream.oid = "stream-1"
+        live_stream.creator_oid = "test_oid"
+        live_stream.stream_state = StreamState.LIVE
+        live_stream.title = "Test Stream"
+        live_stream.stream_start_time = datetime(2026, 3, 6, 12, 0, 0)
+        live_stream.creator_nickname = "TestCreator"
+
+        mock_api.get_livestream_status.side_effect = [
+            RPlayAuthError("Unauthorized"),
+            [live_stream],
+            RPlayAuthError("Unauthorized again"),
+        ]
+        mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
+
+        monitor = LiveStreamMonitor(
+            auth_token="test_token",
+            user_oid="test_oid",
+            api=mock_api,
+        )
+
+        with (
+            caplog.at_level(logging.DEBUG, logger="Monitor"),
+            patch("core.live_stream_monitor.StreamDownloader.download"),
+        ):
+            monitor.check_live_streams_and_start_download()  # auth fail → ERROR
+            monitor.check_live_streams_and_start_download()  # key2 success → re-arm
+            monitor.check_live_streams_and_start_download()  # auth fail → ERROR again
+
+        error_auth = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.ERROR and "Authentication error" in r.getMessage()
+        ]
+        assert len(error_auth) == 2
+        assert monitor._auth_error_notified is True
+
+    def test_start_download_auth_error_dedup(self, mock_api, monitor, caplog):
+        """Test get_stream_url auth failures dedup across start attempts."""
+        mock_api.get_stream_url.side_effect = RPlayAuthError("Unauthorized")
+        mock_stream = MagicMock()
+        mock_stream.creator_oid = "test_oid"
+        mock_stream.title = "Test Stream"
+        mock_stream.stream_start_time = datetime(2026, 3, 6, 12, 0, 0)
+        monitor.monitored_creators["test_oid"] = CreatorProfile(
+            creator_name="TestCreator",
+            creator_oid="test_oid",
+        )
+
+        with caplog.at_level(logging.DEBUG, logger="Monitor"):
+            monitor._start_download(mock_stream)
+            # Second attempt: session may already exist; force a fresh start path
+            monitor.sessions.clear()
+            monitor._active_raw_session_by_creator.clear()
+            monitor._start_download(mock_stream)
+
+        error_auth = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.ERROR and "Auth error for" in r.getMessage()
+        ]
+        debug_auth = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.DEBUG and "Auth error for" in r.getMessage()
+        ]
+        assert len(error_auth) == 1
+        assert len(debug_auth) >= 1
 
 
 class TestGetActiveDownloads:

--- a/tests/test_live_stream_monitor.py
+++ b/tests/test_live_stream_monitor.py
@@ -623,21 +623,41 @@ class TestStartDownload:
         messages = [record.getMessage() for record in caplog.records]
         assert '[TestCreator] 🔴 Live: "Test Stream"' in messages
 
-    def test_start_download_auth_error(self, mock_api, monitor):
-        """Test auth error is logged."""
+    def test_start_download_auth_error(self, mock_api, monitor, caplog):
+        """Test first auth error is ERROR; a repeat is DEBUG-only (dedup)."""
         mock_api.get_stream_url.side_effect = RPlayAuthError("Unauthorized")
         mock_stream = MagicMock()
         mock_stream.creator_oid = "test_oid"
         mock_stream.title = "Test Stream"
+        mock_stream.stream_start_time = datetime(2026, 3, 6, 12, 0, 0)
         monitor.monitored_creators["test_oid"] = CreatorProfile(
             creator_name="TestCreator",
             creator_oid="test_oid",
         )
 
-        with patch('core.live_stream_monitor.StreamDownloader.download') as mock_download:
+        with (
+            caplog.at_level(logging.DEBUG, logger="Monitor"),
+            patch("core.live_stream_monitor.StreamDownloader.download") as mock_download,
+        ):
+            monitor._start_download(mock_stream)
+            # Second attempt: clear session state so the start path runs again.
+            monitor.sessions.clear()
+            monitor._active_raw_session_by_creator.clear()
             monitor._start_download(mock_stream)
 
         mock_download.assert_not_called()
+        error_auth = [
+            r
+            for r in caplog.records
+            if r.levelno >= logging.ERROR and "Auth error for" in r.getMessage()
+        ]
+        debug_auth = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.DEBUG and "Auth error for" in r.getMessage()
+        ]
+        assert len(error_auth) == 1
+        assert len(debug_auth) >= 1
 
     def test_start_download_api_error(self, mock_api, monitor):
         """Test API error is logged as warning."""
@@ -945,54 +965,8 @@ class TestAuthErrorDedup:
         assert len(error_auth) == 1
         assert len(debug_auth) >= 1
 
-    @patch("core.live_stream_monitor.read_config")
-    def test_successful_key2_rearms_auth_error_logging(
-        self, mock_read_config, mock_api, caplog
-    ):
+    def test_successful_key2_rearms_auth_error_logging(self, mock_api, monitor, caplog):
         """Test a successful key2 fetch re-arms the next auth-failure ERROR log."""
-        mock_read_config.return_value = _runtime_config(
-            [CreatorProfile(creator_name="TestCreator", creator_oid="test_oid")]
-        )
-        live_stream = MagicMock()
-        live_stream.oid = "stream-1"
-        live_stream.creator_oid = "test_oid"
-        live_stream.stream_state = StreamState.LIVE
-        live_stream.title = "Test Stream"
-        live_stream.stream_start_time = datetime(2026, 3, 6, 12, 0, 0)
-        live_stream.creator_nickname = "TestCreator"
-
-        mock_api.get_livestream_status.side_effect = [
-            RPlayAuthError("Unauthorized"),
-            [live_stream],
-            RPlayAuthError("Unauthorized again"),
-        ]
-        mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
-
-        monitor = LiveStreamMonitor(
-            auth_token="test_token",
-            user_oid="test_oid",
-            api=mock_api,
-        )
-
-        with (
-            caplog.at_level(logging.DEBUG, logger="Monitor"),
-            patch("core.live_stream_monitor.StreamDownloader.download"),
-        ):
-            monitor.check_live_streams_and_start_download()  # auth fail → ERROR
-            monitor.check_live_streams_and_start_download()  # key2 success → re-arm
-            monitor.check_live_streams_and_start_download()  # auth fail → ERROR again
-
-        error_auth = [
-            r
-            for r in caplog.records
-            if r.levelno >= logging.ERROR and "Authentication error" in r.getMessage()
-        ]
-        assert len(error_auth) == 2
-        assert monitor._auth_error_notified is True
-
-    def test_start_download_auth_error_dedup(self, mock_api, monitor, caplog):
-        """Test get_stream_url auth failures dedup across start attempts."""
-        mock_api.get_stream_url.side_effect = RPlayAuthError("Unauthorized")
         mock_stream = MagicMock()
         mock_stream.creator_oid = "test_oid"
         mock_stream.title = "Test Stream"
@@ -1001,26 +975,31 @@ class TestAuthErrorDedup:
             creator_name="TestCreator",
             creator_oid="test_oid",
         )
+        mock_api.get_stream_url.side_effect = [
+            RPlayAuthError("Unauthorized"),
+            "http://example.com/stream.m3u8",
+            RPlayAuthError("Unauthorized again"),
+        ]
 
-        with caplog.at_level(logging.DEBUG, logger="Monitor"):
-            monitor._start_download(mock_stream)
-            # Second attempt: session may already exist; force a fresh start path
+        with (
+            caplog.at_level(logging.DEBUG, logger="Monitor"),
+            patch("core.live_stream_monitor.StreamDownloader.download"),
+        ):
+            monitor._start_download(mock_stream)  # auth fail → ERROR
             monitor.sessions.clear()
             monitor._active_raw_session_by_creator.clear()
-            monitor._start_download(mock_stream)
+            monitor._start_download(mock_stream)  # key2 success → re-arm
+            monitor.sessions.clear()
+            monitor._active_raw_session_by_creator.clear()
+            monitor._start_download(mock_stream)  # auth fail → ERROR again
 
         error_auth = [
             r
             for r in caplog.records
             if r.levelno >= logging.ERROR and "Auth error for" in r.getMessage()
         ]
-        debug_auth = [
-            r
-            for r in caplog.records
-            if r.levelno == logging.DEBUG and "Auth error for" in r.getMessage()
-        ]
-        assert len(error_auth) == 1
-        assert len(debug_auth) >= 1
+        assert len(error_auth) == 2
+        assert monitor._auth_error_notified is True
 
 
 class TestGetActiveDownloads:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,8 +5,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from main import _warn_about_orphaned_downloads, main
+from core.rplay import RPlayAPIError, RPlayAuthError, RPlayConnectionError
+from main import _validate_startup_credentials, _warn_about_orphaned_downloads, main
 from models.env import EnvConfig
+
+
+def _valid_env() -> EnvConfig:
+    return EnvConfig(auth_token="test_token", user_oid="test_oid", interval=60)
 
 
 def test_warns_about_each_kind_of_leftover(tmp_path, monkeypatch, caplog):
@@ -88,3 +93,109 @@ def test_main_invalid_log_level_exits_before_setup_logger(monkeypatch, capsys):
     assert secret_oid not in captured.err
     assert secret_token not in captured.out
     assert secret_oid not in captured.out
+
+
+def test_validate_startup_credentials_success(monkeypatch):
+    """Test credential validation returns True on success."""
+    logger = MagicMock(spec=logging.Logger)
+    api = MagicMock()
+    monkeypatch.setattr("main.RPlayAPI", MagicMock(return_value=api))
+
+    assert _validate_startup_credentials(_valid_env(), logger) is True
+    api.validate_credentials.assert_called_once_with()
+    api.close.assert_called_once_with()
+
+
+def test_validate_startup_credentials_auth_failure(monkeypatch):
+    """Test credential validation returns False on auth failure."""
+    logger = MagicMock(spec=logging.Logger)
+    api = MagicMock()
+    api.validate_credentials.side_effect = RPlayAuthError(
+        "Authentication failed. Please check your AUTH_TOKEN."
+    )
+    monkeypatch.setattr("main.RPlayAPI", MagicMock(return_value=api))
+
+    assert _validate_startup_credentials(_valid_env(), logger) is False
+    assert any("Authentication failed" in str(c) for c in logger.error.call_args_list)
+    api.close.assert_called_once_with()
+
+
+def test_validate_startup_credentials_network_does_not_block(monkeypatch):
+    """Test network errors allow startup (monitor owns retries)."""
+    logger = MagicMock(spec=logging.Logger)
+    api = MagicMock()
+    api.validate_credentials.side_effect = RPlayConnectionError("Request timed out")
+    monkeypatch.setattr("main.RPlayAPI", MagicMock(return_value=api))
+
+    assert _validate_startup_credentials(_valid_env(), logger) is True
+    logger.warning.assert_called()
+    api.close.assert_called_once_with()
+
+
+def test_validate_startup_credentials_api_error_does_not_block(monkeypatch):
+    """Test non-auth API errors allow startup."""
+    logger = MagicMock(spec=logging.Logger)
+    api = MagicMock()
+    api.validate_credentials.side_effect = RPlayAPIError("HTTP error: 500")
+    monkeypatch.setattr("main.RPlayAPI", MagicMock(return_value=api))
+
+    assert _validate_startup_credentials(_valid_env(), logger) is True
+    logger.warning.assert_called()
+
+
+def test_main_exits_nonzero_on_auth_failure(monkeypatch, capsys):
+    """Test main exits before the scheduler when credentials are invalid."""
+    monkeypatch.setenv("AUTH_TOKEN", "test-token")
+    monkeypatch.setenv("USER_OID", "test-oid")
+    monkeypatch.setattr("main.load_dotenv", lambda: None)
+    monkeypatch.setattr(
+        EnvConfig,
+        "model_config",
+        {**EnvConfig.model_config, "env_file": None},
+    )
+    monkeypatch.setattr("main.configure_logging", MagicMock())
+    monkeypatch.setattr(
+        "main.setup_logger", MagicMock(return_value=MagicMock(spec=logging.Logger))
+    )
+    monkeypatch.setattr("main.cleanup_old_logs", MagicMock(return_value=0))
+    monkeypatch.setattr("main._warn_about_orphaned_downloads", MagicMock())
+    monkeypatch.setattr(
+        "main._validate_startup_credentials",
+        MagicMock(return_value=False),
+    )
+    run_scheduler_mock = MagicMock()
+    monkeypatch.setattr("main.run_scheduler", run_scheduler_mock)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code == 1
+    run_scheduler_mock.assert_not_called()
+
+
+def test_main_starts_scheduler_when_credentials_ok(monkeypatch):
+    """Test main reaches the scheduler after successful credential validation."""
+    monkeypatch.setenv("AUTH_TOKEN", "test-token")
+    monkeypatch.setenv("USER_OID", "test-oid")
+    monkeypatch.setattr("main.load_dotenv", lambda: None)
+    monkeypatch.setattr(
+        EnvConfig,
+        "model_config",
+        {**EnvConfig.model_config, "env_file": None},
+    )
+    monkeypatch.setattr("main.configure_logging", MagicMock())
+    monkeypatch.setattr(
+        "main.setup_logger", MagicMock(return_value=MagicMock(spec=logging.Logger))
+    )
+    monkeypatch.setattr("main.cleanup_old_logs", MagicMock(return_value=0))
+    monkeypatch.setattr("main._warn_about_orphaned_downloads", MagicMock())
+    monkeypatch.setattr(
+        "main._validate_startup_credentials",
+        MagicMock(return_value=True),
+    )
+    run_scheduler_mock = MagicMock()
+    monkeypatch.setattr("main.run_scheduler", run_scheduler_mock)
+
+    main()
+
+    run_scheduler_mock.assert_called_once()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,12 +6,83 @@ from unittest.mock import MagicMock
 import pytest
 
 from core.rplay import RPlayAPIError, RPlayAuthError, RPlayConnectionError
-from main import _validate_startup_credentials, _warn_about_orphaned_downloads, main
+from main import _warn_about_orphaned_downloads, main
+from models.config import AppConfig
 from models.env import EnvConfig
 
 
-def _valid_env() -> EnvConfig:
-    return EnvConfig(auth_token="test_token", user_oid="test_oid", interval=60)
+def _patch_main_startup(monkeypatch, *, api_side_effect=None, calls=None):
+    """Patch main() deps; optionally record call order in ``calls``."""
+    monkeypatch.setenv("AUTH_TOKEN", "test-token")
+    monkeypatch.setenv("USER_OID", "test-oid")
+    monkeypatch.setattr("main.load_dotenv", lambda: None)
+    monkeypatch.setattr(
+        EnvConfig,
+        "model_config",
+        {**EnvConfig.model_config, "env_file": None},
+    )
+
+    def _track(name, fn):
+        def wrapper(*args, **kwargs):
+            if calls is not None:
+                calls.append(name)
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    monkeypatch.setattr(
+        "main.configure_logging",
+        _track("configure_logging", MagicMock()),
+    )
+    monkeypatch.setattr(
+        "main.setup_logger",
+        _track("setup_logger", MagicMock(return_value=MagicMock(spec=logging.Logger))),
+    )
+    monkeypatch.setattr("main.cleanup_old_logs", MagicMock(return_value=0))
+    monkeypatch.setattr("main._warn_about_orphaned_downloads", MagicMock())
+    monkeypatch.setattr(
+        "main.read_app_config",
+        MagicMock(
+            return_value=AppConfig(
+                api_base_url="https://api.example.com",
+                creators=[],
+            )
+        ),
+    )
+
+    api = MagicMock()
+    if api_side_effect is not None:
+        api.validate_credentials.side_effect = api_side_effect
+
+    def _make_api(*args, **kwargs):
+        if calls is not None:
+            calls.append("validate_credentials")
+        return api
+
+    # Track when the validation client is constructed (stands in for the probe).
+    monkeypatch.setattr("main.RPlayAPI", _make_api)
+
+    run_scheduler_mock = MagicMock()
+    if calls is not None:
+
+        def _run_scheduler(*args, **kwargs):
+            calls.append("run_scheduler")
+            return run_scheduler_mock(*args, **kwargs)
+
+        monkeypatch.setattr("main.run_scheduler", _run_scheduler)
+    else:
+        monkeypatch.setattr("main.run_scheduler", run_scheduler_mock)
+
+    # load_env runs before configure_logging; record it via a thin wrapper.
+    real_load_env = __import__("main", fromlist=["load_env"]).load_env
+
+    def _load_env():
+        if calls is not None:
+            calls.append("load_env")
+        return real_load_env()
+
+    monkeypatch.setattr("main.load_env", _load_env)
+    return api, run_scheduler_mock
 
 
 def test_warns_about_each_kind_of_leftover(tmp_path, monkeypatch, caplog):
@@ -95,107 +166,66 @@ def test_main_invalid_log_level_exits_before_setup_logger(monkeypatch, capsys):
     assert secret_oid not in captured.out
 
 
-def test_validate_startup_credentials_success(monkeypatch):
-    """Test credential validation returns True on success."""
-    logger = MagicMock(spec=logging.Logger)
-    api = MagicMock()
-    monkeypatch.setattr("main.RPlayAPI", MagicMock(return_value=api))
+def test_main_success_order(monkeypatch):
+    """Test main runs load_env → logging → credential validation → scheduler."""
+    calls: list[str] = []
+    api, _ = _patch_main_startup(monkeypatch, calls=calls)
 
-    assert _validate_startup_credentials(_valid_env(), logger) is True
+    main()
+
+    assert calls == [
+        "load_env",
+        "configure_logging",
+        "setup_logger",
+        "validate_credentials",
+        "run_scheduler",
+    ]
     api.validate_credentials.assert_called_once_with()
     api.close.assert_called_once_with()
 
 
-def test_validate_startup_credentials_auth_failure(monkeypatch):
-    """Test credential validation returns False on auth failure."""
+def test_main_auth_failure_exits_once_and_never_starts_scheduler(monkeypatch):
+    """Test auth failure exits 1 with exactly one ERROR; scheduler never starts."""
     logger = MagicMock(spec=logging.Logger)
-    api = MagicMock()
-    api.validate_credentials.side_effect = RPlayAuthError(
-        "Authentication failed. Please check your AUTH_TOKEN."
+    api, run_scheduler_mock = _patch_main_startup(
+        monkeypatch,
+        api_side_effect=RPlayAuthError(
+            "Authentication failed. Please check your AUTH_TOKEN."
+        ),
     )
-    monkeypatch.setattr("main.RPlayAPI", MagicMock(return_value=api))
-
-    assert _validate_startup_credentials(_valid_env(), logger) is False
-    assert any("Authentication failed" in str(c) for c in logger.error.call_args_list)
-    api.close.assert_called_once_with()
-
-
-def test_validate_startup_credentials_network_does_not_block(monkeypatch):
-    """Test network errors allow startup (monitor owns retries)."""
-    logger = MagicMock(spec=logging.Logger)
-    api = MagicMock()
-    api.validate_credentials.side_effect = RPlayConnectionError("Request timed out")
-    monkeypatch.setattr("main.RPlayAPI", MagicMock(return_value=api))
-
-    assert _validate_startup_credentials(_valid_env(), logger) is True
-    logger.warning.assert_called()
-    api.close.assert_called_once_with()
-
-
-def test_validate_startup_credentials_api_error_does_not_block(monkeypatch):
-    """Test non-auth API errors allow startup."""
-    logger = MagicMock(spec=logging.Logger)
-    api = MagicMock()
-    api.validate_credentials.side_effect = RPlayAPIError("HTTP error: 500")
-    monkeypatch.setattr("main.RPlayAPI", MagicMock(return_value=api))
-
-    assert _validate_startup_credentials(_valid_env(), logger) is True
-    logger.warning.assert_called()
-
-
-def test_main_exits_nonzero_on_auth_failure(monkeypatch, capsys):
-    """Test main exits before the scheduler when credentials are invalid."""
-    monkeypatch.setenv("AUTH_TOKEN", "test-token")
-    monkeypatch.setenv("USER_OID", "test-oid")
-    monkeypatch.setattr("main.load_dotenv", lambda: None)
-    monkeypatch.setattr(
-        EnvConfig,
-        "model_config",
-        {**EnvConfig.model_config, "env_file": None},
-    )
-    monkeypatch.setattr("main.configure_logging", MagicMock())
-    monkeypatch.setattr(
-        "main.setup_logger", MagicMock(return_value=MagicMock(spec=logging.Logger))
-    )
-    monkeypatch.setattr("main.cleanup_old_logs", MagicMock(return_value=0))
-    monkeypatch.setattr("main._warn_about_orphaned_downloads", MagicMock())
-    monkeypatch.setattr(
-        "main._validate_startup_credentials",
-        MagicMock(return_value=False),
-    )
-    run_scheduler_mock = MagicMock()
-    monkeypatch.setattr("main.run_scheduler", run_scheduler_mock)
+    monkeypatch.setattr("main.setup_logger", MagicMock(return_value=logger))
 
     with pytest.raises(SystemExit) as exc_info:
         main()
 
     assert exc_info.value.code == 1
     run_scheduler_mock.assert_not_called()
+    assert logger.error.call_count == 1
+    error_msg = str(logger.error.call_args.args[0])
+    assert "Authentication failed" in error_msg
+    assert "AUTH_TOKEN" in error_msg
+    api.close.assert_called_once_with()
 
 
-def test_main_starts_scheduler_when_credentials_ok(monkeypatch):
-    """Test main reaches the scheduler after successful credential validation."""
-    monkeypatch.setenv("AUTH_TOKEN", "test-token")
-    monkeypatch.setenv("USER_OID", "test-oid")
-    monkeypatch.setattr("main.load_dotenv", lambda: None)
-    monkeypatch.setattr(
-        EnvConfig,
-        "model_config",
-        {**EnvConfig.model_config, "env_file": None},
+@pytest.mark.parametrize(
+    "side_effect",
+    [
+        RPlayConnectionError("Request timed out"),
+        RPlayAPIError("HTTP error: 500"),
+    ],
+)
+def test_main_transient_api_error_continues_to_scheduler(monkeypatch, side_effect):
+    """Test network/API probe failures warn and still start the scheduler."""
+    logger = MagicMock(spec=logging.Logger)
+    api, run_scheduler_mock = _patch_main_startup(
+        monkeypatch,
+        api_side_effect=side_effect,
     )
-    monkeypatch.setattr("main.configure_logging", MagicMock())
-    monkeypatch.setattr(
-        "main.setup_logger", MagicMock(return_value=MagicMock(spec=logging.Logger))
-    )
-    monkeypatch.setattr("main.cleanup_old_logs", MagicMock(return_value=0))
-    monkeypatch.setattr("main._warn_about_orphaned_downloads", MagicMock())
-    monkeypatch.setattr(
-        "main._validate_startup_credentials",
-        MagicMock(return_value=True),
-    )
-    run_scheduler_mock = MagicMock()
-    monkeypatch.setattr("main.run_scheduler", run_scheduler_mock)
+    monkeypatch.setattr("main.setup_logger", MagicMock(return_value=logger))
 
     main()
 
     run_scheduler_mock.assert_called_once()
+    logger.warning.assert_called()
+    logger.error.assert_not_called()
+    api.close.assert_called_once_with()

--- a/tests/test_rplay.py
+++ b/tests/test_rplay.py
@@ -136,6 +136,39 @@ class TestGetStreamUrl:
         assert "playlist.m3u8" in url
 
 
+class TestValidateCredentials:
+    """Tests for validate_credentials method."""
+
+    def test_success_calls_get_stream_key(self):
+        """Test successful validation obtains a stream key."""
+        api = RPlayAPI(auth_token="test", user_oid="test")
+
+        with patch.object(api, "_get_stream_key", return_value="key") as mock_key:
+            api.validate_credentials()
+
+        mock_key.assert_called_once_with()
+
+    def test_auth_failure_raises_auth_error(self):
+        """Test auth failure propagates as RPlayAuthError."""
+        api = RPlayAPI(auth_token="test", user_oid="test")
+
+        with patch.object(
+            api, "_get_stream_key", side_effect=RPlayAuthError("Authentication failed")
+        ):
+            with pytest.raises(RPlayAuthError, match="Authentication failed"):
+                api.validate_credentials()
+
+    def test_network_failure_raises_connection_error(self):
+        """Test network failure propagates as RPlayConnectionError."""
+        api = RPlayAPI(auth_token="test", user_oid="test")
+
+        with patch.object(
+            api, "_get_stream_key", side_effect=RPlayConnectionError("Request timed out")
+        ):
+            with pytest.raises(RPlayConnectionError, match="timed out"):
+                api.validate_credentials()
+
+
 class TestGetStreamKey:
     """Tests for _get_stream_key method."""
 

--- a/tests/test_rplay.py
+++ b/tests/test_rplay.py
@@ -137,36 +137,33 @@ class TestGetStreamUrl:
 
 
 class TestValidateCredentials:
-    """Tests for validate_credentials method."""
+    """Tests for the public credential-validation seam."""
 
-    def test_success_calls_get_stream_key(self):
-        """Test successful validation obtains a stream key."""
+    def test_success(self):
+        """Test successful validation when key2 returns an authKey."""
         api = RPlayAPI(auth_token="test", user_oid="test")
 
-        with patch.object(api, "_get_stream_key", return_value="key") as mock_key:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"authKey": "stream-key"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(api._session, "get", return_value=mock_response):
             api.validate_credentials()
 
-        mock_key.assert_called_once_with()
-
     def test_auth_failure_raises_auth_error(self):
-        """Test auth failure propagates as RPlayAuthError."""
+        """Test 401 from key2 raises RPlayAuthError without API-layer ERROR log."""
         api = RPlayAPI(auth_token="test", user_oid="test")
 
-        with patch.object(
-            api, "_get_stream_key", side_effect=RPlayAuthError("Authentication failed")
-        ):
-            with pytest.raises(RPlayAuthError, match="Authentication failed"):
-                api.validate_credentials()
+        mock_response = MagicMock()
+        mock_response.status_code = 401
 
-    def test_network_failure_raises_connection_error(self):
-        """Test network failure propagates as RPlayConnectionError."""
-        api = RPlayAPI(auth_token="test", user_oid="test")
+        with patch.object(api._session, "get", return_value=mock_response):
+            with patch.object(api.logger, "error") as mock_error:
+                with pytest.raises(RPlayAuthError, match="Authentication failed"):
+                    api.validate_credentials()
 
-        with patch.object(
-            api, "_get_stream_key", side_effect=RPlayConnectionError("Request timed out")
-        ):
-            with pytest.raises(RPlayConnectionError, match="timed out"):
-                api.validate_credentials()
+        mock_error.assert_not_called()
 
 
 class TestGetStreamKey:


### PR DESCRIPTION
## Summary
Startup now validates API credentials once, and the monitor stops repeating auth-error spam.

- `RPlayAPI.validate_credentials()`: minimal public seam over the cheapest authenticated call (key2 fetch).
- `main.py`: after env + logging are configured, validate once against the same `apiBaseUrl` the monitor uses from `config.yaml` (falls back to the default URL with a warning if config can't be read — the scheduler owns hard config failures). Auth failure → exactly ONE actionable error line, exit 1. Transient network/API errors do NOT block startup; the monitor's retry loop owns those (`RPlayConnectionError` is an `RPlayAPIError` — one continue branch).
- API layer no longer logs ERROR for expected auth failures — it raises only, and the caller reports: startup logs once; the monitor logs on state change only (first failure logs, repeats demoted to DEBUG, a successful key2 fetch re-arms the next report).
- At the key2 endpoint 401 and 403 both mean auth. Paid-content restriction is playlist 404 with a valid key2 and never reaches this call; downloader classification is untouched.

## Acceptance criteria
- [ ] Invalid credentials at startup → single error line naming AUTH_TOKEN action, exit 1, scheduler never starts
- [ ] Startup order pinned by test: load_env → configure_logging → setup_logger → validate_credentials → scheduler
- [ ] Network/API blips at startup → warn + continue
- [ ] Startup probe uses config.yaml apiBaseUrl (same endpoint the monitor polls)
- [ ] Repeated monitor auth failures log once; recovery re-arms; next failure logs again
- [ ] No token/key2 material in any error path

## Verification
- Full suite 3 consecutive runs: `344 passed in 38.47s` / `344 passed in 38.49s` / `344 passed in 38.50s`
- Single-error-line proven by test: `logger.error.call_count == 1` + scheduler never called
- Dual independent review (L3-calibrated pragmatic + over-engineering pass) + fix round addressing all findings
