### PR TITLE
feat: promote quiet-night heartbeat log to INFO

### DIFF
--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -558,7 +558,7 @@ class LiveStreamMonitor:
                 f"{monitored_live}/{monitored_count} monitored creator(s) live"
             )
         elif periodic_heartbeat and monitored_count > 0:
-            self.logger.debug(
+            self.logger.info(
                 f"📊 Checked {total_live} live stream(s), "
                 f"none of {monitored_count} monitored creator(s) are live"
             )

--- a/tests/test_live_stream_monitor.py
+++ b/tests/test_live_stream_monitor.py
@@ -1597,13 +1597,14 @@ class TestHeartbeatLogOptimization:
             api=mock_api,
         )
 
-        with patch.object(monitor.logger, 'debug') as mock_debug:
+        with patch.object(monitor.logger, 'info') as mock_info:
             # Run multiple checks
             for _ in range(10):
                 monitor.check_live_streams_and_start_download()
 
-        # Should have at least one periodic heartbeat (debug level)
-        heartbeat_logs = [c for c in mock_debug.call_args_list if "Checked" in str(c) or "heartbeat" in str(c).lower()]
+        # Should have at least one periodic heartbeat (info level, so quiet
+        # nights still show life in default INFO logs)
+        heartbeat_logs = [c for c in mock_info.call_args_list if "Checked" in str(c)]
         assert len(heartbeat_logs) >= 1
 
 


### PR DESCRIPTION
## Summary
The every-10th-check quiet-night heartbeat logged at DEBUG, so default INFO logs showed no sign of life during long idle stretches. Promote that one log call to INFO. Frequency unchanged (once per 10 checks); state-change status logs unchanged.

## Acceptance criteria
- [ ] With no live creators, INFO logs show a heartbeat every 10th check
- [ ] No new log volume beyond the level promotion

## Verification
- Full suite: `348 passed in 39.18s`
