### PR TITLE
feat: skip new recordings when free disk is below MIN_FREE_DISK_GB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,7 @@ USER_OID=
 # Optional: monitor poll interval in seconds (10-3600)
 INTERVAL=60
 
-# Optional: minimum free disk space in GiB before starting a recording
-# 0 disables the guard; negative or non-numeric values abort startup
+# Optional: min free disk GiB before recording (0 disables; invalid aborts startup)
 MIN_FREE_DISK_GB=5
 
 # Optional: application log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ USER_OID=
 # Optional: monitor poll interval in seconds (10-3600)
 INTERVAL=60
 
+# Optional: minimum free disk space in GiB before starting a recording
+# 0 disables the guard; negative or non-numeric values abort startup
+MIN_FREE_DISK_GB=5
+
 # Optional: application log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 LOG_LEVEL=INFO
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ USER_OID=your_user_oid
 # Optional: monitor poll interval in seconds (10-3600)
 INTERVAL=60
 
+# Optional: minimum free disk space in GiB before starting a recording
+# 0 disables the guard; negative or non-numeric values abort startup
+MIN_FREE_DISK_GB=5
+
 # Optional: application log level
 LOG_LEVEL=INFO
 
@@ -200,6 +204,7 @@ Environment variables:
 | `AUTH_TOKEN` | yes | none | non-empty | RPlay auth token used for API and stream access |
 | `USER_OID` | yes | none | non-empty | Your RPlay user identifier |
 | `INTERVAL` | no | `60` | integer `10`-`3600` | Poll interval in seconds |
+| `MIN_FREE_DISK_GB` | no | `5` | non-negative number; `0` disables the guard; invalid/negative values abort startup | Skip starting a new recording when free space on the output volume is below this many GiB |
 | `LOG_LEVEL` | no | `INFO` | `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`; invalid values abort startup with a non-zero exit | Console and file log verbosity |
 | `LOG_YTDLP_INTERNAL` | no | `false` | truthy: `1`, `true`, `yes`, `on`; falsy: `0`, `false`, `no`, `off`, empty; other values abort startup | Enables noisy yt-dlp internal debug lines |
 | `LOG_MAX_SIZE_MB` | no | `5` | integer `1`-`100` | Maximum size of each log file before rotation |

--- a/README.md
+++ b/README.md
@@ -176,8 +176,6 @@ USER_OID=your_user_oid
 # Optional: monitor poll interval in seconds (10-3600)
 INTERVAL=60
 
-# Optional: minimum free disk space in GiB before starting a recording
-# 0 disables the guard; negative or non-numeric values abort startup
 MIN_FREE_DISK_GB=5
 
 # Optional: application log level

--- a/core/constants.py
+++ b/core/constants.py
@@ -41,6 +41,9 @@ DEFAULT_LOG_BACKUP_COUNT = 5
 DEFAULT_LOG_RETENTION_DAYS = 30
 DEFAULT_LOG_YTDLP_INTERNAL = False
 
+# Minimum free disk space (GiB) before starting a recording; 0 disables
+DEFAULT_MIN_FREE_DISK_GB = 5.0
+
 __all__ = [
     "RPLAY_SITE_URL",
     "DEFAULT_RPLAY_API_BASE_URL",
@@ -59,4 +62,5 @@ __all__ = [
     "DEFAULT_LOG_BACKUP_COUNT",
     "DEFAULT_LOG_RETENTION_DAYS",
     "DEFAULT_LOG_YTDLP_INTERNAL",
+    "DEFAULT_MIN_FREE_DISK_GB",
 ]

--- a/core/env.py
+++ b/core/env.py
@@ -47,12 +47,13 @@ def load_env() -> EnvConfig:
             field = error.get("loc", [None])[0]
             error_type = error.get("type", "")
 
+            # Convert field name to env var format (e.g., auth_token -> AUTH_TOKEN)
+            env_var = str(field).upper() if field else "UNKNOWN"
             if error_type == "missing":
-                # Convert field name to env var format (e.g., auth_token -> AUTH_TOKEN)
-                env_var = field.upper() if field else "UNKNOWN"
                 missing_vars.append(env_var)
             else:
-                other_errors.append(error.get("msg", str(error)))
+                # Prefix so users can act on the offending variable name.
+                other_errors.append(f"{env_var}: {error.get('msg', str(error))}")
 
         if missing_vars:
             raise EnvConfigError(

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -1,5 +1,6 @@
 """Live stream monitoring module."""
 
+import shutil
 import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -11,6 +12,7 @@ from typing import Callable, Dict, List, Optional, Set, Union
 
 from pathvalidate import sanitize_filename
 
+from core.constants import DEFAULT_MIN_FREE_DISK_GB
 from models.config import CreatorProfile
 from models.download import (
     DownloadSession,
@@ -113,6 +115,7 @@ class LiveStreamMonitor:
         config_path: str = DEFAULT_CONFIG_PATH,
         api: Optional[RPlayAPI] = None,
         merge_timeout_seconds: int = DEFAULT_MERGE_TIMEOUT_SECONDS,
+        min_free_disk_gb: float = DEFAULT_MIN_FREE_DISK_GB,
     ) -> None:
         """
         Initialize monitor with authentication and configuration.
@@ -123,10 +126,12 @@ class LiveStreamMonitor:
             config_path: Path to creator profiles YAML config
             api: Optional RPlayAPI instance for dependency injection (testing)
             merge_timeout_seconds: Timeout for ffmpeg merge commands
+            min_free_disk_gb: Minimum free disk space in GiB before recording; 0 disables
         """
         self.api = api if api is not None else RPlayAPI(auth_token, user_oid)
         self.config_path = config_path
         self.merge_timeout_seconds = merge_timeout_seconds
+        self.min_free_disk_gb = min_free_disk_gb
         self.monitored_creators: Dict[str, CreatorProfile] = {}
         self.sessions: Dict[str, DownloadSession] = {}
         self.latest_stream_oid_by_creator: Dict[str, str] = {}
@@ -444,6 +449,10 @@ class LiveStreamMonitor:
 
         creator_name = creator_profile.creator_name
         creator_oid = stream.creator_oid
+        output_dir = self._build_session_output_dir(creator_name)
+        if not self._has_enough_free_disk(output_dir):
+            return
+
         recording_started_at = datetime.now(timezone.utc)
 
         self._update_creator_stream_state(stream)
@@ -465,6 +474,38 @@ class LiveStreamMonitor:
             )
         except Exception as exc:
             self._handle_start_download_error(session.session_key, creator_name, exc)
+
+    def _has_enough_free_disk(self, output_dir: Path) -> bool:
+        """Return False when free space is below the configured threshold."""
+        if self.min_free_disk_gb <= 0:
+            return True
+
+        check_path = output_dir
+        while not check_path.exists():
+            parent = check_path.parent
+            if parent == check_path:
+                break
+            check_path = parent
+
+        try:
+            free_bytes = shutil.disk_usage(check_path).free
+        except OSError as exc:
+            # ponytail: availability beats blocking recordings on a broken statvfs
+            self.logger.warning(
+                f"Could not check free disk space for {output_dir} "
+                f"(via {check_path}): {exc}; allowing session"
+            )
+            return True
+
+        free_gb = free_bytes / (1024 ** 3)
+        if free_gb < self.min_free_disk_gb:
+            self.logger.error(
+                f"Insufficient free disk space to start recording: "
+                f"path={output_dir}, free={free_gb:.2f} GiB, "
+                f"required={self.min_free_disk_gb:g} GiB"
+            )
+            return False
+        return True
 
     def _launch_session_downloader(
         self,

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -450,8 +450,31 @@ class LiveStreamMonitor:
         creator_name = creator_profile.creator_name
         creator_oid = stream.creator_oid
         output_dir = self._build_session_output_dir(creator_name)
-        if not self._has_enough_free_disk(output_dir):
-            return
+
+        if self.min_free_disk_gb > 0:
+            check_path = next(
+                p for p in (output_dir, *output_dir.parents) if p.exists()
+            )
+            try:
+                free_bytes = shutil.disk_usage(check_path).free
+            except OSError as exc:
+                # ponytail: availability beats blocking recordings on a broken statvfs
+                self.logger.warning(
+                    f"Could not check free disk space for {output_dir} "
+                    f"(via {check_path}): {exc}; allowing session"
+                )
+            else:
+                required_bytes = int(self.min_free_disk_gb * (1024 ** 3))
+                if free_bytes < required_bytes:
+                    free_gb = free_bytes / (1024 ** 3)
+                    self.logger.error(
+                        f"Insufficient free disk space to start recording: "
+                        f"path={output_dir}, free={free_gb:.4f} GiB "
+                        f"({free_bytes} bytes), "
+                        f"required={self.min_free_disk_gb:g} GiB "
+                        f"({required_bytes} bytes)"
+                    )
+                    return
 
         recording_started_at = datetime.now(timezone.utc)
 
@@ -474,38 +497,6 @@ class LiveStreamMonitor:
             )
         except Exception as exc:
             self._handle_start_download_error(session.session_key, creator_name, exc)
-
-    def _has_enough_free_disk(self, output_dir: Path) -> bool:
-        """Return False when free space is below the configured threshold."""
-        if self.min_free_disk_gb <= 0:
-            return True
-
-        check_path = output_dir
-        while not check_path.exists():
-            parent = check_path.parent
-            if parent == check_path:
-                break
-            check_path = parent
-
-        try:
-            free_bytes = shutil.disk_usage(check_path).free
-        except OSError as exc:
-            # ponytail: availability beats blocking recordings on a broken statvfs
-            self.logger.warning(
-                f"Could not check free disk space for {output_dir} "
-                f"(via {check_path}): {exc}; allowing session"
-            )
-            return True
-
-        free_gb = free_bytes / (1024 ** 3)
-        if free_gb < self.min_free_disk_gb:
-            self.logger.error(
-                f"Insufficient free disk space to start recording: "
-                f"path={output_dir}, free={free_gb:.2f} GiB, "
-                f"required={self.min_free_disk_gb:g} GiB"
-            )
-            return False
-        return True
 
     def _launch_session_downloader(
         self,

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -63,7 +63,11 @@ class LiveStreamScheduler:
         self.env = env
         self.version = version
         self.git_sha = os.getenv("APP_GIT_SHA", "").strip()
-        self.monitor = LiveStreamMonitor(self.env.auth_token, self.env.user_oid)
+        self.monitor = LiveStreamMonitor(
+            self.env.auth_token,
+            self.env.user_oid,
+            min_free_disk_gb=self.env.min_free_disk_gb,
+        )
         self.scheduler = BlockingScheduler()
         self._stopped = False
 

--- a/models/env.py
+++ b/models/env.py
@@ -82,6 +82,8 @@ class EnvConfig(BaseSettings):
     min_free_disk_gb: float = Field(
         default=DEFAULT_MIN_FREE_DISK_GB,
         description="Minimum free disk space in GiB before starting a recording; 0 disables",
+        ge=0,
+        allow_inf_nan=False,
     )
 
     model_config = SettingsConfigDict(
@@ -137,21 +139,3 @@ class EnvConfig(BaseSettings):
             "1, true, yes, on, 0, false, no, off (or empty); "
             f"got {v!r}"
         )
-
-    @field_validator("min_free_disk_gb", mode="before")
-    @classmethod
-    def validate_min_free_disk_gb(cls, v: object) -> float:
-        """Reject negative or non-numeric MIN_FREE_DISK_GB at startup."""
-        if v is None or (isinstance(v, str) and not v.strip()):
-            return DEFAULT_MIN_FREE_DISK_GB
-        try:
-            value = float(v)
-        except (TypeError, ValueError) as exc:
-            raise ValueError(
-                f"MIN_FREE_DISK_GB must be a non-negative number; got {v!r}"
-            ) from exc
-        if value < 0:
-            raise ValueError(
-                f"MIN_FREE_DISK_GB must be a non-negative number; got {v!r}"
-            )
-        return value

--- a/models/env.py
+++ b/models/env.py
@@ -14,6 +14,7 @@ from core.constants import (
     DEFAULT_LOG_MAX_SIZE_MB,
     DEFAULT_LOG_RETENTION_DAYS,
     DEFAULT_LOG_YTDLP_INTERNAL,
+    DEFAULT_MIN_FREE_DISK_GB,
 )
 
 # Validation vocabulary lives beside the only consumer (this model).
@@ -78,6 +79,10 @@ class EnvConfig(BaseSettings):
         ge=1,
         le=365,
     )
+    min_free_disk_gb: float = Field(
+        default=DEFAULT_MIN_FREE_DISK_GB,
+        description="Minimum free disk space in GiB before starting a recording; 0 disables",
+    )
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -132,3 +137,21 @@ class EnvConfig(BaseSettings):
             "1, true, yes, on, 0, false, no, off (or empty); "
             f"got {v!r}"
         )
+
+    @field_validator("min_free_disk_gb", mode="before")
+    @classmethod
+    def validate_min_free_disk_gb(cls, v: object) -> float:
+        """Reject negative or non-numeric MIN_FREE_DISK_GB at startup."""
+        if v is None or (isinstance(v, str) and not v.strip()):
+            return DEFAULT_MIN_FREE_DISK_GB
+        try:
+            value = float(v)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"MIN_FREE_DISK_GB must be a non-negative number; got {v!r}"
+            ) from exc
+        if value < 0:
+            raise ValueError(
+                f"MIN_FREE_DISK_GB must be a non-negative number; got {v!r}"
+            )
+        return value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,21 @@
 """Pytest configuration and fixtures."""
 
 import logging
+from types import SimpleNamespace
 
 import pytest
+
+_GIB = 1024 ** 3
+
+
+@pytest.fixture(autouse=True)
+def plenty_of_free_disk(monkeypatch):
+    """Keep suite independent of real free disk (MIN_FREE_DISK_GB default is 5).
+
+    Guard-specific tests override this by patching disk_usage themselves.
+    """
+    usage = SimpleNamespace(total=100 * _GIB, used=10 * _GIB, free=90 * _GIB)
+    monkeypatch.setattr("shutil.disk_usage", lambda path: usage)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,21 +1,8 @@
 """Pytest configuration and fixtures."""
 
 import logging
-from types import SimpleNamespace
 
 import pytest
-
-_GIB = 1024 ** 3
-
-
-@pytest.fixture(autouse=True)
-def plenty_of_free_disk(monkeypatch):
-    """Keep suite independent of real free disk (MIN_FREE_DISK_GB default is 5).
-
-    Guard-specific tests override this by patching disk_usage themselves.
-    """
-    usage = SimpleNamespace(total=100 * _GIB, used=10 * _GIB, free=90 * _GIB)
-    monkeypatch.setattr("shutil.disk_usage", lambda path: usage)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -297,26 +297,6 @@ class TestLogConfigEnvVars:
 class TestMinFreeDiskGbEnv:
     """Tests for MIN_FREE_DISK_GB environment variable."""
 
-    def test_default_is_five(self, no_dotenv_file):
-        """Test default MIN_FREE_DISK_GB is 5."""
-        no_dotenv_file.setenv("AUTH_TOKEN", "test_token")
-        no_dotenv_file.setenv("USER_OID", "test_oid")
-        no_dotenv_file.delenv("MIN_FREE_DISK_GB", raising=False)
-
-        config = load_env()
-
-        assert config.min_free_disk_gb == 5.0
-
-    def test_zero_disables_guard(self, monkeypatch):
-        """Test MIN_FREE_DISK_GB=0 is accepted (disables the guard)."""
-        monkeypatch.setenv("AUTH_TOKEN", "test_token")
-        monkeypatch.setenv("USER_OID", "test_oid")
-        monkeypatch.setenv("MIN_FREE_DISK_GB", "0")
-
-        config = load_env()
-
-        assert config.min_free_disk_gb == 0.0
-
     def test_custom_value(self, monkeypatch):
         """Test custom MIN_FREE_DISK_GB value."""
         monkeypatch.setenv("AUTH_TOKEN", "test_token")
@@ -327,24 +307,25 @@ class TestMinFreeDiskGbEnv:
 
         assert config.min_free_disk_gb == 10.5
 
-    def test_negative_raises(self, monkeypatch):
-        """Test negative MIN_FREE_DISK_GB is a startup validation error."""
+    def test_zero_accepted(self, monkeypatch):
+        """Test MIN_FREE_DISK_GB=0 is accepted (disables the guard)."""
         monkeypatch.setenv("AUTH_TOKEN", "test_token")
         monkeypatch.setenv("USER_OID", "test_oid")
-        monkeypatch.setenv("MIN_FREE_DISK_GB", "-1")
+        monkeypatch.setenv("MIN_FREE_DISK_GB", "0")
 
-        with pytest.raises(ValueError) as exc_info:
-            load_env()
+        config = load_env()
 
-        message = str(exc_info.value)
-        assert "Invalid environment configuration" in message
-        assert "MIN_FREE_DISK_GB" in message
+        assert config.min_free_disk_gb == 0.0
 
-    def test_garbage_raises(self, monkeypatch):
-        """Test non-numeric MIN_FREE_DISK_GB is a startup validation error."""
+    @pytest.mark.parametrize(
+        "raw",
+        ["", "nan", "inf", "-inf", "-1"],
+    )
+    def test_invalid_values_raise_actionable_error(self, monkeypatch, raw):
+        """Blank, non-finite, and negative values fail startup with field name."""
         monkeypatch.setenv("AUTH_TOKEN", "test_token")
         monkeypatch.setenv("USER_OID", "test_oid")
-        monkeypatch.setenv("MIN_FREE_DISK_GB", "plenty")
+        monkeypatch.setenv("MIN_FREE_DISK_GB", raw)
 
         with pytest.raises(ValueError) as exc_info:
             load_env()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -292,3 +292,63 @@ class TestLogConfigEnvVars:
         config = load_env()
 
         assert config.log_retention_days == 365
+
+
+class TestMinFreeDiskGbEnv:
+    """Tests for MIN_FREE_DISK_GB environment variable."""
+
+    def test_default_is_five(self, no_dotenv_file):
+        """Test default MIN_FREE_DISK_GB is 5."""
+        no_dotenv_file.setenv("AUTH_TOKEN", "test_token")
+        no_dotenv_file.setenv("USER_OID", "test_oid")
+        no_dotenv_file.delenv("MIN_FREE_DISK_GB", raising=False)
+
+        config = load_env()
+
+        assert config.min_free_disk_gb == 5.0
+
+    def test_zero_disables_guard(self, monkeypatch):
+        """Test MIN_FREE_DISK_GB=0 is accepted (disables the guard)."""
+        monkeypatch.setenv("AUTH_TOKEN", "test_token")
+        monkeypatch.setenv("USER_OID", "test_oid")
+        monkeypatch.setenv("MIN_FREE_DISK_GB", "0")
+
+        config = load_env()
+
+        assert config.min_free_disk_gb == 0.0
+
+    def test_custom_value(self, monkeypatch):
+        """Test custom MIN_FREE_DISK_GB value."""
+        monkeypatch.setenv("AUTH_TOKEN", "test_token")
+        monkeypatch.setenv("USER_OID", "test_oid")
+        monkeypatch.setenv("MIN_FREE_DISK_GB", "10.5")
+
+        config = load_env()
+
+        assert config.min_free_disk_gb == 10.5
+
+    def test_negative_raises(self, monkeypatch):
+        """Test negative MIN_FREE_DISK_GB is a startup validation error."""
+        monkeypatch.setenv("AUTH_TOKEN", "test_token")
+        monkeypatch.setenv("USER_OID", "test_oid")
+        monkeypatch.setenv("MIN_FREE_DISK_GB", "-1")
+
+        with pytest.raises(ValueError) as exc_info:
+            load_env()
+
+        message = str(exc_info.value)
+        assert "Invalid environment configuration" in message
+        assert "MIN_FREE_DISK_GB" in message
+
+    def test_garbage_raises(self, monkeypatch):
+        """Test non-numeric MIN_FREE_DISK_GB is a startup validation error."""
+        monkeypatch.setenv("AUTH_TOKEN", "test_token")
+        monkeypatch.setenv("USER_OID", "test_oid")
+        monkeypatch.setenv("MIN_FREE_DISK_GB", "plenty")
+
+        with pytest.raises(ValueError) as exc_info:
+            load_env()
+
+        message = str(exc_info.value)
+        assert "Invalid environment configuration" in message
+        assert "MIN_FREE_DISK_GB" in message

--- a/tests/test_live_stream_monitor.py
+++ b/tests/test_live_stream_monitor.py
@@ -20,6 +20,8 @@ from models.download import (
 )
 from models.rplay import CreatorStreamState, StreamState
 
+_GIB = 1024 ** 3
+
 
 def _runtime_config(creators):
     """Build AppConfig test data with the default hot-reload API base URL."""
@@ -691,6 +693,126 @@ class TestStartDownload:
             monitor._start_download(mock_stream)
 
         mock_download.assert_not_called()
+
+
+class TestMinFreeDiskGuard:
+    """Tests for the minimum free-disk guard before session creation."""
+
+    def _stream_and_profile(self, monitor):
+        mock_stream = MagicMock()
+        mock_stream.creator_oid = "test_oid"
+        mock_stream.title = "Test Stream"
+        mock_stream.stream_start_time = datetime(2026, 3, 6, 12, 0, 0)
+        monitor.monitored_creators["test_oid"] = CreatorProfile(
+            creator_name="TestCreator",
+            creator_oid="test_oid",
+        )
+        return mock_stream
+
+    def test_below_threshold_blocks_session_and_logs_error(self, mock_api, caplog):
+        """Below-threshold free space skips session creation and logs one error."""
+        monitor = LiveStreamMonitor(
+            auth_token="test_token",
+            user_oid="test_oid",
+            api=mock_api,
+            min_free_disk_gb=5,
+        )
+        mock_stream = self._stream_and_profile(monitor)
+        usage = MagicMock(free=2 * _GIB, total=100 * _GIB, used=98 * _GIB)
+
+        with (
+            patch("core.live_stream_monitor.shutil.disk_usage", return_value=usage) as mock_usage,
+            patch("core.live_stream_monitor.StreamDownloader.download") as mock_download,
+            caplog.at_level(logging.ERROR, logger="Monitor"),
+        ):
+            monitor._start_download(mock_stream)
+
+        mock_usage.assert_called_once()
+        mock_download.assert_not_called()
+        mock_api.get_stream_url.assert_not_called()
+        assert monitor.sessions == {}
+        error_msgs = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelno >= logging.ERROR and "Insufficient free disk space" in r.getMessage()
+        ]
+        assert len(error_msgs) == 1
+        assert "path=" in error_msgs[0]
+        assert "free=" in error_msgs[0]
+        assert "required=5" in error_msgs[0]
+
+    def test_above_threshold_proceeds(self, mock_api):
+        """Above-threshold free space allows the session to start."""
+        monitor = LiveStreamMonitor(
+            auth_token="test_token",
+            user_oid="test_oid",
+            api=mock_api,
+            min_free_disk_gb=5,
+        )
+        mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
+        mock_stream = self._stream_and_profile(monitor)
+        usage = MagicMock(free=50 * _GIB, total=100 * _GIB, used=50 * _GIB)
+
+        with (
+            patch("core.live_stream_monitor.shutil.disk_usage", return_value=usage) as mock_usage,
+            patch("core.live_stream_monitor.StreamDownloader.download") as mock_download,
+        ):
+            monitor._start_download(mock_stream)
+
+        mock_usage.assert_called_once()
+        mock_download.assert_called_once()
+        assert len(monitor.sessions) == 1
+
+    def test_zero_disables_guard(self, mock_api):
+        """MIN_FREE_DISK_GB=0 skips disk_usage and still starts the session."""
+        monitor = LiveStreamMonitor(
+            auth_token="test_token",
+            user_oid="test_oid",
+            api=mock_api,
+            min_free_disk_gb=0,
+        )
+        mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
+        mock_stream = self._stream_and_profile(monitor)
+
+        with (
+            patch("core.live_stream_monitor.shutil.disk_usage") as mock_usage,
+            patch("core.live_stream_monitor.StreamDownloader.download") as mock_download,
+        ):
+            monitor._start_download(mock_stream)
+
+        mock_usage.assert_not_called()
+        mock_download.assert_called_once()
+        assert len(monitor.sessions) == 1
+
+    def test_disk_usage_oserror_allows_session_with_warning(self, mock_api, caplog):
+        """OSError from disk_usage logs a warning and allows the session."""
+        monitor = LiveStreamMonitor(
+            auth_token="test_token",
+            user_oid="test_oid",
+            api=mock_api,
+            min_free_disk_gb=5,
+        )
+        mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
+        mock_stream = self._stream_and_profile(monitor)
+
+        with (
+            patch(
+                "core.live_stream_monitor.shutil.disk_usage",
+                side_effect=OSError("statvfs failed"),
+            ),
+            patch("core.live_stream_monitor.StreamDownloader.download") as mock_download,
+            caplog.at_level(logging.WARNING, logger="Monitor"),
+        ):
+            monitor._start_download(mock_stream)
+
+        mock_download.assert_called_once()
+        assert len(monitor.sessions) == 1
+        warnings = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "Could not check free disk space" in r.getMessage()
+        ]
+        assert len(warnings) == 1
 
 
 class TestCheckLiveStreams:

--- a/tests/test_live_stream_monitor.py
+++ b/tests/test_live_stream_monitor.py
@@ -2,6 +2,7 @@
 
 import logging
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -26,6 +27,13 @@ _GIB = 1024 ** 3
 def _runtime_config(creators):
     """Build AppConfig test data with the default hot-reload API base URL."""
     return AppConfig(api_base_url="https://api.rplay.live", creators=creators)
+
+
+@pytest.fixture(autouse=True)
+def plenty_of_free_disk(monkeypatch):
+    """Keep this module independent of real free disk (default guard is 5 GiB)."""
+    usage = SimpleNamespace(total=100 * _GIB, used=10 * _GIB, free=90 * _GIB)
+    monkeypatch.setattr("shutil.disk_usage", lambda path: usage)
 
 
 @pytest.fixture
@@ -709,16 +717,12 @@ class TestMinFreeDiskGuard:
         )
         return mock_stream
 
-    def test_below_threshold_blocks_session_and_logs_error(self, mock_api, caplog):
+    def test_below_threshold_blocks_session_and_logs_error(self, mock_api, monitor, caplog):
         """Below-threshold free space skips session creation and logs one error."""
-        monitor = LiveStreamMonitor(
-            auth_token="test_token",
-            user_oid="test_oid",
-            api=mock_api,
-            min_free_disk_gb=5,
-        )
+        monitor.min_free_disk_gb = 5
         mock_stream = self._stream_and_profile(monitor)
-        usage = MagicMock(free=2 * _GIB, total=100 * _GIB, used=98 * _GIB)
+        free_bytes = 2 * _GIB
+        usage = MagicMock(free=free_bytes, total=100 * _GIB, used=98 * _GIB)
 
         with (
             patch("core.live_stream_monitor.shutil.disk_usage", return_value=usage) as mock_usage,
@@ -738,39 +742,12 @@ class TestMinFreeDiskGuard:
         ]
         assert len(error_msgs) == 1
         assert "path=" in error_msgs[0]
-        assert "free=" in error_msgs[0]
+        assert f"({free_bytes} bytes)" in error_msgs[0]
         assert "required=5" in error_msgs[0]
 
-    def test_above_threshold_proceeds(self, mock_api):
-        """Above-threshold free space allows the session to start."""
-        monitor = LiveStreamMonitor(
-            auth_token="test_token",
-            user_oid="test_oid",
-            api=mock_api,
-            min_free_disk_gb=5,
-        )
-        mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
-        mock_stream = self._stream_and_profile(monitor)
-        usage = MagicMock(free=50 * _GIB, total=100 * _GIB, used=50 * _GIB)
-
-        with (
-            patch("core.live_stream_monitor.shutil.disk_usage", return_value=usage) as mock_usage,
-            patch("core.live_stream_monitor.StreamDownloader.download") as mock_download,
-        ):
-            monitor._start_download(mock_stream)
-
-        mock_usage.assert_called_once()
-        mock_download.assert_called_once()
-        assert len(monitor.sessions) == 1
-
-    def test_zero_disables_guard(self, mock_api):
+    def test_zero_disables_guard(self, mock_api, monitor):
         """MIN_FREE_DISK_GB=0 skips disk_usage and still starts the session."""
-        monitor = LiveStreamMonitor(
-            auth_token="test_token",
-            user_oid="test_oid",
-            api=mock_api,
-            min_free_disk_gb=0,
-        )
+        monitor.min_free_disk_gb = 0
         mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
         mock_stream = self._stream_and_profile(monitor)
 
@@ -784,14 +761,9 @@ class TestMinFreeDiskGuard:
         mock_download.assert_called_once()
         assert len(monitor.sessions) == 1
 
-    def test_disk_usage_oserror_allows_session_with_warning(self, mock_api, caplog):
+    def test_disk_usage_oserror_allows_session_with_warning(self, mock_api, monitor, caplog):
         """OSError from disk_usage logs a warning and allows the session."""
-        monitor = LiveStreamMonitor(
-            auth_token="test_token",
-            user_oid="test_oid",
-            api=mock_api,
-            min_free_disk_gb=5,
-        )
+        monitor.min_free_disk_gb = 5
         mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
         mock_stream = self._stream_and_profile(monitor)
 

--- a/tests/test_monitor_events.py
+++ b/tests/test_monitor_events.py
@@ -4,6 +4,7 @@ import inspect
 
 from threading import Event as ThreadEvent, Thread
 from time import monotonic
+from types import SimpleNamespace
 
 from models.download import MergeCompleted
 
@@ -24,6 +25,15 @@ from models.download import (
     SessionState,
 )
 from models.rplay import StreamState
+
+_GIB = 1024 ** 3
+
+
+@pytest.fixture(autouse=True)
+def plenty_of_free_disk(monkeypatch):
+    """Keep this module independent of real free disk (default guard is 5 GiB)."""
+    usage = SimpleNamespace(total=100 * _GIB, used=10 * _GIB, free=90 * _GIB)
+    monkeypatch.setattr("shutil.disk_usage", lambda path: usage)
 
 
 def test_raw_completion_event_immediately_submits_merge(tmp_path):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -54,7 +54,11 @@ class TestLiveStreamSchedulerInit:
         """Test that LiveStreamMonitor is created."""
         mock_scheduler_class, mock_monitor_class = patched_scheduler_deps
         scheduler = LiveStreamScheduler(env=mock_env, logger=mock_logger, version="1.0.0")
-        mock_monitor_class.assert_called_once_with("test_token", "test_oid")
+        mock_monitor_class.assert_called_once_with(
+            "test_token",
+            "test_oid",
+            min_free_disk_gb=5.0,
+        )
         assert scheduler.monitor is mock_monitor_class.return_value
 
     def test_init_creates_scheduler(self, patched_scheduler_deps, mock_env, mock_logger):


### PR DESCRIPTION
## Summary
New recordings are skipped when the output disk is below a configurable free-space floor, so a full disk can no longer start doomed sessions.

- `MIN_FREE_DISK_GB` (default 5, `0` disables) owned by `EnvConfig` with pydantic-native validation: `ge=0`, `allow_inf_nan=False` — blank/NaN/±inf/negative are startup errors whose message names the variable (`MIN_FREE_DISK_GB: Input should be a finite number`).
- Single choke point: `_start_download` checks `shutil.disk_usage` on the session output dir (nearest existing parent) before creating a session. Below threshold → one error naming path, free space (GiB + exact bytes), and threshold; session not created; other creators unaffected; re-checked on later polls.
- `disk_usage` OSError → warn and allow (availability over blocking on a broken statvfs; marked `# ponytail:`).
- Documented in README + `.env.example`.

## Acceptance criteria
- [ ] Below threshold: no session created, one diagnosable error per poll
- [ ] `0` disables (no disk_usage call)
- [ ] Invalid values (blank/NaN/inf/negative) abort startup naming the variable
- [ ] statvfs failure never blocks recordings

## Verification
- Full suite 3 consecutive runs: `358 passed in 38.59s` / `38.52s` / `38.27s`
- Dual independent review (L3-calibrated pragmatic + over-engineering pass) + fix round addressing all findings (incl. Critical NaN/Inf validation gap)
