### PR TITLE
fix: cache stream key2 once per poll cycle

### DIFF
--- a/core/downloader.py
+++ b/core/downloader.py
@@ -6,6 +6,7 @@ with support for concurrent downloads and automatic file management.
 """
 
 import logging
+import re
 import threading
 import time
 from datetime import datetime
@@ -36,6 +37,9 @@ __all__ = [
     "StreamDownloader",
 ]
 
+# Playlist URLs embed key2; mask before any yt-dlp message reaches the logger.
+_KEY2_QUERY_RE = re.compile(r"key2=[^&\s\"']+")
+
 
 class _RetryableDownloadTaskError(Exception):
     """Internal exception used to retry a full yt-dlp task."""
@@ -56,7 +60,8 @@ class _YtDlpLoggerBridge:
         normalized = str(message).strip()
         if not normalized:
             return
-        self._downloader.log.debug(f"yt-dlp: {normalized}")
+        masked = _KEY2_QUERY_RE.sub("key2=REDACTED", normalized)
+        self._downloader.log.debug(f"yt-dlp: {masked}")
 
     def debug(self, message: Any) -> None:
         self._emit(message)

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -169,6 +169,8 @@ class LiveStreamMonitor:
         self._auth_error_notified = False
         # ponytail: per-cycle only, no TTL — key2 is user-scoped, not creator-scoped.
         self._cycle_stream_key: Optional[str] = None
+        # Unrecovered key2 auth failure this cycle → mark poll unhealthy at end.
+        self._cycle_key_fetch_auth_failed = False
 
         # Track per-creator stream session state for M3U8 404 handling
         self._creator_states: Dict[str, CreatorStreamState] = {}
@@ -297,6 +299,7 @@ class LiveStreamMonitor:
         """Check active streams and start new downloads on the control loop."""
         # Unconditional: never carry key2 across poll cycles (incl. A3 retry polls).
         self._cycle_stream_key = None
+        self._cycle_key_fetch_auth_failed = False
         try:
             self._update_downloaders()
             live_streams = self.api.get_livestream_status()
@@ -312,7 +315,11 @@ class LiveStreamMonitor:
             live_creator_oids = {stream.creator_oid for stream in live_streams}
             self._cleanup_offline_creator_states(live_creator_oids)
             self._log_status_summary(len(live_streams), monitored_live)
-            self._mark_check_succeeded()
+            # Match playlist-401 health: unrecovered key2 auth fails the cycle.
+            if self._cycle_key_fetch_auth_failed:
+                self._mark_check_failed()
+            else:
+                self._mark_check_succeeded()
         except ConfigError:
             self.logger.warning("Skipping check due to config file error")
             self._mark_check_failed()
@@ -459,7 +466,18 @@ class LiveStreamMonitor:
         bind(self.logger, creator_name).info(f'🔴 Live: "{clip(stream.title)}"')
 
         try:
-            stream_url = self._get_cycle_stream_url(creator_oid)
+            if self._cycle_stream_key is not None:
+                stream_key = self._cycle_stream_key
+            else:
+                # Real fetch: only successes are cached; failures leave the slot empty.
+                stream_key = self.api._get_stream_key()
+                self._cycle_stream_key = stream_key
+                # A later success clears an earlier unrecovered auth failure this cycle.
+                self._cycle_key_fetch_auth_failed = False
+                # Successful key2 re-arms auth-error logging for the next failure streak.
+                # Cache hits skip re-arm — they follow a success already in this cycle.
+                self._auth_error_notified = False
+            stream_url = self.api.get_stream_url(creator_oid, stream_key=stream_key)
             self._launch_session_downloader(
                 session=session,
                 stream_url=stream_url,
@@ -467,22 +485,6 @@ class LiveStreamMonitor:
             )
         except Exception as exc:
             self._handle_start_download_error(session.session_key, creator_name, exc)
-
-    def _get_cycle_stream_url(self, creator_oid: str) -> str:
-        """Build a stream URL, reusing this poll cycle's key2 after the first success."""
-        if self._cycle_stream_key is not None:
-            return self.api.get_stream_url(
-                creator_oid,
-                stream_key=self._cycle_stream_key,
-            )
-
-        # Real fetch: only successes are cached; failures leave the slot empty.
-        stream_key = self.api._get_stream_key()
-        self._cycle_stream_key = stream_key
-        # Successful key2 re-arms auth-error logging for the next failure streak.
-        # Cache hits skip re-arm — they follow a success already in this cycle.
-        self._auth_error_notified = False
-        return self.api.get_stream_url(creator_oid, stream_key=stream_key)
 
     def _launch_session_downloader(
         self,
@@ -539,6 +541,7 @@ class LiveStreamMonitor:
         self._remove_session(session_key)
 
         if isinstance(exc, RPlayAuthError):
+            self._cycle_key_fetch_auth_failed = True
             self._log_auth_error(
                 f"Auth error for {creator_name}: {exc}. "
                 "Please verify AUTH_TOKEN and USER_OID credentials."

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -167,6 +167,8 @@ class LiveStreamMonitor:
         self._last_status: Dict[str, int] = {"active_downloads": 0, "monitored_live": 0}
         # ponytail: one bool; re-armed on successful key2 (get_stream_url).
         self._auth_error_notified = False
+        # ponytail: per-cycle only, no TTL — key2 is user-scoped, not creator-scoped.
+        self._cycle_stream_key: Optional[str] = None
 
         # Track per-creator stream session state for M3U8 404 handling
         self._creator_states: Dict[str, CreatorStreamState] = {}
@@ -293,6 +295,8 @@ class LiveStreamMonitor:
 
     def _run_poll_cycle(self) -> None:
         """Check active streams and start new downloads on the control loop."""
+        # Unconditional: never carry key2 across poll cycles (incl. A3 retry polls).
+        self._cycle_stream_key = None
         try:
             self._update_downloaders()
             live_streams = self.api.get_livestream_status()
@@ -455,9 +459,7 @@ class LiveStreamMonitor:
         bind(self.logger, creator_name).info(f'🔴 Live: "{clip(stream.title)}"')
 
         try:
-            stream_url = self.api.get_stream_url(creator_oid)
-            # Successful key2 re-arms auth-error logging for the next failure streak.
-            self._auth_error_notified = False
+            stream_url = self._get_cycle_stream_url(creator_oid)
             self._launch_session_downloader(
                 session=session,
                 stream_url=stream_url,
@@ -465,6 +467,22 @@ class LiveStreamMonitor:
             )
         except Exception as exc:
             self._handle_start_download_error(session.session_key, creator_name, exc)
+
+    def _get_cycle_stream_url(self, creator_oid: str) -> str:
+        """Build a stream URL, reusing this poll cycle's key2 after the first success."""
+        if self._cycle_stream_key is not None:
+            return self.api.get_stream_url(
+                creator_oid,
+                stream_key=self._cycle_stream_key,
+            )
+
+        # Real fetch: only successes are cached; failures leave the slot empty.
+        stream_key = self.api._get_stream_key()
+        self._cycle_stream_key = stream_key
+        # Successful key2 re-arms auth-error logging for the next failure streak.
+        # Cache hits skip re-arm — they follow a success already in this cycle.
+        self._auth_error_notified = False
+        return self.api.get_stream_url(creator_oid, stream_key=stream_key)
 
     def _launch_session_downloader(
         self,

--- a/core/rplay.py
+++ b/core/rplay.py
@@ -6,7 +6,7 @@ including methods for retrieving stream status and generating stream URLs.
 """
 
 import time
-from typing import List
+from typing import List, Optional
 from urllib.parse import urlencode
 
 import requests
@@ -212,12 +212,17 @@ class RPlayAPI:
 
         return []
 
-    def get_stream_url(self, creator_oid: str) -> str:
+    def get_stream_url(
+        self,
+        creator_oid: str,
+        stream_key: Optional[str] = None,
+    ) -> str:
         """
         Generate the playback URL for a specific creator's livestream.
 
         Args:
             creator_oid: Unique identifier of the streamer
+            stream_key: Optional pre-fetched key2. When omitted, key2 is fetched.
 
         Returns:
             str: Complete M3U8 format stream URL with authentication parameters
@@ -226,7 +231,8 @@ class RPlayAPI:
             RPlayAuthError: If authentication fails
             RPlayAPIError: If stream key retrieval fails
         """
-        stream_key = self._get_stream_key()
+        if stream_key is None:
+            stream_key = self._get_stream_key()
 
         params = urlencode({
             "creatorOid": creator_oid,

--- a/core/rplay.py
+++ b/core/rplay.py
@@ -6,7 +6,7 @@ including methods for retrieving stream status and generating stream URLs.
 """
 
 import time
-from typing import List, Optional
+from typing import List
 from urllib.parse import urlencode
 
 import requests
@@ -212,28 +212,17 @@ class RPlayAPI:
 
         return []
 
-    def get_stream_url(
-        self,
-        creator_oid: str,
-        stream_key: Optional[str] = None,
-    ) -> str:
+    def get_stream_url(self, creator_oid: str, stream_key: str) -> str:
         """
         Generate the playback URL for a specific creator's livestream.
 
         Args:
             creator_oid: Unique identifier of the streamer
-            stream_key: Optional pre-fetched key2. When omitted, key2 is fetched.
+            stream_key: Pre-fetched key2 authentication value
 
         Returns:
             str: Complete M3U8 format stream URL with authentication parameters
-
-        Raises:
-            RPlayAuthError: If authentication fails
-            RPlayAPIError: If stream key retrieval fails
         """
-        if stream_key is None:
-            stream_key = self._get_stream_key()
-
         params = urlencode({
             "creatorOid": creator_oid,
             "key2": stream_key,
@@ -298,10 +287,12 @@ class RPlayAPI:
 
                     response.raise_for_status()
                     data = response.json()
-                    if "authKey" not in data:
+                    auth_key = data.get("authKey")
+                    # None/empty must not enter the per-cycle cache/URL path.
+                    if not isinstance(auth_key, str) or not auth_key:
                         # Caller logs expected auth failures (startup / monitor dedup).
                         raise RPlayAuthError("Invalid authentication response")
-                    return data["authKey"]
+                    return auth_key
 
         except RPlayAuthError:
             raise

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -201,6 +201,30 @@ class TestYtDlpLoggerBridge:
 
         assert any("yt-dlp" in str(call) for call in mock_log.debug.call_args_list)
 
+    def test_key2_query_values_are_redacted_before_forwarding(self, tmp_path, monkeypatch):
+        import core.logger as logger_module
+
+        monkeypatch.setattr(logger_module, "_configured_ytdlp_internal", True)
+        downloader = StreamDownloader("TestCreator", output_dir=tmp_path)
+        logger_bridge = downloader._build_ydl_options(tmp_path / "test.ts")["logger"]
+        message = (
+            "[generic] Extracting URL: "
+            "https://api.example/live/stream/playlist.m3u8"
+            "?creatorOid=c1&key2=SECRET"
+        )
+
+        with patch.object(downloader, "log") as mock_log:
+            logger_bridge.debug(message)
+            logger_bridge.info(message)
+            logger_bridge.warning(message)
+            logger_bridge.error(message)
+
+        assert mock_log.debug.call_count == 4
+        for call in mock_log.debug.call_args_list:
+            logged = call.args[0]
+            assert "REDACTED" in logged
+            assert "SECRET" not in logged
+
 
 class TestBuildYdlOptions:
     """Tests for _build_ydl_options method."""

--- a/tests/test_live_stream_monitor.py
+++ b/tests/test_live_stream_monitor.py
@@ -234,7 +234,7 @@ class TestSessionAwareMonitoring:
             api=mock_api,
         )
 
-        def assert_eager_state(creator_oid: str) -> str:
+        def assert_eager_state(creator_oid: str, stream_key=None) -> str:
             active_session_key = monitor._active_raw_session_by_creator[creator_oid]
             assert active_session_key in monitor.sessions
             active_session = monitor.sessions[active_session_key]
@@ -243,6 +243,7 @@ class TestSessionAwareMonitoring:
             return "http://example.com/stream.m3u8"
 
         fixed_now = datetime(2026, 3, 7, 5, 3, 41)
+        mock_api._get_stream_key.return_value = "cycle-key"
         mock_api.get_stream_url.side_effect = assert_eager_state
 
         with patch('core.live_stream_monitor.datetime') as mock_datetime:
@@ -290,7 +291,10 @@ class TestSessionAwareMonitoring:
 
         monitor.check_live_streams_and_start_download()
 
-        mock_api.get_stream_url.assert_called_once_with("creator1")
+        mock_api._get_stream_key.assert_called_once()
+        mock_api.get_stream_url.assert_called_once_with(
+            "creator1", stream_key=mock_api._get_stream_key.return_value
+        )
         mock_download.assert_called_once_with(
             "http://example.com/stream.m3u8", "Test Stream"
         )
@@ -588,6 +592,7 @@ class TestStartDownload:
 
     def test_start_download_success(self, mock_api, monitor):
         """Test successful download start."""
+        mock_api._get_stream_key.return_value = "cycle-key"
         mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
         mock_stream = MagicMock()
         mock_stream.creator_oid = "test_oid"
@@ -601,7 +606,10 @@ class TestStartDownload:
         with patch('core.live_stream_monitor.StreamDownloader.download') as mock_download:
             monitor._start_download(mock_stream)
 
-        mock_api.get_stream_url.assert_called_once_with("test_oid")
+        mock_api._get_stream_key.assert_called_once()
+        mock_api.get_stream_url.assert_called_once_with(
+            "test_oid", stream_key="cycle-key"
+        )
         mock_download.assert_called_once_with(
             "http://example.com/stream.m3u8", "Test Stream"
         )
@@ -626,7 +634,7 @@ class TestStartDownload:
 
     def test_start_download_auth_error(self, mock_api, monitor, caplog):
         """Test first auth error is ERROR; a repeat is DEBUG-only (dedup)."""
-        mock_api.get_stream_url.side_effect = RPlayAuthError("Unauthorized")
+        mock_api._get_stream_key.side_effect = RPlayAuthError("Unauthorized")
         mock_stream = MagicMock()
         mock_stream.creator_oid = "test_oid"
         mock_stream.title = "Test Stream"
@@ -647,6 +655,7 @@ class TestStartDownload:
             monitor._start_download(mock_stream)
 
         mock_download.assert_not_called()
+        mock_api.get_stream_url.assert_not_called()
         error_auth = [
             r
             for r in caplog.records
@@ -659,10 +668,12 @@ class TestStartDownload:
         ]
         assert len(error_auth) == 1
         assert len(debug_auth) >= 1
+        # Failed fetches must not be cached.
+        assert monitor._cycle_stream_key is None
 
     def test_start_download_api_error(self, mock_api, monitor):
         """Test API error is logged as warning."""
-        mock_api.get_stream_url.side_effect = RPlayAPIError("API Error")
+        mock_api._get_stream_key.side_effect = RPlayAPIError("API Error")
         mock_stream = MagicMock()
         mock_stream.creator_oid = "test_oid"
         mock_stream.title = "Test Stream"
@@ -675,10 +686,11 @@ class TestStartDownload:
             monitor._start_download(mock_stream)
 
         mock_download.assert_not_called()
+        assert monitor._cycle_stream_key is None
 
     def test_start_download_unexpected_error(self, mock_api, monitor):
         """Test unexpected error is caught and logged."""
-        mock_api.get_stream_url.side_effect = RuntimeError("Unexpected")
+        mock_api._get_stream_key.side_effect = RuntimeError("Unexpected")
         mock_stream = MagicMock()
         mock_stream.creator_oid = "test_oid"
         mock_stream.title = "Test Stream"
@@ -691,6 +703,137 @@ class TestStartDownload:
             monitor._start_download(mock_stream)
 
         mock_download.assert_not_called()
+        assert monitor._cycle_stream_key is None
+
+
+class TestCycleStreamKeyCache:
+    """Per-poll-cycle key2 cache: user-scoped, one fetch per cycle."""
+
+    def _live_stream(self, creator_oid: str, title: str = "Live"):
+        stream = MagicMock()
+        stream.oid = f"stream-{creator_oid}"
+        stream.creator_oid = creator_oid
+        stream.stream_state = StreamState.LIVE
+        stream.stream_start_time = datetime(2026, 3, 7, 5, 3, 40)
+        stream.title = title
+        return stream
+
+    @patch("core.live_stream_monitor.read_config")
+    @patch("core.live_stream_monitor.StreamDownloader.download")
+    def test_n_live_creators_fetch_key2_once_per_cycle(
+        self, mock_download, mock_read_config, mock_api
+    ):
+        """N live creators in one cycle share a single key2 fetch."""
+        streams = [self._live_stream("c1"), self._live_stream("c2"), self._live_stream("c3")]
+        mock_api.get_livestream_status.return_value = streams
+        mock_api._get_stream_key.return_value = "shared-key"
+        mock_api.get_stream_url.side_effect = (
+            lambda oid, stream_key=None: f"http://example.com/{oid}.m3u8"
+        )
+        mock_read_config.return_value = _runtime_config([
+            CreatorProfile(creator_name="C1", creator_oid="c1"),
+            CreatorProfile(creator_name="C2", creator_oid="c2"),
+            CreatorProfile(creator_name="C3", creator_oid="c3"),
+        ])
+        monitor = LiveStreamMonitor(
+            auth_token="test_token",
+            user_oid="test_oid",
+            api=mock_api,
+        )
+
+        monitor.check_live_streams_and_start_download()
+
+        assert mock_api._get_stream_key.call_count == 1
+        assert mock_api.get_stream_url.call_count == 3
+        for call, oid in zip(mock_api.get_stream_url.call_args_list, ("c1", "c2", "c3")):
+            assert call.args[0] == oid
+            assert call.kwargs["stream_key"] == "shared-key"
+        assert monitor._cycle_stream_key == "shared-key"
+        assert mock_download.call_count == 3
+
+    @patch("core.live_stream_monitor.read_config")
+    @patch("core.live_stream_monitor.StreamDownloader.download")
+    def test_next_cycle_fetches_key2_again(
+        self, mock_download, mock_read_config, mock_api
+    ):
+        """Cache is reset at each poll-cycle start; no cross-cycle reuse."""
+        stream = self._live_stream("c1")
+        mock_api.get_livestream_status.return_value = [stream]
+        mock_api._get_stream_key.return_value = "shared-key"
+        mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
+        mock_read_config.return_value = _runtime_config([
+            CreatorProfile(creator_name="C1", creator_oid="c1"),
+        ])
+        monitor = LiveStreamMonitor(
+            auth_token="test_token",
+            user_oid="test_oid",
+            api=mock_api,
+        )
+
+        monitor.check_live_streams_and_start_download()
+        # First cycle left the creator RAW_RUNNING; clear so the next cycle starts again.
+        monitor.sessions.clear()
+        monitor._active_raw_session_by_creator.clear()
+        monitor._active_downloaders.clear()
+        monitor.check_live_streams_and_start_download()
+
+        assert mock_api._get_stream_key.call_count == 2
+
+    @patch("core.live_stream_monitor.read_config")
+    @patch("core.live_stream_monitor.StreamDownloader.download")
+    def test_failed_key2_not_cached_retries_for_next_creator(
+        self, mock_download, mock_read_config, mock_api
+    ):
+        """A failed key2 fetch is not cached; the next creator retries for real."""
+        streams = [self._live_stream("c1"), self._live_stream("c2")]
+        mock_api.get_livestream_status.return_value = streams
+        mock_api._get_stream_key.side_effect = [
+            RPlayAuthError("Unauthorized"),
+            "recovered-key",
+        ]
+        mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
+        mock_read_config.return_value = _runtime_config([
+            CreatorProfile(creator_name="C1", creator_oid="c1"),
+            CreatorProfile(creator_name="C2", creator_oid="c2"),
+        ])
+        monitor = LiveStreamMonitor(
+            auth_token="test_token",
+            user_oid="test_oid",
+            api=mock_api,
+        )
+
+        monitor.check_live_streams_and_start_download()
+
+        assert mock_api._get_stream_key.call_count == 2
+        assert monitor._cycle_stream_key == "recovered-key"
+        mock_download.assert_called_once_with(
+            "http://example.com/stream.m3u8", "Live"
+        )
+        mock_api.get_stream_url.assert_called_once_with(
+            "c2", stream_key="recovered-key"
+        )
+
+    def test_cache_hit_does_not_rearm_auth_dedup(self, mock_api, monitor):
+        """Cache hit skips re-arm; re-arm only runs on a real key2 fetch."""
+        mock_api._get_stream_key.return_value = "shared-key"
+        mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
+        monitor.monitored_creators["c1"] = CreatorProfile(
+            creator_name="C1", creator_oid="c1"
+        )
+        monitor.monitored_creators["c2"] = CreatorProfile(
+            creator_name="C2", creator_oid="c2"
+        )
+        monitor._auth_error_notified = True
+
+        with patch("core.live_stream_monitor.StreamDownloader.download"):
+            monitor._start_download(self._live_stream("c1"))
+            assert monitor._auth_error_notified is False
+            monitor._auth_error_notified = True  # simulate a later notify
+            monitor._start_download(self._live_stream("c2"))
+
+        # Second creator used the cache; re-arm did not run again.
+        assert monitor._auth_error_notified is True
+        assert mock_api._get_stream_key.call_count == 1
 
 
 class TestCheckLiveStreams:
@@ -736,6 +879,7 @@ class TestCheckLiveStreams:
         mock_stream.stream_state = StreamState.LIVE
         mock_stream.title = "Live Stream"
         mock_api.get_livestream_status.return_value = [mock_stream]
+        mock_api._get_stream_key.return_value = "cycle-key"
         mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
         mock_read_config.return_value = _runtime_config([
             CreatorProfile(creator_name="Creator", creator_oid="creator_oid"),
@@ -751,7 +895,9 @@ class TestCheckLiveStreams:
         # to pollute whichever test happened to be patching that logger.
         with patch('core.live_stream_monitor.StreamDownloader.download'):
             monitor.check_live_streams_and_start_download()
-        mock_api.get_stream_url.assert_called_once_with("creator_oid")
+        mock_api.get_stream_url.assert_called_once_with(
+            "creator_oid", stream_key="cycle-key"
+        )
 
     @patch('core.live_stream_monitor.read_config')
     def test_already_downloading_no_restart(self, mock_read_config, tmp_path):
@@ -976,11 +1122,12 @@ class TestAuthErrorDedup:
             creator_name="TestCreator",
             creator_oid="test_oid",
         )
-        mock_api.get_stream_url.side_effect = [
+        mock_api._get_stream_key.side_effect = [
             RPlayAuthError("Unauthorized"),
-            "http://example.com/stream.m3u8",
+            "cycle-key",
             RPlayAuthError("Unauthorized again"),
         ]
+        mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
 
         with (
             caplog.at_level(logging.DEBUG, logger="Monitor"),
@@ -992,6 +1139,8 @@ class TestAuthErrorDedup:
             monitor._start_download(mock_stream)  # key2 success → re-arm
             monitor.sessions.clear()
             monitor._active_raw_session_by_creator.clear()
+            # New cycle (or explicit clear): cache must not hide the next real fetch.
+            monitor._cycle_stream_key = None
             monitor._start_download(mock_stream)  # auth fail → ERROR again
 
         error_auth = [

--- a/tests/test_live_stream_monitor.py
+++ b/tests/test_live_stream_monitor.py
@@ -234,7 +234,7 @@ class TestSessionAwareMonitoring:
             api=mock_api,
         )
 
-        def assert_eager_state(creator_oid: str, stream_key=None) -> str:
+        def assert_eager_state(creator_oid: str, stream_key: str) -> str:
             active_session_key = monitor._active_raw_session_by_creator[creator_oid]
             assert active_session_key in monitor.sessions
             active_session = monitor.sessions[active_session_key]
@@ -291,10 +291,6 @@ class TestSessionAwareMonitoring:
 
         monitor.check_live_streams_and_start_download()
 
-        mock_api._get_stream_key.assert_called_once()
-        mock_api.get_stream_url.assert_called_once_with(
-            "creator1", stream_key=mock_api._get_stream_key.return_value
-        )
         mock_download.assert_called_once_with(
             "http://example.com/stream.m3u8", "Test Stream"
         )
@@ -591,7 +587,6 @@ class TestStartDownload:
     """Tests for _start_download method."""
 
     def test_start_download_success(self, mock_api, monitor):
-        """Test successful download start."""
         mock_api._get_stream_key.return_value = "cycle-key"
         mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
         mock_stream = MagicMock()
@@ -606,10 +601,6 @@ class TestStartDownload:
         with patch('core.live_stream_monitor.StreamDownloader.download') as mock_download:
             monitor._start_download(mock_stream)
 
-        mock_api._get_stream_key.assert_called_once()
-        mock_api.get_stream_url.assert_called_once_with(
-            "test_oid", stream_key="cycle-key"
-        )
         mock_download.assert_called_once_with(
             "http://example.com/stream.m3u8", "Test Stream"
         )
@@ -633,7 +624,7 @@ class TestStartDownload:
         assert '[TestCreator] 🔴 Live: "Test Stream"' in messages
 
     def test_start_download_auth_error(self, mock_api, monitor, caplog):
-        """Test first auth error is ERROR; a repeat is DEBUG-only (dedup)."""
+        """First auth error is ERROR; a repeat is DEBUG-only; failed key is not cached."""
         mock_api._get_stream_key.side_effect = RPlayAuthError("Unauthorized")
         mock_stream = MagicMock()
         mock_stream.creator_oid = "test_oid"
@@ -656,6 +647,8 @@ class TestStartDownload:
 
         mock_download.assert_not_called()
         mock_api.get_stream_url.assert_not_called()
+        # Failure is not cached: each start retries the real key2 fetch.
+        assert mock_api._get_stream_key.call_count == 2
         error_auth = [
             r
             for r in caplog.records
@@ -668,8 +661,8 @@ class TestStartDownload:
         ]
         assert len(error_auth) == 1
         assert len(debug_auth) >= 1
-        # Failed fetches must not be cached.
         assert monitor._cycle_stream_key is None
+        assert monitor._cycle_key_fetch_auth_failed is True
 
     def test_start_download_api_error(self, mock_api, monitor):
         """Test API error is logged as warning."""
@@ -707,8 +700,6 @@ class TestStartDownload:
 
 
 class TestCycleStreamKeyCache:
-    """Per-poll-cycle key2 cache: user-scoped, one fetch per cycle."""
-
     def _live_stream(self, creator_oid: str, title: str = "Live"):
         stream = MagicMock()
         stream.oid = f"stream-{creator_oid}"
@@ -720,20 +711,18 @@ class TestCycleStreamKeyCache:
 
     @patch("core.live_stream_monitor.read_config")
     @patch("core.live_stream_monitor.StreamDownloader.download")
-    def test_n_live_creators_fetch_key2_once_per_cycle(
+    def test_two_creators_share_one_key2_fetch_and_reset_next_cycle(
         self, mock_download, mock_read_config, mock_api
     ):
-        """N live creators in one cycle share a single key2 fetch."""
-        streams = [self._live_stream("c1"), self._live_stream("c2"), self._live_stream("c3")]
+        streams = [self._live_stream("c1"), self._live_stream("c2")]
         mock_api.get_livestream_status.return_value = streams
         mock_api._get_stream_key.return_value = "shared-key"
         mock_api.get_stream_url.side_effect = (
-            lambda oid, stream_key=None: f"http://example.com/{oid}.m3u8"
+            lambda oid, stream_key: f"http://example.com/{oid}.m3u8"
         )
         mock_read_config.return_value = _runtime_config([
             CreatorProfile(creator_name="C1", creator_oid="c1"),
             CreatorProfile(creator_name="C2", creator_oid="c2"),
-            CreatorProfile(creator_name="C3", creator_oid="c3"),
         ])
         monitor = LiveStreamMonitor(
             auth_token="test_token",
@@ -742,79 +731,21 @@ class TestCycleStreamKeyCache:
         )
 
         monitor.check_live_streams_and_start_download()
-
         assert mock_api._get_stream_key.call_count == 1
-        assert mock_api.get_stream_url.call_count == 3
-        for call, oid in zip(mock_api.get_stream_url.call_args_list, ("c1", "c2", "c3")):
-            assert call.args[0] == oid
-            assert call.kwargs["stream_key"] == "shared-key"
-        assert monitor._cycle_stream_key == "shared-key"
-        assert mock_download.call_count == 3
+        assert mock_api.get_stream_url.call_count == 2
+        for call, oid in zip(mock_api.get_stream_url.call_args_list, ("c1", "c2")):
+            assert call.args == (oid,)
+            assert call.kwargs == {"stream_key": "shared-key"}
+        assert mock_download.call_count == 2
 
-    @patch("core.live_stream_monitor.read_config")
-    @patch("core.live_stream_monitor.StreamDownloader.download")
-    def test_next_cycle_fetches_key2_again(
-        self, mock_download, mock_read_config, mock_api
-    ):
-        """Cache is reset at each poll-cycle start; no cross-cycle reuse."""
-        stream = self._live_stream("c1")
-        mock_api.get_livestream_status.return_value = [stream]
-        mock_api._get_stream_key.return_value = "shared-key"
-        mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
-        mock_read_config.return_value = _runtime_config([
-            CreatorProfile(creator_name="C1", creator_oid="c1"),
-        ])
-        monitor = LiveStreamMonitor(
-            auth_token="test_token",
-            user_oid="test_oid",
-            api=mock_api,
-        )
-
-        monitor.check_live_streams_and_start_download()
-        # First cycle left the creator RAW_RUNNING; clear so the next cycle starts again.
+        # Next cycle: clear sessions so downloads start again; cache must reset.
         monitor.sessions.clear()
         monitor._active_raw_session_by_creator.clear()
         monitor._active_downloaders.clear()
         monitor.check_live_streams_and_start_download()
-
         assert mock_api._get_stream_key.call_count == 2
-
-    @patch("core.live_stream_monitor.read_config")
-    @patch("core.live_stream_monitor.StreamDownloader.download")
-    def test_failed_key2_not_cached_retries_for_next_creator(
-        self, mock_download, mock_read_config, mock_api
-    ):
-        """A failed key2 fetch is not cached; the next creator retries for real."""
-        streams = [self._live_stream("c1"), self._live_stream("c2")]
-        mock_api.get_livestream_status.return_value = streams
-        mock_api._get_stream_key.side_effect = [
-            RPlayAuthError("Unauthorized"),
-            "recovered-key",
-        ]
-        mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
-        mock_read_config.return_value = _runtime_config([
-            CreatorProfile(creator_name="C1", creator_oid="c1"),
-            CreatorProfile(creator_name="C2", creator_oid="c2"),
-        ])
-        monitor = LiveStreamMonitor(
-            auth_token="test_token",
-            user_oid="test_oid",
-            api=mock_api,
-        )
-
-        monitor.check_live_streams_and_start_download()
-
-        assert mock_api._get_stream_key.call_count == 2
-        assert monitor._cycle_stream_key == "recovered-key"
-        mock_download.assert_called_once_with(
-            "http://example.com/stream.m3u8", "Live"
-        )
-        mock_api.get_stream_url.assert_called_once_with(
-            "c2", stream_key="recovered-key"
-        )
 
     def test_cache_hit_does_not_rearm_auth_dedup(self, mock_api, monitor):
-        """Cache hit skips re-arm; re-arm only runs on a real key2 fetch."""
         mock_api._get_stream_key.return_value = "shared-key"
         mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
         monitor.monitored_creators["c1"] = CreatorProfile(
@@ -831,7 +762,6 @@ class TestCycleStreamKeyCache:
             monitor._auth_error_notified = True  # simulate a later notify
             monitor._start_download(self._live_stream("c2"))
 
-        # Second creator used the cache; re-arm did not run again.
         assert monitor._auth_error_notified is True
         assert mock_api._get_stream_key.call_count == 1
 
@@ -893,10 +823,10 @@ class TestCheckLiveStreams:
         # example.com. Its failure callback lands after this test returns and
         # logs through the process-wide "Monitor" logger, which is how it used
         # to pollute whichever test happened to be patching that logger.
-        with patch('core.live_stream_monitor.StreamDownloader.download'):
+        with patch('core.live_stream_monitor.StreamDownloader.download') as mock_download:
             monitor.check_live_streams_and_start_download()
-        mock_api.get_stream_url.assert_called_once_with(
-            "creator_oid", stream_key="cycle-key"
+        mock_download.assert_called_once_with(
+            "http://example.com/stream.m3u8", "Live Stream"
         )
 
     @patch('core.live_stream_monitor.read_config')
@@ -983,6 +913,69 @@ class TestCheckLiveStreamsErrorHandling:
         )
         monitor.check_live_streams_and_start_download()
         assert monitor.is_healthy is False
+
+    @patch("core.live_stream_monitor.read_config")
+    @patch("core.live_stream_monitor.StreamDownloader.download")
+    def test_all_key2_auth_failures_mark_cycle_unhealthy(
+        self, mock_download, mock_read_config, mock_api
+    ):
+        stream = MagicMock()
+        stream.oid = "stream-c1"
+        stream.creator_oid = "c1"
+        stream.stream_state = StreamState.LIVE
+        stream.stream_start_time = datetime(2026, 3, 7, 5, 3, 40)
+        stream.title = "Live"
+        mock_api.get_livestream_status.return_value = [stream]
+        mock_api._get_stream_key.side_effect = RPlayAuthError("Unauthorized")
+        mock_read_config.return_value = _runtime_config([
+            CreatorProfile(creator_name="C1", creator_oid="c1"),
+        ])
+        monitor = LiveStreamMonitor(
+            auth_token="test_token",
+            user_oid="test_oid",
+            api=mock_api,
+        )
+
+        monitor.check_live_streams_and_start_download()
+
+        mock_download.assert_not_called()
+        assert monitor.is_healthy is False
+
+    @patch("core.live_stream_monitor.read_config")
+    @patch("core.live_stream_monitor.StreamDownloader.download")
+    def test_key2_auth_failure_then_success_marks_cycle_healthy(
+        self, mock_download, mock_read_config, mock_api
+    ):
+        streams = []
+        for oid in ("c1", "c2"):
+            stream = MagicMock()
+            stream.oid = f"stream-{oid}"
+            stream.creator_oid = oid
+            stream.stream_state = StreamState.LIVE
+            stream.stream_start_time = datetime(2026, 3, 7, 5, 3, 40)
+            stream.title = "Live"
+            streams.append(stream)
+        mock_api.get_livestream_status.return_value = streams
+        mock_api._get_stream_key.side_effect = [
+            RPlayAuthError("Unauthorized"),
+            "recovered-key",
+        ]
+        mock_api.get_stream_url.return_value = "http://example.com/stream.m3u8"
+        mock_read_config.return_value = _runtime_config([
+            CreatorProfile(creator_name="C1", creator_oid="c1"),
+            CreatorProfile(creator_name="C2", creator_oid="c2"),
+        ])
+        monitor = LiveStreamMonitor(
+            auth_token="test_token",
+            user_oid="test_oid",
+            api=mock_api,
+        )
+
+        monitor.check_live_streams_and_start_download()
+
+        assert mock_api._get_stream_key.call_count == 2
+        mock_download.assert_called_once()
+        assert monitor.is_healthy is True
 
     @patch('core.live_stream_monitor.read_config')
     def test_connection_error_sets_unhealthy(self, mock_read_config):

--- a/tests/test_monitor_events.py
+++ b/tests/test_monitor_events.py
@@ -439,7 +439,7 @@ def test_in_flight_poll_does_not_start_recording_after_shutdown(tmp_path, monkey
     at_stream_url = ThreadEvent()
     resume_poll = ThreadEvent()
 
-    def blocking_stream_url(creator_oid, stream_key=None):
+    def blocking_stream_url(creator_oid, stream_key):
         at_stream_url.set()
         assert resume_poll.wait(timeout=5)
         return "http://example.com/stream.m3u8"

--- a/tests/test_monitor_events.py
+++ b/tests/test_monitor_events.py
@@ -439,11 +439,12 @@ def test_in_flight_poll_does_not_start_recording_after_shutdown(tmp_path, monkey
     at_stream_url = ThreadEvent()
     resume_poll = ThreadEvent()
 
-    def blocking_stream_url(creator_oid):
+    def blocking_stream_url(creator_oid, stream_key=None):
         at_stream_url.set()
         assert resume_poll.wait(timeout=5)
         return "http://example.com/stream.m3u8"
 
+    mock_api._get_stream_key.return_value = "cycle-key"
     mock_api.get_stream_url.side_effect = blocking_stream_url
 
     with patch.object(StreamDownloader, "download") as mock_download:

--- a/tests/test_rplay.py
+++ b/tests/test_rplay.py
@@ -115,36 +115,11 @@ class TestGetStreamUrl:
     """Tests for get_stream_url method."""
 
     def test_url_encoding(self):
-        """Test that stream URL is properly URL-encoded."""
         api = RPlayAPI(auth_token="test", user_oid="test")
-
-        # Mock _get_stream_key to return a key with special characters
-        with patch.object(api, "_get_stream_key", return_value="key+with/special=chars"):
-            url = api.get_stream_url("creator123")
-
-        # Check URL encoding
+        url = api.get_stream_url("creator123", stream_key="key+with/special=chars")
         assert "key%2Bwith%2Fspecial%3Dchars" in url
         assert "creatorOid=creator123" in url
-
-    def test_returns_m3u8_url(self):
-        """Test that returned URL is an m3u8 playlist URL."""
-        api = RPlayAPI(auth_token="test", user_oid="test")
-
-        with patch.object(api, "_get_stream_key", return_value="simple_key"):
-            url = api.get_stream_url("creator123")
-
         assert "playlist.m3u8" in url
-
-    def test_reuses_provided_stream_key_without_fetch(self):
-        """Test an explicit stream_key skips the key2 network call."""
-        api = RPlayAPI(auth_token="test", user_oid="test")
-
-        with patch.object(api, "_get_stream_key") as mock_get_key:
-            url = api.get_stream_url("creator123", stream_key="prefetched")
-
-        mock_get_key.assert_not_called()
-        assert "key2=prefetched" in url
-        assert "creatorOid=creator123" in url
 
 
 class TestValidateCredentials:
@@ -194,11 +169,22 @@ class TestGetStreamKey:
         assert key == "my_stream_key"
 
     def test_missing_auth_key_raises_auth_error(self):
-        """Test that missing authKey raises RPlayAuthError."""
         api = RPlayAPI(auth_token="test", user_oid="test")
 
         mock_response = MagicMock()
         mock_response.json.return_value = {"other": "data"}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(api._session, "get", return_value=mock_response):
+            with pytest.raises(RPlayAuthError, match="Invalid authentication"):
+                api._get_stream_key()
+
+    @pytest.mark.parametrize("auth_key", [None, ""])
+    def test_null_or_empty_auth_key_raises_auth_error(self, auth_key):
+        api = RPlayAPI(auth_token="test", user_oid="test")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"authKey": auth_key}
         mock_response.raise_for_status = MagicMock()
 
         with patch.object(api._session, "get", return_value=mock_response):
@@ -336,8 +322,8 @@ class TestTransientRetry:
             ) as mock_get,
             patch("time.sleep") as mock_sleep,
         ):
-            stream_url = api.get_stream_url("creator123")
+            key = api._get_stream_key()
 
-        assert "creatorOid=creator123" in stream_url
+        assert key == "my_stream_key"
         assert mock_get.call_count == 3
         assert mock_sleep.call_count == 2

--- a/tests/test_rplay.py
+++ b/tests/test_rplay.py
@@ -135,6 +135,17 @@ class TestGetStreamUrl:
 
         assert "playlist.m3u8" in url
 
+    def test_reuses_provided_stream_key_without_fetch(self):
+        """Test an explicit stream_key skips the key2 network call."""
+        api = RPlayAPI(auth_token="test", user_oid="test")
+
+        with patch.object(api, "_get_stream_key") as mock_get_key:
+            url = api.get_stream_url("creator123", stream_key="prefetched")
+
+        mock_get_key.assert_not_called()
+        assert "key2=prefetched" in url
+        assert "creatorOid=creator123" in url
+
 
 class TestValidateCredentials:
     """Tests for the public credential-validation seam."""


### PR DESCRIPTION
## Summary
The stream key (key2) is user-scoped — `/live/key2?requestorOid=…` carries no creator parameter — so fetching it once per creator per poll cycle was N redundant authenticated calls. Now the monitor fetches it at most once per cycle.

- `_cycle_stream_key` reset unconditionally at every poll-cycle start (including failure-driven retry cycles); first successful fetch reused within the cycle; failed fetches never cached; never carried across cycles.
- `get_stream_url` now requires `stream_key` (monitor is the sole caller); `_get_stream_key` rejects null/empty `authKey` as an auth error.
- Health accounting made consistent: a cycle whose key fetches all fail with auth errors no longer ends "healthy" — an unrecovered key-fetch auth failure fails the cycle, matching the playlist-401 path.
- Security hardening: the yt-dlp internal log bridge masks `key2=…` query values (`key2=REDACTED`) before any message reaches the logger, with a regression test (`LOG_YTDLP_INTERNAL=true` could previously log playlist URLs containing the key).
- Auth-error dedup re-arm fires only on real fetches (cache hits follow a same-cycle success).

## Acceptance criteria
- [ ] N live creators in one cycle → exactly one key2 fetch
- [ ] No cross-cycle reuse; failures not cached
- [ ] All-fetches-fail cycle marks health failed; recovery restores it
- [ ] No key2 material can reach logs through the yt-dlp bridge

## Verification
- Full suite 3 consecutive runs: `354 passed in 38.60s` / `38.49s` / `38.52s`
- Masking regression test asserts REDACTED present / secret absent at all bridge levels
- Dual independent review (L3-calibrated pragmatic + over-engineering pass) + fix round addressing all findings
