### PR TITLE
feat: add heartbeat-file Docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,5 +48,9 @@ COPY . .
 ENV PYTHONUNBUFFERED=1
 ENV APP_GIT_SHA=${APP_GIT_SHA}
 
+# Heartbeat file touched each poll cycle; stale after 3×INTERVAL (see core/health.py)
+HEALTHCHECK --interval=60s --timeout=5s --start-period=90s --retries=3 \
+    CMD python -m core.health
+
 # Run the application
 CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -342,16 +342,7 @@ docker run -d \
 
 #### Docker healthcheck
 
-The image defines a `HEALTHCHECK` that runs `python -m core.health`.
-
-| Detail | Behavior |
-| --- | --- |
-| Heartbeat file | `/tmp/rplay-live-dl-heartbeat` (touched once per monitor poll cycle) |
-| Healthy | file exists and mtime is fresher than `3 × INTERVAL` seconds |
-| Unhealthy | file missing or stale (probe prints a one-line reason) |
-| Probe interval | every 60s inside the container (independent of app `INTERVAL`) |
-
-Docker only *displays* unhealthy status; it does not restart the container. The staleness window scales with `INTERVAL` (default 60 → unhealthy after 180s without a successful poll-cycle touch).
+The image runs `python -m core.health` every 60s (`--retries=3`). Healthy when `/tmp/rplay-live-dl-heartbeat` exists and its mtime is strictly fresher than `3 × INTERVAL` seconds (touched once per monitor poll cycle, including failed ones). Docker only *displays* unhealthy status; it does not restart the container. With default `INTERVAL=60`, probes start failing after 180s without a heartbeat update, and Docker marks the container unhealthy ~300–360s after the last heartbeat update.
 
 ### Directory Structure
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Startup protection:
 - failed merge leaves raw `.ts` files in place for manual recovery
 - fail-fast startup validation for legacy config path upgrades
 - Docker-first deployment for long-running operation
+- Docker `HEALTHCHECK` via a poll-cycle heartbeat file (`python -m core.health`)
 
 ---
 
@@ -339,6 +340,19 @@ docker run -d \
   paverz/rplay-live-dl:v2.2.1-vibe
 ```
 
+#### Docker healthcheck
+
+The image defines a `HEALTHCHECK` that runs `python -m core.health`.
+
+| Detail | Behavior |
+| --- | --- |
+| Heartbeat file | `/tmp/rplay-live-dl-heartbeat` (touched once per monitor poll cycle) |
+| Healthy | file exists and mtime is fresher than `3 × INTERVAL` seconds |
+| Unhealthy | file missing or stale (probe prints a one-line reason) |
+| Probe interval | every 60s inside the container (independent of app `INTERVAL`) |
+
+Docker only *displays* unhealthy status; it does not restart the container. The staleness window scales with `INTERVAL` (default 60 → unhealthy after 180s without a successful poll-cycle touch).
+
 ### Directory Structure
 
 Typical runtime layout:
@@ -480,6 +494,7 @@ rplay-live-dl/
 │   ├── download_merge_executor.py
 │   ├── downloader.py
 │   ├── env.py
+│   ├── health.py
 │   ├── live_stream_monitor.py
 │   ├── logger.py
 │   ├── rplay.py
@@ -498,6 +513,7 @@ rplay-live-dl/
 │   ├── test_download_models.py
 │   ├── test_downloader.py
 │   ├── test_env.py
+│   ├── test_health.py
 │   ├── test_live_stream_monitor.py
 │   ├── test_logger.py
 │   ├── test_main.py

--- a/core/constants.py
+++ b/core/constants.py
@@ -44,6 +44,13 @@ DEFAULT_LOG_YTDLP_INTERNAL = False
 # Minimum free disk space (GiB) before starting a recording; 0 disables
 DEFAULT_MIN_FREE_DISK_GB = 5.0
 
+# Poll interval default (INTERVAL env); shared by EnvConfig and the health probe
+DEFAULT_INTERVAL = 60
+
+# Docker healthcheck heartbeat file (touched once per monitor poll cycle)
+HEARTBEAT_FILE_PATH = "/tmp/rplay-live-dl-heartbeat"
+HEARTBEAT_STALE_MULTIPLIER = 3
+
 __all__ = [
     "RPLAY_SITE_URL",
     "DEFAULT_RPLAY_API_BASE_URL",
@@ -63,4 +70,7 @@ __all__ = [
     "DEFAULT_LOG_RETENTION_DAYS",
     "DEFAULT_LOG_YTDLP_INTERNAL",
     "DEFAULT_MIN_FREE_DISK_GB",
+    "DEFAULT_INTERVAL",
+    "HEARTBEAT_FILE_PATH",
+    "HEARTBEAT_STALE_MULTIPLIER",
 ]

--- a/core/constants.py
+++ b/core/constants.py
@@ -47,10 +47,6 @@ DEFAULT_MIN_FREE_DISK_GB = 5.0
 # Poll interval default (INTERVAL env); shared by EnvConfig and the health probe
 DEFAULT_INTERVAL = 60
 
-# Docker healthcheck heartbeat file (touched once per monitor poll cycle)
-HEARTBEAT_FILE_PATH = "/tmp/rplay-live-dl-heartbeat"
-HEARTBEAT_STALE_MULTIPLIER = 3
-
 __all__ = [
     "RPLAY_SITE_URL",
     "DEFAULT_RPLAY_API_BASE_URL",
@@ -71,6 +67,4 @@ __all__ = [
     "DEFAULT_LOG_YTDLP_INTERNAL",
     "DEFAULT_MIN_FREE_DISK_GB",
     "DEFAULT_INTERVAL",
-    "HEARTBEAT_FILE_PATH",
-    "HEARTBEAT_STALE_MULTIPLIER",
 ]

--- a/core/health.py
+++ b/core/health.py
@@ -1,0 +1,87 @@
+"""
+Heartbeat health probe for Docker HEALTHCHECK.
+
+The monitor touches a heartbeat file once per poll cycle. This module checks
+that the file exists and its mtime is within 3 × INTERVAL seconds.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+
+from core.constants import (
+    DEFAULT_INTERVAL,
+    HEARTBEAT_FILE_PATH,
+    HEARTBEAT_STALE_MULTIPLIER,
+)
+
+__all__ = [
+    "touch_heartbeat",
+    "check_heartbeat",
+    "main",
+]
+
+
+def touch_heartbeat(path: Optional[str] = None) -> None:
+    """Create or update the heartbeat file mtime."""
+    Path(path if path is not None else HEARTBEAT_FILE_PATH).touch()
+
+
+def _interval_seconds() -> int:
+    # ponytail: raw getenv only; wrong value skews the threshold, not app config
+    raw = os.getenv("INTERVAL", str(DEFAULT_INTERVAL))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_INTERVAL
+    return value if value > 0 else DEFAULT_INTERVAL
+
+
+def _max_age_seconds() -> int:
+    return HEARTBEAT_STALE_MULTIPLIER * _interval_seconds()
+
+
+def check_heartbeat(
+    path: Optional[str] = None,
+    *,
+    now: Optional[float] = None,
+) -> Tuple[bool, str]:
+    """
+    Return (healthy, reason). reason is empty when healthy.
+
+    Args:
+        path: Heartbeat file path (defaults to HEARTBEAT_FILE_PATH)
+        now: Optional epoch seconds for deterministic tests
+    """
+    heartbeat_path = Path(path if path is not None else HEARTBEAT_FILE_PATH)
+    if not heartbeat_path.exists():
+        return False, f"heartbeat missing: {heartbeat_path}"
+
+    try:
+        mtime = heartbeat_path.stat().st_mtime
+    except OSError as exc:
+        return False, f"heartbeat unreadable: {exc}"
+
+    age = (time.time() if now is None else now) - mtime
+    max_age = _max_age_seconds()
+    if age > max_age:
+        return False, f"heartbeat stale: age={age:.0f}s max={max_age}s"
+    return True, ""
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entry: exit 0 if healthy, non-zero with a one-line reason otherwise."""
+    del argv  # reserved for future flags; probe takes no args today
+    ok, reason = check_heartbeat()
+    if ok:
+        return 0
+    print(reason, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/health.py
+++ b/core/health.py
@@ -11,76 +11,54 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Optional, Tuple
 
-from core.constants import (
-    DEFAULT_INTERVAL,
-    HEARTBEAT_FILE_PATH,
-    HEARTBEAT_STALE_MULTIPLIER,
-)
+from core.constants import DEFAULT_INTERVAL
 
 __all__ = [
+    "HEARTBEAT_FILE",
     "touch_heartbeat",
-    "check_heartbeat",
     "main",
 ]
 
+HEARTBEAT_FILE = "/tmp/rplay-live-dl-heartbeat"
 
-def touch_heartbeat(path: Optional[str] = None) -> None:
+
+def touch_heartbeat() -> None:
     """Create or update the heartbeat file mtime."""
-    Path(path if path is not None else HEARTBEAT_FILE_PATH).touch()
+    Path(HEARTBEAT_FILE).touch()
 
 
-def _interval_seconds() -> int:
+def main() -> int:
+    """CLI entry: exit 0 if healthy, non-zero with a one-line reason otherwise."""
     # ponytail: raw getenv only; wrong value skews the threshold, not app config
     raw = os.getenv("INTERVAL", str(DEFAULT_INTERVAL))
     try:
-        value = int(raw)
+        interval = int(raw)
     except (TypeError, ValueError):
-        return DEFAULT_INTERVAL
-    return value if value > 0 else DEFAULT_INTERVAL
+        interval = DEFAULT_INTERVAL
+    if interval <= 0:
+        interval = DEFAULT_INTERVAL
+    max_age = 3 * interval
 
-
-def _max_age_seconds() -> int:
-    return HEARTBEAT_STALE_MULTIPLIER * _interval_seconds()
-
-
-def check_heartbeat(
-    path: Optional[str] = None,
-    *,
-    now: Optional[float] = None,
-) -> Tuple[bool, str]:
-    """
-    Return (healthy, reason). reason is empty when healthy.
-
-    Args:
-        path: Heartbeat file path (defaults to HEARTBEAT_FILE_PATH)
-        now: Optional epoch seconds for deterministic tests
-    """
-    heartbeat_path = Path(path if path is not None else HEARTBEAT_FILE_PATH)
-    if not heartbeat_path.exists():
-        return False, f"heartbeat missing: {heartbeat_path}"
+    path = Path(HEARTBEAT_FILE)
+    if not path.exists():
+        print(f"heartbeat missing: {path}", file=sys.stderr)
+        return 1
 
     try:
-        mtime = heartbeat_path.stat().st_mtime
+        mtime = path.stat().st_mtime
     except OSError as exc:
-        return False, f"heartbeat unreadable: {exc}"
+        print(f"heartbeat unreadable: {exc}", file=sys.stderr)
+        return 1
 
-    age = (time.time() if now is None else now) - mtime
-    max_age = _max_age_seconds()
-    if age > max_age:
-        return False, f"heartbeat stale: age={age:.0f}s max={max_age}s"
-    return True, ""
-
-
-def main(argv: Optional[list[str]] = None) -> int:
-    """CLI entry: exit 0 if healthy, non-zero with a one-line reason otherwise."""
-    del argv  # reserved for future flags; probe takes no args today
-    ok, reason = check_heartbeat()
-    if ok:
-        return 0
-    print(reason, file=sys.stderr)
-    return 1
+    age = time.time() - mtime
+    if age < 0:
+        print(f"heartbeat clock skew: mtime in the future by {-age:.0f}s", file=sys.stderr)
+        return 1
+    if age >= max_age:
+        print(f"heartbeat stale: age={age:.0f}s max={max_age}s", file=sys.stderr)
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -31,6 +31,7 @@ from models.rplay import CreatorStreamState, LiveStream, StreamState
 from .config import ConfigError, DEFAULT_CONFIG_PATH, read_app_config as read_config
 from .download_merge_executor import DownloadMergeExecutor
 from .downloader import StreamDownloader
+from .health import touch_heartbeat
 from .logger import bind, clip, setup_logger
 from .rplay import RPlayAPI, RPlayAPIError, RPlayAuthError, RPlayConnectionError
 from .utils import terminate_child_processes
@@ -176,6 +177,8 @@ class LiveStreamMonitor:
         self._cycle_stream_key: Optional[str] = None
         # Unrecovered key2 auth failure this cycle → mark poll unhealthy at end.
         self._cycle_key_fetch_auth_failed = False
+        # One warning if the heartbeat file cannot be written; never spam logs.
+        self._heartbeat_write_warned = False
 
         # Track per-creator stream session state for M3U8 404 handling
         self._creator_states: Dict[str, CreatorStreamState] = {}
@@ -343,6 +346,18 @@ class LiveStreamMonitor:
         except Exception as exc:
             self.logger.exception(f"Unexpected error during monitoring: {exc}")
             self._mark_check_failed()
+        finally:
+            # Heartbeat once per cycle so Docker can see the monitor is polling.
+            self._touch_heartbeat()
+
+    def _touch_heartbeat(self) -> None:
+        """Update the Docker healthcheck heartbeat file; never break polling."""
+        try:
+            touch_heartbeat()
+        except OSError as exc:
+            if not self._heartbeat_write_warned:
+                self._heartbeat_write_warned = True
+                self.logger.warning(f"Failed to write heartbeat file: {exc}")
 
     def _mark_check_succeeded(self) -> None:
         """Record a successful monitor poll."""

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -348,16 +348,12 @@ class LiveStreamMonitor:
             self._mark_check_failed()
         finally:
             # Heartbeat once per cycle so Docker can see the monitor is polling.
-            self._touch_heartbeat()
-
-    def _touch_heartbeat(self) -> None:
-        """Update the Docker healthcheck heartbeat file; never break polling."""
-        try:
-            touch_heartbeat()
-        except OSError as exc:
-            if not self._heartbeat_write_warned:
-                self._heartbeat_write_warned = True
-                self.logger.warning(f"Failed to write heartbeat file: {exc}")
+            try:
+                touch_heartbeat()
+            except OSError as exc:
+                if not self._heartbeat_write_warned:
+                    self._heartbeat_write_warned = True
+                    self.logger.warning(f"Failed to write heartbeat file: {exc}")
 
     def _mark_check_succeeded(self) -> None:
         """Record a successful monitor poll."""

--- a/models/env.py
+++ b/models/env.py
@@ -9,6 +9,7 @@ from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from core.constants import (
+    DEFAULT_INTERVAL,
     DEFAULT_LOG_BACKUP_COUNT,
     DEFAULT_LOG_LEVEL,
     DEFAULT_LOG_MAX_SIZE_MB,
@@ -47,7 +48,7 @@ class EnvConfig(BaseSettings):
         min_length=1,
     )
     interval: int = Field(
-        default=60,
+        default=DEFAULT_INTERVAL,
         description="Check interval in seconds",
         ge=10,
         le=3600,

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,140 +1,91 @@
-"""Tests for Docker heartbeat health probe and monitor touch."""
+"""Tests for Docker heartbeat health probe CLI."""
 
 import os
 import time
-from unittest.mock import MagicMock, patch
-
-import pytest
 
 from core import health
-from core.constants import DEFAULT_INTERVAL, HEARTBEAT_STALE_MULTIPLIER
-from core.health import check_heartbeat, main, touch_heartbeat
-from core.live_stream_monitor import LiveStreamMonitor
-from core.rplay import RPlayAPI
-from models.config import AppConfig
+from core.constants import DEFAULT_INTERVAL
+from core.health import main, touch_heartbeat
 
 
-def _runtime_config(creators=None):
-    return AppConfig(api_base_url="https://api.rplay.live", creators=creators or [])
-
-
-class TestTouchAndCheck:
-    """Unit tests for heartbeat file helpers."""
+class TestHealthCLI:
+    """Probe CLI surface: main() exit codes and reasons."""
 
     def test_fresh_file_is_healthy(self, tmp_path, monkeypatch):
         """A just-touched heartbeat file reports healthy."""
         path = tmp_path / "heartbeat"
-        monkeypatch.setattr(health, "HEARTBEAT_FILE_PATH", str(path))
-        touch_heartbeat(str(path))
+        monkeypatch.setattr(health, "HEARTBEAT_FILE", str(path))
+        touch_heartbeat()
 
-        ok, reason = check_heartbeat(str(path))
-
-        assert ok is True
-        assert reason == ""
         assert main() == 0
 
     def test_missing_file_is_unhealthy(self, tmp_path, monkeypatch, capsys):
         """A missing heartbeat file reports unhealthy with a reason."""
         path = tmp_path / "missing-heartbeat"
-        monkeypatch.setattr(health, "HEARTBEAT_FILE_PATH", str(path))
+        monkeypatch.setattr(health, "HEARTBEAT_FILE", str(path))
 
-        ok, reason = check_heartbeat(str(path))
-
-        assert ok is False
-        assert "missing" in reason
         assert main() == 1
         assert "missing" in capsys.readouterr().err
 
-    def test_stale_mtime_is_unhealthy(self, tmp_path, monkeypatch):
+    def test_stale_mtime_is_unhealthy(self, tmp_path, monkeypatch, capsys):
         """A heartbeat older than 3×INTERVAL reports unhealthy."""
         path = tmp_path / "heartbeat"
-        monkeypatch.setattr(health, "HEARTBEAT_FILE_PATH", str(path))
+        monkeypatch.setattr(health, "HEARTBEAT_FILE", str(path))
         monkeypatch.delenv("INTERVAL", raising=False)
-        touch_heartbeat(str(path))
+        touch_heartbeat()
 
-        max_age = HEARTBEAT_STALE_MULTIPLIER * DEFAULT_INTERVAL
+        max_age = 3 * DEFAULT_INTERVAL
         stale_mtime = time.time() - max_age - 1
         os.utime(path, (stale_mtime, stale_mtime))
 
-        ok, reason = check_heartbeat(str(path), now=time.time())
-
-        assert ok is False
-        assert "stale" in reason
         assert main() == 1
+        assert "stale" in capsys.readouterr().err
 
-    def test_threshold_respects_interval_env(self, tmp_path, monkeypatch):
+    def test_exact_threshold_is_unhealthy(self, tmp_path, monkeypatch, capsys):
+        """age == max_age (3×INTERVAL) is unhealthy; fresher means strictly less."""
+        path = tmp_path / "heartbeat"
+        monkeypatch.setattr(health, "HEARTBEAT_FILE", str(path))
+        monkeypatch.delenv("INTERVAL", raising=False)
+        touch_heartbeat()
+
+        now = 1_700_000_000.0
+        max_age = 3 * DEFAULT_INTERVAL
+        monkeypatch.setattr(time, "time", lambda: now)
+        os.utime(path, (now - max_age, now - max_age))
+
+        assert main() == 1
+        err = capsys.readouterr().err
+        assert "stale" in err
+        assert f"max={max_age}" in err
+
+    def test_future_mtime_is_unhealthy(self, tmp_path, monkeypatch, capsys):
+        """A future mtime (clock stepped backwards) is unhealthy, not forever-healthy."""
+        path = tmp_path / "heartbeat"
+        monkeypatch.setattr(health, "HEARTBEAT_FILE", str(path))
+        touch_heartbeat()
+
+        future = time.time() + 3600
+        os.utime(path, (future, future))
+
+        assert main() == 1
+        assert "clock skew" in capsys.readouterr().err
+
+    def test_threshold_respects_interval_env(self, tmp_path, monkeypatch, capsys):
         """Staleness threshold scales with INTERVAL from the environment."""
         path = tmp_path / "heartbeat"
+        monkeypatch.setattr(health, "HEARTBEAT_FILE", str(path))
         monkeypatch.setenv("INTERVAL", "10")
-        touch_heartbeat(str(path))
+        touch_heartbeat()
 
         # age 25s is fresh at INTERVAL=10 (max=30) but would be stale at 60.
-        age = 25
-        mtime = time.time() - age
-        os.utime(path, (mtime, mtime))
-        now = time.time()
-
-        ok, _ = check_heartbeat(str(path), now=now)
-        assert ok is True
+        now = 1_700_000_000.0
+        monkeypatch.setattr(time, "time", lambda: now)
+        os.utime(path, (now - 25, now - 25))
+        assert main() == 0
 
         # Drop INTERVAL so the same age exceeds 3×interval.
         monkeypatch.setenv("INTERVAL", "5")
-        ok, reason = check_heartbeat(str(path), now=now)
-        assert ok is False
-        assert "stale" in reason
-        assert "max=15" in reason
-
-
-class TestMonitorHeartbeat:
-    """Monitor poll cycle must touch the heartbeat without breaking on errors."""
-
-    @patch("core.live_stream_monitor.read_config")
-    def test_poll_cycle_touches_heartbeat(self, mock_read_config, tmp_path, monkeypatch):
-        """A completed poll cycle creates/updates the heartbeat file."""
-        path = tmp_path / "heartbeat"
-        monkeypatch.setattr("core.health.HEARTBEAT_FILE_PATH", str(path))
-        monkeypatch.setattr(
-            "core.live_stream_monitor.touch_heartbeat",
-            lambda: touch_heartbeat(str(path)),
-        )
-        mock_api = MagicMock(spec=RPlayAPI)
-        mock_api.get_livestream_status.return_value = []
-        mock_read_config.return_value = _runtime_config()
-        monitor = LiveStreamMonitor(
-            auth_token="test_token",
-            user_oid="test_oid",
-            api=mock_api,
-        )
-
-        assert not path.exists()
-        monitor.check_live_streams_and_start_download()
-        assert path.exists()
-
-    @patch("core.live_stream_monitor.read_config")
-    def test_oserror_on_touch_does_not_break_cycle(
-        self, mock_read_config, monkeypatch, caplog
-    ):
-        """OSError writing the heartbeat is logged once and does not fail the poll."""
-        mock_api = MagicMock(spec=RPlayAPI)
-        mock_api.get_livestream_status.return_value = []
-        mock_read_config.return_value = _runtime_config()
-
-        def boom() -> None:
-            raise OSError("disk full")
-
-        monkeypatch.setattr("core.live_stream_monitor.touch_heartbeat", boom)
-        monitor = LiveStreamMonitor(
-            auth_token="test_token",
-            user_oid="test_oid",
-            api=mock_api,
-        )
-
-        with caplog.at_level("WARNING"):
-            monitor.check_live_streams_and_start_download()
-            monitor.check_live_streams_and_start_download()
-
-        assert monitor.is_healthy is True
-        warnings = [
-            r for r in caplog.records if "Failed to write heartbeat file" in r.message
-        ]
-        assert len(warnings) == 1
+        assert main() == 1
+        err = capsys.readouterr().err
+        assert "stale" in err
+        assert "max=15" in err

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,140 @@
+"""Tests for Docker heartbeat health probe and monitor touch."""
+
+import os
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core import health
+from core.constants import DEFAULT_INTERVAL, HEARTBEAT_STALE_MULTIPLIER
+from core.health import check_heartbeat, main, touch_heartbeat
+from core.live_stream_monitor import LiveStreamMonitor
+from core.rplay import RPlayAPI
+from models.config import AppConfig
+
+
+def _runtime_config(creators=None):
+    return AppConfig(api_base_url="https://api.rplay.live", creators=creators or [])
+
+
+class TestTouchAndCheck:
+    """Unit tests for heartbeat file helpers."""
+
+    def test_fresh_file_is_healthy(self, tmp_path, monkeypatch):
+        """A just-touched heartbeat file reports healthy."""
+        path = tmp_path / "heartbeat"
+        monkeypatch.setattr(health, "HEARTBEAT_FILE_PATH", str(path))
+        touch_heartbeat(str(path))
+
+        ok, reason = check_heartbeat(str(path))
+
+        assert ok is True
+        assert reason == ""
+        assert main() == 0
+
+    def test_missing_file_is_unhealthy(self, tmp_path, monkeypatch, capsys):
+        """A missing heartbeat file reports unhealthy with a reason."""
+        path = tmp_path / "missing-heartbeat"
+        monkeypatch.setattr(health, "HEARTBEAT_FILE_PATH", str(path))
+
+        ok, reason = check_heartbeat(str(path))
+
+        assert ok is False
+        assert "missing" in reason
+        assert main() == 1
+        assert "missing" in capsys.readouterr().err
+
+    def test_stale_mtime_is_unhealthy(self, tmp_path, monkeypatch):
+        """A heartbeat older than 3×INTERVAL reports unhealthy."""
+        path = tmp_path / "heartbeat"
+        monkeypatch.setattr(health, "HEARTBEAT_FILE_PATH", str(path))
+        monkeypatch.delenv("INTERVAL", raising=False)
+        touch_heartbeat(str(path))
+
+        max_age = HEARTBEAT_STALE_MULTIPLIER * DEFAULT_INTERVAL
+        stale_mtime = time.time() - max_age - 1
+        os.utime(path, (stale_mtime, stale_mtime))
+
+        ok, reason = check_heartbeat(str(path), now=time.time())
+
+        assert ok is False
+        assert "stale" in reason
+        assert main() == 1
+
+    def test_threshold_respects_interval_env(self, tmp_path, monkeypatch):
+        """Staleness threshold scales with INTERVAL from the environment."""
+        path = tmp_path / "heartbeat"
+        monkeypatch.setenv("INTERVAL", "10")
+        touch_heartbeat(str(path))
+
+        # age 25s is fresh at INTERVAL=10 (max=30) but would be stale at 60.
+        age = 25
+        mtime = time.time() - age
+        os.utime(path, (mtime, mtime))
+        now = time.time()
+
+        ok, _ = check_heartbeat(str(path), now=now)
+        assert ok is True
+
+        # Drop INTERVAL so the same age exceeds 3×interval.
+        monkeypatch.setenv("INTERVAL", "5")
+        ok, reason = check_heartbeat(str(path), now=now)
+        assert ok is False
+        assert "stale" in reason
+        assert "max=15" in reason
+
+
+class TestMonitorHeartbeat:
+    """Monitor poll cycle must touch the heartbeat without breaking on errors."""
+
+    @patch("core.live_stream_monitor.read_config")
+    def test_poll_cycle_touches_heartbeat(self, mock_read_config, tmp_path, monkeypatch):
+        """A completed poll cycle creates/updates the heartbeat file."""
+        path = tmp_path / "heartbeat"
+        monkeypatch.setattr("core.health.HEARTBEAT_FILE_PATH", str(path))
+        monkeypatch.setattr(
+            "core.live_stream_monitor.touch_heartbeat",
+            lambda: touch_heartbeat(str(path)),
+        )
+        mock_api = MagicMock(spec=RPlayAPI)
+        mock_api.get_livestream_status.return_value = []
+        mock_read_config.return_value = _runtime_config()
+        monitor = LiveStreamMonitor(
+            auth_token="test_token",
+            user_oid="test_oid",
+            api=mock_api,
+        )
+
+        assert not path.exists()
+        monitor.check_live_streams_and_start_download()
+        assert path.exists()
+
+    @patch("core.live_stream_monitor.read_config")
+    def test_oserror_on_touch_does_not_break_cycle(
+        self, mock_read_config, monkeypatch, caplog
+    ):
+        """OSError writing the heartbeat is logged once and does not fail the poll."""
+        mock_api = MagicMock(spec=RPlayAPI)
+        mock_api.get_livestream_status.return_value = []
+        mock_read_config.return_value = _runtime_config()
+
+        def boom() -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr("core.live_stream_monitor.touch_heartbeat", boom)
+        monitor = LiveStreamMonitor(
+            auth_token="test_token",
+            user_oid="test_oid",
+            api=mock_api,
+        )
+
+        with caplog.at_level("WARNING"):
+            monitor.check_live_streams_and_start_download()
+            monitor.check_live_streams_and_start_download()
+
+        assert monitor.is_healthy is True
+        warnings = [
+            r for r in caplog.records if "Failed to write heartbeat file" in r.message
+        ]
+        assert len(warnings) == 1

--- a/tests/test_live_stream_monitor.py
+++ b/tests/test_live_stream_monitor.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from core import health
 from core.config import ConfigError
 from core.live_stream_monitor import LiveStreamMonitor
 from core.rplay import RPlayAPI, RPlayAPIError, RPlayAuthError, RPlayConnectionError
@@ -1987,3 +1988,60 @@ class TestSessionLifecycleLogging:
             )
 
         assert any("Merge completed" in str(call) for call in mock_info.call_args_list)
+
+
+class TestMonitorHeartbeatFile:
+    """Poll-cycle Docker heartbeat file: touch, OSError guard, finally on raise."""
+
+    @patch("core.live_stream_monitor.read_config")
+    def test_poll_cycle_touches_heartbeat(
+        self, mock_read_config, monitor, mock_api, tmp_path, monkeypatch
+    ):
+        """A completed poll cycle creates/updates the heartbeat file."""
+        path = tmp_path / "heartbeat"
+        monkeypatch.setattr(health, "HEARTBEAT_FILE", str(path))
+        mock_api.get_livestream_status.return_value = []
+        mock_read_config.return_value = _runtime_config([])
+
+        assert not path.exists()
+        monitor.check_live_streams_and_start_download()
+        assert path.exists()
+
+    @patch("core.live_stream_monitor.read_config")
+    def test_oserror_on_touch_does_not_break_cycle(
+        self, mock_read_config, monitor, mock_api, monkeypatch, caplog
+    ):
+        """OSError writing the heartbeat is logged once and does not fail the poll."""
+        mock_api.get_livestream_status.return_value = []
+        mock_read_config.return_value = _runtime_config([])
+
+        def boom() -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr("core.live_stream_monitor.touch_heartbeat", boom)
+
+        with caplog.at_level("WARNING"):
+            monitor.check_live_streams_and_start_download()
+            monitor.check_live_streams_and_start_download()
+
+        assert monitor.is_healthy is True
+        warnings = [
+            r for r in caplog.records if "Failed to write heartbeat file" in r.message
+        ]
+        assert len(warnings) == 1
+
+    @patch("core.live_stream_monitor.read_config")
+    def test_raising_cycle_still_touches_heartbeat(
+        self, mock_read_config, monitor, mock_api, tmp_path, monkeypatch
+    ):
+        """A poll body that raises still updates the heartbeat in finally."""
+        path = tmp_path / "heartbeat"
+        monkeypatch.setattr(health, "HEARTBEAT_FILE", str(path))
+        mock_read_config.return_value = _runtime_config([])
+        mock_api.get_livestream_status.side_effect = RPlayAPIError("API down")
+
+        assert not path.exists()
+        monitor.check_live_streams_and_start_download()
+        assert path.exists()
+        assert monitor.is_healthy is False
+


### PR DESCRIPTION
## Summary
Container-visible liveness: the monitor touches a heartbeat file once per poll cycle, and a stdlib-only probe exposes staleness to Docker.

- Monitor touches `/tmp/rplay-live-dl-heartbeat` in the poll cycle's `finally` (failed cycles still count as alive — this is a liveness check for a hung/dead loop, not readiness; OSError → warn once, never breaks polling).
- `python -m core.health` exits 0 when the heartbeat is fresher than 3×INTERVAL, else 1 with a one-line reason. Boundary is strict (`age >= 3×INTERVAL` is stale); a FUTURE mtime (clock stepped back) is unhealthy with a clock-skew reason; garbage/non-positive INTERVAL falls back to the shared default.
- Dockerfile `HEALTHCHECK` runs the probe (60s interval, retries 3, start period). Docker only DISPLAYS unhealthy — no autoheal/restart logic, by scope decision. Docker marks unhealthy roughly 300–360s after the last heartbeat update.
- README documents the behavior in one paragraph.

## Acceptance criteria
- [ ] Fresh heartbeat → exit 0; missing/stale/exact-threshold/future mtime → exit 1 with reason
- [ ] Poll cycles (including ones whose body raises) update the heartbeat
- [ ] Probe is stdlib-only and honors INTERVAL from env
- [ ] `docker inspect` shows health status; no restart behavior added

## Verification
- Full suite 3 consecutive runs: `357 passed in 38.54s` / `38.57s` / `38.50s`
- Docker build verified: HEALTHCHECK present; probe runs in image (exit 1 with missing heartbeat as expected)
- Dual independent review (L3-calibrated pragmatic + over-engineering pass) + fix round addressing all findings
