### PR TITLE
feat: recover orphaned .ts recordings at startup

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -44,6 +44,10 @@ DEFAULT_LOG_YTDLP_INTERNAL = False
 # Minimum free disk space (GiB) before starting a recording; 0 disables
 DEFAULT_MIN_FREE_DISK_GB = 5.0
 
+# Wall-clock ceiling for one ffmpeg concat merge, shared by the live merge
+# executor and startup orphan recovery so both bound the same work identically.
+DEFAULT_MERGE_TIMEOUT_SECONDS = 7200
+
 # Poll interval default (INTERVAL env); shared by EnvConfig and the health probe
 DEFAULT_INTERVAL = 60
 
@@ -66,5 +70,6 @@ __all__ = [
     "DEFAULT_LOG_RETENTION_DAYS",
     "DEFAULT_LOG_YTDLP_INTERNAL",
     "DEFAULT_MIN_FREE_DISK_GB",
+    "DEFAULT_MERGE_TIMEOUT_SECONDS",
     "DEFAULT_INTERVAL",
 ]

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -12,7 +12,10 @@ from typing import Callable, Dict, List, Optional, Set, Union
 
 from pathvalidate import sanitize_filename
 
-from core.constants import DEFAULT_MIN_FREE_DISK_GB
+from core.constants import (
+    DEFAULT_MERGE_TIMEOUT_SECONDS as _DEFAULT_MERGE_TIMEOUT_SECONDS,
+    DEFAULT_MIN_FREE_DISK_GB,
+)
 from models.config import CreatorProfile
 from models.download import (
     DownloadSession,
@@ -34,7 +37,7 @@ from .downloader import StreamDownloader
 from .health import touch_heartbeat
 from .logger import bind, clip, setup_logger
 from .rplay import RPlayAPI, RPlayAPIError, RPlayAuthError, RPlayConnectionError
-from .utils import terminate_child_processes
+from .utils import merge_ts_files_to_mp4, terminate_child_processes
 
 __all__ = [
     "LiveStreamMonitor",
@@ -92,7 +95,7 @@ class LiveStreamMonitor:
     - Automatic cleanup of inactive downloaders which are not monitored
     """
 
-    DEFAULT_MERGE_TIMEOUT_SECONDS = 7200
+    DEFAULT_MERGE_TIMEOUT_SECONDS = _DEFAULT_MERGE_TIMEOUT_SECONDS
     POLL_WAIT_TIMEOUT_SECONDS = 30.0
     # One aggregate budget for the whole shutdown, not a per-step timeout that
     # the next step can extend: every wait below draws from the same deadline,
@@ -1148,31 +1151,7 @@ class LiveStreamMonitor:
 
     def _run_ffmpeg_merge(self, ts_files: List[Path], output_path: Path) -> None:
         """Merge ts fragments into one mp4 file using ffmpeg concat."""
-        list_path = ts_files[0].parent / "merge-inputs.txt"
-        list_content = "\n".join(
-            self._format_ffconcat_input_path(ts_file) for ts_file in ts_files
-        )
-        list_path.write_text(list_content, encoding="utf-8")
-
-        try:
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            self._run_merge_subprocess(
-                [
-                    "ffmpeg",
-                    "-y",
-                    "-f",
-                    "concat",
-                    "-safe",
-                    "0",
-                    "-i",
-                    str(list_path),
-                    "-c",
-                    "copy",
-                    str(output_path),
-                ]
-            )
-        finally:
-            list_path.unlink(missing_ok=True)
+        merge_ts_files_to_mp4(ts_files, output_path, self._run_merge_subprocess)
 
     def _run_merge_subprocess(self, command: List[str]) -> None:
         """
@@ -1215,11 +1194,6 @@ class LiveStreamMonitor:
         finally:
             with self._state_lock:
                 self._merge_process_pids.discard(process.pid)
-
-    def _format_ffconcat_input_path(self, ts_file: Path) -> str:
-        """Format one concat-demuxer input line with apostrophe-safe escaping."""
-        escaped_path = ts_file.resolve().as_posix().replace("'", r"'\''")
-        return f"file '{escaped_path}'"
 
     def _shutdown_time_left(self, cap: Optional[float] = None) -> float:
         """Return the seconds left in the aggregate budget, capped for one phase."""

--- a/core/orphan_recovery.py
+++ b/core/orphan_recovery.py
@@ -1,15 +1,10 @@
 """
 Startup recovery for raw .ts recordings whose merge never completed.
 
-Two paths leave a finished recording unmerged on disk: a merge abandoned when
-shutdown's aggregate budget ran out, and a raw download whose completion event
-arrived after the merge executor had already closed. Both are logged at the
-time, but nothing merges them afterwards, so the recording stays as .ts files
-that no later run would ever look at again.
-
-This module merges them at the next startup using the same ffmpeg concat
-invocation the live merge executor uses, so a recovered recording is
-byte-for-byte the artifact the interrupted run would have produced.
+A merge abandoned when shutdown's aggregate budget ran out, or a raw download
+whose completion arrived after the merge executor had closed, leaves a finished
+recording on disk as .ts files that no later run would look at again. This
+merges them through the same ffmpeg concat invocation the live merge uses.
 """
 
 import logging
@@ -27,64 +22,35 @@ __all__ = [
 ]
 
 # The canonical session prefix the downloader stamps onto every raw output:
-# YYYYMMDD_HHMMSS_. Recovery is deliberately narrow — a .ts file without this
-# prefix was not produced by a session this application can reconstruct, so it
-# is left alone rather than guessed at.
+# YYYYMMDD_HHMMSS_. A .ts file without it was not produced by a session this
+# application can reconstruct, so it is left alone rather than guessed at.
 _SESSION_PREFIX_RE = re.compile(r"^[0-9]{8}_[0-9]{6}_")
 
-_TS_SUFFIX = ".ts"
 
-
-def recover_orphaned_sessions(
-    logger: logging.Logger,
-    merge_timeout_seconds: int = DEFAULT_MERGE_TIMEOUT_SECONDS,
-) -> int:
+def recover_orphaned_sessions(logger: logging.Logger) -> None:
     """
     Merge every recoverable orphaned session under the archive directory.
 
     Runs synchronously at startup, before the scheduler polls, so recovery
-    cannot race a fresh recording writing into the same creator directory.
-
-    Single-instance assumption: at startup nothing else in this process is
-    writing these files. A second concurrent instance pointed at the same
-    volume is explicitly out of scope — it could observe a half-written mp4
-    from the other instance's merge.
-
-    Returns:
-        The number of sessions merged successfully.
+    cannot race a fresh recording writing into the same creator directory. A
+    second concurrent instance on the same volume is out of scope: it could
+    observe a half-written mp4 from the other instance's merge.
     """
     archive = Path.cwd() / StreamDownloader.ARCHIVE_DIR
-    if not archive.is_dir():
-        return 0
 
-    sessions = _group_orphan_sessions(archive)
-    recovered = 0
-    for (output_dir, session_prefix), ts_files in sorted(sessions.items()):
-        if _recover_one_session(
-            logger, output_dir, session_prefix, ts_files, merge_timeout_seconds
-        ):
-            recovered += 1
-
-    return recovered
-
-
-def _group_orphan_sessions(archive: Path) -> Dict[Tuple[Path, str], List[Path]]:
-    """
-    Group orphaned .ts payloads by the session that produced them.
-
-    Only ``*.ts`` is globbed, which is what keeps yt-dlp's in-flight artifacts
-    out of recovery entirely: .part, .part-FragN and .ytdl all end in another
-    suffix, so they can never enter a concat list nor a cleanup loop. Those may
-    be truncated mid-write, and merging them would produce broken video.
-    """
+    # Globbing *.ts alone is what keeps yt-dlp's in-flight artifacts out of
+    # recovery entirely: .part, .part-FragN and .ytdl all end in another
+    # suffix, so they can enter neither a concat list nor a cleanup loop. Those
+    # may be truncated mid-write, and merging them would produce broken video.
     sessions: Dict[Tuple[Path, str], List[Path]] = {}
-    for ts_file in sorted(archive.glob(f"*/*{_TS_SUFFIX}")):
+    for ts_file in sorted(archive.glob("*/*.ts")):
         match = _SESSION_PREFIX_RE.match(ts_file.name)
         if match is None:
             continue
         sessions.setdefault((ts_file.parent, match.group(0)), []).append(ts_file)
 
-    return sessions
+    for (output_dir, session_prefix), ts_files in sorted(sessions.items()):
+        _recover_one_session(logger, output_dir, session_prefix, ts_files)
 
 
 def _recover_one_session(
@@ -92,9 +58,8 @@ def _recover_one_session(
     output_dir: Path,
     session_prefix: str,
     ts_files: List[Path],
-    merge_timeout_seconds: int,
-) -> bool:
-    """Merge one session's raw .ts files, returning True only on full success."""
+) -> None:
+    """Merge one session's raw .ts files, deleting them only once the mp4 is proven."""
     session_id = session_prefix.rstrip("_")
 
     # The live path builds the final name by dropping the session prefix from
@@ -107,7 +72,7 @@ def _recover_one_session(
             f"⚠️ Skipping orphan recovery for session {session_id}: "
             f"{ts_files[0].name} has no name beyond its session prefix"
         )
-        return False
+        return
 
     output_path = output_dir / f"{final_stem}.mp4"
     if output_path.exists():
@@ -120,24 +85,47 @@ def _recover_one_session(
             f"{output_path.name} already exists. "
             f"Raw .ts files left in: {output_dir}"
         )
-        return False
+        return
 
+    # ffmpeg writes to a temporary name in the same directory, and only a
+    # validated result is renamed onto the final one. A process death mid-merge
+    # would otherwise leave a partial file under the final name, which the
+    # collision check above reads as a finished recording — skipping that
+    # session, and its intact inputs, on every later startup. The .mp4 suffix
+    # is kept so ffmpeg still infers the mp4 muxer; a stale temp from an
+    # interrupted attempt is overwritten by the invocation's -y.
+    temp_path = output_path.with_name(f".{final_stem}.recovering.mp4")
     try:
         merge_ts_files_to_mp4(
             ts_files,
-            output_path,
-            lambda command: _run_recovery_ffmpeg(command, merge_timeout_seconds),
+            temp_path,
+            lambda command: subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=DEFAULT_MERGE_TIMEOUT_SECONDS,
+            ),
         )
+
+        # A merge callable that returns without producing anything must not
+        # count as success: the inputs below are deleted on the strength of
+        # this check, so the recording would be lost to an empty result.
+        if not temp_path.is_file() or temp_path.stat().st_size == 0:
+            raise RuntimeError(f"merge produced no output at {temp_path.name}")
+
+        # Atomic within the directory: the final name never exists half-written.
+        temp_path.replace(output_path)
     except Exception as exc:
-        # Same contract as the live merge: drop the half-written mp4 so a
-        # failure cannot pass for a finished recording, and keep every input so
-        # the next startup can attempt this session again unchanged.
-        _discard_partial_output(logger, output_path)
+        # Same contract as the live merge: drop the partial output so a failure
+        # cannot pass for a finished recording, and keep every input so the
+        # next startup can attempt this session again unchanged.
+        _discard_partial_output(logger, temp_path)
         logger.warning(
             f"⚠️ Orphan recovery merge failed for session {session_id}: {exc}. "
             f"Raw .ts files left in: {output_dir}"
         )
-        return False
+        return
 
     for ts_file in ts_files:
         try:
@@ -154,34 +142,13 @@ def _recover_one_session(
         f"🛟 Recovered interrupted recording (session {session_id}): "
         f"merged {len(ts_files)} raw file(s) into {output_path}"
     )
-    return True
 
 
-def _run_recovery_ffmpeg(command: List[str], timeout_seconds: int) -> None:
-    """
-    Run one recovery merge to completion.
-
-    Unlike the monitor's merge child, this one needs no pid registration: no
-    recording sweep runs at startup, so there is nothing to be spared from.
-
-    Raises:
-        subprocess.TimeoutExpired: If the merge outlives timeout_seconds
-        subprocess.CalledProcessError: If ffmpeg exits non-zero
-    """
-    subprocess.run(
-        command,
-        check=True,
-        capture_output=True,
-        text=True,
-        timeout=timeout_seconds,
-    )
-
-
-def _discard_partial_output(logger: logging.Logger, output_path: Path) -> None:
-    """Drop a half-written mp4 so a failed recovery leaves no broken artifact."""
+def _discard_partial_output(logger: logging.Logger, temp_path: Path) -> None:
+    """Drop a half-written merge output, without letting a locked file raise."""
     try:
-        output_path.unlink(missing_ok=True)
+        temp_path.unlink(missing_ok=True)
     except OSError as exc:
         logger.warning(
-            f"Could not remove partial recovery output {output_path.name}: {exc}"
+            f"Could not remove partial recovery output {temp_path.name}: {exc}"
         )

--- a/core/orphan_recovery.py
+++ b/core/orphan_recovery.py
@@ -1,0 +1,187 @@
+"""
+Startup recovery for raw .ts recordings whose merge never completed.
+
+Two paths leave a finished recording unmerged on disk: a merge abandoned when
+shutdown's aggregate budget ran out, and a raw download whose completion event
+arrived after the merge executor had already closed. Both are logged at the
+time, but nothing merges them afterwards, so the recording stays as .ts files
+that no later run would ever look at again.
+
+This module merges them at the next startup using the same ffmpeg concat
+invocation the live merge executor uses, so a recovered recording is
+byte-for-byte the artifact the interrupted run would have produced.
+"""
+
+import logging
+import re
+import subprocess
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from core.constants import DEFAULT_MERGE_TIMEOUT_SECONDS
+from core.downloader import StreamDownloader
+from core.utils import merge_ts_files_to_mp4
+
+__all__ = [
+    "recover_orphaned_sessions",
+]
+
+# The canonical session prefix the downloader stamps onto every raw output:
+# YYYYMMDD_HHMMSS_. Recovery is deliberately narrow — a .ts file without this
+# prefix was not produced by a session this application can reconstruct, so it
+# is left alone rather than guessed at.
+_SESSION_PREFIX_RE = re.compile(r"^[0-9]{8}_[0-9]{6}_")
+
+_TS_SUFFIX = ".ts"
+
+
+def recover_orphaned_sessions(
+    logger: logging.Logger,
+    merge_timeout_seconds: int = DEFAULT_MERGE_TIMEOUT_SECONDS,
+) -> int:
+    """
+    Merge every recoverable orphaned session under the archive directory.
+
+    Runs synchronously at startup, before the scheduler polls, so recovery
+    cannot race a fresh recording writing into the same creator directory.
+
+    Single-instance assumption: at startup nothing else in this process is
+    writing these files. A second concurrent instance pointed at the same
+    volume is explicitly out of scope — it could observe a half-written mp4
+    from the other instance's merge.
+
+    Returns:
+        The number of sessions merged successfully.
+    """
+    archive = Path.cwd() / StreamDownloader.ARCHIVE_DIR
+    if not archive.is_dir():
+        return 0
+
+    sessions = _group_orphan_sessions(archive)
+    recovered = 0
+    for (output_dir, session_prefix), ts_files in sorted(sessions.items()):
+        if _recover_one_session(
+            logger, output_dir, session_prefix, ts_files, merge_timeout_seconds
+        ):
+            recovered += 1
+
+    return recovered
+
+
+def _group_orphan_sessions(archive: Path) -> Dict[Tuple[Path, str], List[Path]]:
+    """
+    Group orphaned .ts payloads by the session that produced them.
+
+    Only ``*.ts`` is globbed, which is what keeps yt-dlp's in-flight artifacts
+    out of recovery entirely: .part, .part-FragN and .ytdl all end in another
+    suffix, so they can never enter a concat list nor a cleanup loop. Those may
+    be truncated mid-write, and merging them would produce broken video.
+    """
+    sessions: Dict[Tuple[Path, str], List[Path]] = {}
+    for ts_file in sorted(archive.glob(f"*/*{_TS_SUFFIX}")):
+        match = _SESSION_PREFIX_RE.match(ts_file.name)
+        if match is None:
+            continue
+        sessions.setdefault((ts_file.parent, match.group(0)), []).append(ts_file)
+
+    return sessions
+
+
+def _recover_one_session(
+    logger: logging.Logger,
+    output_dir: Path,
+    session_prefix: str,
+    ts_files: List[Path],
+    merge_timeout_seconds: int,
+) -> bool:
+    """Merge one session's raw .ts files, returning True only on full success."""
+    session_id = session_prefix.rstrip("_")
+
+    # The live path builds the final name by dropping the session prefix from
+    # the raw output name, so recovering it is the same subtraction. Deriving
+    # it from the file on disk also keeps whatever title sanitization the
+    # original run applied, which post-restart state can no longer supply.
+    final_stem = ts_files[0].stem[len(session_prefix):]
+    if not final_stem:
+        logger.warning(
+            f"⚠️ Skipping orphan recovery for session {session_id}: "
+            f"{ts_files[0].name} has no name beyond its session prefix"
+        )
+        return False
+
+    output_path = output_dir / f"{final_stem}.mp4"
+    if output_path.exists():
+        # Most likely this session already merged and only the .ts cleanup
+        # failed (a locked input leaves the mp4 in place by design). Re-merging
+        # would archive a duplicate of a finished recording, so the inputs are
+        # left for an operator to compare and remove.
+        logger.warning(
+            f"⚠️ Skipping orphan recovery for session {session_id}: "
+            f"{output_path.name} already exists. "
+            f"Raw .ts files left in: {output_dir}"
+        )
+        return False
+
+    try:
+        merge_ts_files_to_mp4(
+            ts_files,
+            output_path,
+            lambda command: _run_recovery_ffmpeg(command, merge_timeout_seconds),
+        )
+    except Exception as exc:
+        # Same contract as the live merge: drop the half-written mp4 so a
+        # failure cannot pass for a finished recording, and keep every input so
+        # the next startup can attempt this session again unchanged.
+        _discard_partial_output(logger, output_path)
+        logger.warning(
+            f"⚠️ Orphan recovery merge failed for session {session_id}: {exc}. "
+            f"Raw .ts files left in: {output_dir}"
+        )
+        return False
+
+    for ts_file in ts_files:
+        try:
+            ts_file.unlink(missing_ok=True)
+        except OSError as cleanup_error:
+            # The mp4 is the artifact of record from here; a locked input must
+            # not undo a good merge. Startup's leftover scan will list it, and
+            # the next run skips this session on the existing-output check.
+            logger.warning(
+                f"Merged, but could not remove {ts_file.name}: {cleanup_error}"
+            )
+
+    logger.info(
+        f"🛟 Recovered interrupted recording (session {session_id}): "
+        f"merged {len(ts_files)} raw file(s) into {output_path}"
+    )
+    return True
+
+
+def _run_recovery_ffmpeg(command: List[str], timeout_seconds: int) -> None:
+    """
+    Run one recovery merge to completion.
+
+    Unlike the monitor's merge child, this one needs no pid registration: no
+    recording sweep runs at startup, so there is nothing to be spared from.
+
+    Raises:
+        subprocess.TimeoutExpired: If the merge outlives timeout_seconds
+        subprocess.CalledProcessError: If ffmpeg exits non-zero
+    """
+    subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+    )
+
+
+def _discard_partial_output(logger: logging.Logger, output_path: Path) -> None:
+    """Drop a half-written mp4 so a failed recovery leaves no broken artifact."""
+    try:
+        output_path.unlink(missing_ok=True)
+    except OSError as exc:
+        logger.warning(
+            f"Could not remove partial recovery output {output_path.name}: {exc}"
+        )

--- a/core/utils.py
+++ b/core/utils.py
@@ -4,12 +4,14 @@ Utility functions for rplay-live-dl.
 Provides common helper functions used across multiple modules.
 """
 
-from typing import Optional
+from pathlib import Path
+from typing import Callable, List, Optional
 
 import psutil
 
 __all__ = [
     "format_file_size",
+    "merge_ts_files_to_mp4",
     "terminate_child_processes",
 ]
 
@@ -70,6 +72,59 @@ def terminate_child_processes(
         total += len(children)
 
     return total
+
+
+def _format_ffconcat_input_path(ts_file: Path) -> str:
+    """Format one concat-demuxer input line with apostrophe-safe escaping."""
+    escaped_path = ts_file.resolve().as_posix().replace("'", r"'\''")
+    return f"file '{escaped_path}'"
+
+
+def merge_ts_files_to_mp4(
+    ts_files: List[Path],
+    output_path: Path,
+    run_command: Callable[[List[str]], None],
+) -> None:
+    """
+    Merge ts fragments into one mp4 file using ffmpeg concat.
+
+    Shared by the live merge executor and startup orphan recovery so a
+    recovered recording is produced by exactly the same ffmpeg invocation as
+    one merged in-process. Only process supervision differs between the two,
+    which is why the caller supplies ``run_command``: the monitor registers the
+    child pid under its state lock so shutdown can spare an active merge, while
+    startup recovery has no sweep to protect against and just waits.
+
+    Args:
+        ts_files: Raw inputs, already ordered; the first one's parent holds the
+            temporary concat list.
+        output_path: Destination mp4. Callers own collision policy.
+        run_command: Executes the ffmpeg command. Must raise on non-zero exit
+            (``CalledProcessError``) and on timeout (``TimeoutExpired``).
+    """
+    list_path = ts_files[0].parent / "merge-inputs.txt"
+    list_content = "\n".join(_format_ffconcat_input_path(ts_file) for ts_file in ts_files)
+    list_path.write_text(list_content, encoding="utf-8")
+
+    try:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        run_command(
+            [
+                "ffmpeg",
+                "-y",
+                "-f",
+                "concat",
+                "-safe",
+                "0",
+                "-i",
+                str(list_path),
+                "-c",
+                "copy",
+                str(output_path),
+            ]
+        )
+    finally:
+        list_path.unlink(missing_ok=True)
 
 
 def format_file_size(size_bytes: float) -> str:

--- a/core/utils.py
+++ b/core/utils.py
@@ -88,17 +88,17 @@ def merge_ts_files_to_mp4(
     """
     Merge ts fragments into one mp4 file using ffmpeg concat.
 
-    Shared by the live merge executor and startup orphan recovery so a
-    recovered recording is produced by exactly the same ffmpeg invocation as
-    one merged in-process. Only process supervision differs between the two,
-    which is why the caller supplies ``run_command``: the monitor registers the
-    child pid under its state lock so shutdown can spare an active merge, while
-    startup recovery has no sweep to protect against and just waits.
+    Shared by the live merge executor and startup orphan recovery so both
+    produce a recording through the same invocation. Only process supervision
+    differs, which is why the caller supplies ``run_command``: the monitor
+    registers the child pid under its state lock so shutdown can spare an
+    active merge, while startup recovery has no sweep to protect against.
 
     Args:
         ts_files: Raw inputs, already ordered; the first one's parent holds the
             temporary concat list.
-        output_path: Destination mp4. Callers own collision policy.
+        output_path: Destination mp4, in an existing directory. Callers own
+            collision policy and validation of the result.
         run_command: Executes the ffmpeg command. Must raise on non-zero exit
             (``CalledProcessError``) and on timeout (``TimeoutExpired``).
     """
@@ -107,7 +107,6 @@ def merge_ts_files_to_mp4(
     list_path.write_text(list_content, encoding="utf-8")
 
     try:
-        output_path.parent.mkdir(parents=True, exist_ok=True)
         run_command(
             [
                 "ffmpeg",

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from core.constants import DEFAULT_RPLAY_API_BASE_URL
 from core.downloader import StreamDownloader
 from core.env import EnvConfig, EnvConfigError, load_env
 from core.logger import cleanup_old_logs, configure_logging, setup_logger
+from core.orphan_recovery import recover_orphaned_sessions
 from core.rplay import RPlayAPI, RPlayAPIError, RPlayAuthError
 from core.scheduler import run_scheduler
 
@@ -39,9 +40,10 @@ def _warn_about_orphaned_downloads(logger: logging.Logger) -> None:
     *.ytdl and *.part-Frag* behind on a kill; unmerged session .ts files stay
     when a merge fails or the process dies first.
     """
-    # ponytail: report-only. Auto-merging .ts is deferred until shutdown is
-    # trustworthy, and .part fragments may be truncated mid-write, so merging
-    # those would produce broken video.
+    # Runs after recovery, so what it lists is what recovery could not fix:
+    # sessions it skipped or failed to merge, plus the yt-dlp artifacts it
+    # never touches. ponytail: report-only for .part fragments, which may be
+    # truncated mid-write, so merging those would produce broken video.
     archive = Path.cwd() / StreamDownloader.ARCHIVE_DIR
     if not archive.is_dir():
         return
@@ -89,6 +91,15 @@ def main() -> None:
             logger.info(f"Cleaned up {removed} old log file(s)")
     except Exception as e:
         logger.warning(f"Failed to cleanup old logs: {e}")
+
+    # Before the scheduler polls: nothing else is writing the archive yet, so
+    # merging here cannot race a fresh recording into the same directory.
+    try:
+        recover_orphaned_sessions(logger)
+    except Exception as e:
+        # Recovery is best-effort housekeeping; it must never block startup.
+        # Every input it touches is kept on failure, so the next run retries.
+        logger.warning(f"Failed to recover orphaned recordings: {e}")
 
     _warn_about_orphaned_downloads(logger)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -40,6 +40,11 @@ def _patch_main_startup(monkeypatch, *, api_side_effect=None, calls=None):
     )
     monkeypatch.setattr("main.cleanup_old_logs", MagicMock(return_value=0))
     monkeypatch.setattr("main._warn_about_orphaned_downloads", MagicMock())
+    # Never let a main() test merge whatever sits in the real ./archive.
+    monkeypatch.setattr(
+        "main.recover_orphaned_sessions",
+        _track("recover_orphaned_sessions", MagicMock(return_value=0)),
+    )
     monkeypatch.setattr(
         "main.read_app_config",
         MagicMock(
@@ -167,16 +172,20 @@ def test_main_invalid_log_level_exits_before_setup_logger(monkeypatch, capsys):
 
 
 def test_main_success_order(monkeypatch):
-    """Test main runs load_env → logging → credential validation → scheduler."""
+    """Test main runs load_env → logging → orphan recovery → credentials → scheduler."""
     calls: list[str] = []
     api, _ = _patch_main_startup(monkeypatch, calls=calls)
 
     main()
 
+    # Recovery must sit after logging is configured (so its per-session lines
+    # are captured) and before run_scheduler (so no poll can start a recording
+    # into a directory recovery is still merging).
     assert calls == [
         "load_env",
         "configure_logging",
         "setup_logger",
+        "recover_orphaned_sessions",
         "validate_credentials",
         "run_scheduler",
     ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -43,7 +43,7 @@ def _patch_main_startup(monkeypatch, *, api_side_effect=None, calls=None):
     # Never let a main() test merge whatever sits in the real ./archive.
     monkeypatch.setattr(
         "main.recover_orphaned_sessions",
-        _track("recover_orphaned_sessions", MagicMock(return_value=0)),
+        _track("recover_orphaned_sessions", MagicMock()),
     )
     monkeypatch.setattr(
         "main.read_app_config",

--- a/tests/test_orphan_recovery.py
+++ b/tests/test_orphan_recovery.py
@@ -2,12 +2,13 @@
 
 import logging
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
 
-from core.orphan_recovery import _run_recovery_ffmpeg, recover_orphaned_sessions
+from core.orphan_recovery import recover_orphaned_sessions
+
+LOGGER = logging.getLogger("test_recovery")
 
 
 @pytest.fixture
@@ -19,25 +20,21 @@ def archive(tmp_path, monkeypatch):
     return creator_dir
 
 
-def _fake_successful_merge(monkeypatch, captured=None):
-    """Replace the ffmpeg seam with a writer that never spawns a process."""
+def _fake_merge(monkeypatch, *, writes=b"mp4", error=None, captured=None):
+    """
+    Replace the ffmpeg seam with a writer that never spawns a process.
+
+    ``writes=None`` stands in for a merge that returns without producing
+    anything, ``writes=b""`` for one that produces an empty file.
+    """
 
     def fake_merge(ts_files, output_path, run_command):
         if captured is not None:
             captured.append((list(ts_files), output_path))
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_bytes(b"mp4")
-
-    monkeypatch.setattr("core.orphan_recovery.merge_ts_files_to_mp4", fake_merge)
-
-
-def _fake_failing_merge(monkeypatch, error=None):
-    """Replace the ffmpeg seam with one that writes a partial mp4 then fails."""
-
-    def fake_merge(ts_files, output_path, run_command):
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_bytes(b"partial")
-        raise error or RuntimeError("boom")
+        if writes is not None:
+            output_path.write_bytes(writes)
+        if error is not None:
+            raise error
 
     monkeypatch.setattr("core.orphan_recovery.merge_ts_files_to_mp4", fake_merge)
 
@@ -45,79 +42,116 @@ def _fake_failing_merge(monkeypatch, error=None):
 class TestOrphanRecovery:
     """Recovery of session .ts files left behind by an interrupted run."""
 
-    def test_canonical_orphan_is_merged_and_inputs_deleted(self, archive, monkeypatch, caplog):
-        """Test a canonical orphan merges to mp4 and its inputs are removed."""
-        ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
-        ts_file.write_bytes(b"ts")
-        _fake_successful_merge(monkeypatch)
-
-        caplog.set_level(logging.INFO)
-        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
-
-        assert recovered == 1
-        merged = archive / "#Creator 2026-03-06 123.mp4"
-        assert merged.exists()
-        assert not ts_file.exists()
-        assert any(
-            "Recovered interrupted recording" in record.getMessage()
-            for record in caplog.records
-            if record.levelno == logging.INFO
-        )
-
-    def test_sibling_fragments_of_one_session_merge_in_order(self, archive, monkeypatch):
-        """Test numbered siblings of a session merge together, sorted, into one mp4."""
+    def test_session_fragments_merge_in_order_and_inputs_are_deleted(
+        self, archive, monkeypatch
+    ):
+        """Test one session's numbered fragments merge, sorted, into one mp4."""
         prefix = "20260306_120000_"
         base = archive / f"{prefix}#Creator 2026-03-06 123.ts"
         sibling = archive / f"{prefix}#Creator 2026-03-06 123_1.ts"
         base.write_bytes(b"ts")
         sibling.write_bytes(b"ts")
         captured = []
-        _fake_successful_merge(monkeypatch, captured)
+        _fake_merge(monkeypatch, captured=captured)
 
-        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
+        recover_orphaned_sessions(LOGGER)
 
-        assert recovered == 1
-        assert captured == [([base, sibling], archive / "#Creator 2026-03-06 123.mp4")]
+        assert (archive / "#Creator 2026-03-06 123.mp4").read_bytes() == b"mp4"
+        assert [ts_files for ts_files, _ in captured] == [[base, sibling]]
         assert not base.exists()
         assert not sibling.exists()
 
-    def test_failed_merge_keeps_all_inputs_and_discards_partial_output(
-        self, archive, monkeypatch, caplog
+    def test_failed_merge_keeps_every_input_and_the_next_run_recovers(
+        self, archive, monkeypatch
     ):
-        """Test a failed recovery keeps every input and leaves no partial mp4."""
+        """Test a failed merge leaves the session retryable and untouched."""
         prefix = "20260306_120000_"
         base = archive / f"{prefix}#Creator 2026-03-06 123.ts"
         sibling = archive / f"{prefix}#Creator 2026-03-06 123_1.ts"
         base.write_bytes(b"ts")
         sibling.write_bytes(b"ts")
-        _fake_failing_merge(monkeypatch)
-
-        caplog.set_level(logging.WARNING)
-        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
-
-        assert recovered == 0
-        assert base.exists()
-        assert sibling.exists()
-        assert not (archive / "#Creator 2026-03-06 123.mp4").exists()
-        assert any(
-            "Orphan recovery merge failed" in record.getMessage()
-            for record in caplog.records
-            if record.levelno == logging.WARNING
+        _fake_merge(
+            monkeypatch,
+            writes=b"partial",
+            error=subprocess.TimeoutExpired(cmd=["ffmpeg"], timeout=1),
         )
 
-    def test_merge_timeout_keeps_inputs(self, archive, monkeypatch):
-        """Test an ffmpeg timeout is a failure that preserves the recording."""
+        recover_orphaned_sessions(LOGGER)
+
+        # Nothing but the inputs may survive a failure — no partial artifact
+        # under any name, or the next run has a broken recording to reason about.
+        assert sorted(archive.iterdir()) == [base, sibling]
+
+        _fake_merge(monkeypatch)
+        recover_orphaned_sessions(LOGGER)
+
+        assert sorted(archive.iterdir()) == [archive / "#Creator 2026-03-06 123.mp4"]
+
+    def test_merge_producing_no_output_keeps_the_inputs(self, archive, monkeypatch):
+        """Test a merge that returns without writing anything is not a success."""
         ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
         ts_file.write_bytes(b"ts")
-        _fake_failing_merge(
-            monkeypatch, error=subprocess.TimeoutExpired(cmd=["ffmpeg"], timeout=1)
+        _fake_merge(monkeypatch, writes=None)
+
+        recover_orphaned_sessions(LOGGER)
+
+        assert list(archive.iterdir()) == [ts_file]
+
+    def test_merge_producing_an_empty_output_keeps_the_inputs(
+        self, archive, monkeypatch
+    ):
+        """Test a zero-byte result is not a recording, so the inputs stay."""
+        ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
+        ts_file.write_bytes(b"ts")
+        _fake_merge(monkeypatch, writes=b"")
+
+        recover_orphaned_sessions(LOGGER)
+
+        assert list(archive.iterdir()) == [ts_file]
+
+    def test_interrupted_merge_leaves_the_final_name_free_for_the_next_run(
+        self, archive, monkeypatch
+    ):
+        """Test a merge killed mid-write leaves a stale temp the next run overwrites."""
+        ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
+        ts_file.write_bytes(b"ts")
+        final_path = archive / "#Creator 2026-03-06 123.mp4"
+        captured = []
+        _fake_merge(
+            monkeypatch, writes=b"partial", error=RuntimeError("killed"), captured=captured
         )
 
-        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
+        recover_orphaned_sessions(LOGGER)
 
-        assert recovered == 0
+        # ffmpeg must never write the collision-significant final name directly:
+        # a partial left there is read as a finished recording, and the session
+        # is skipped on every later startup instead of being recovered.
+        (_, temp_path), = captured
+        assert temp_path != final_path
+
+        # A killed process runs no cleanup, so its partial temp survives.
+        temp_path.write_bytes(b"partial from a killed process")
+        _fake_merge(monkeypatch)
+
+        recover_orphaned_sessions(LOGGER)
+
+        assert final_path.read_bytes() == b"mp4"
+        assert list(archive.iterdir()) == [final_path]
+
+    def test_existing_output_collision_is_skipped_and_inputs_kept(
+        self, archive, monkeypatch
+    ):
+        """Test recovery never overwrites an existing mp4; it skips and keeps inputs."""
+        ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
+        ts_file.write_bytes(b"ts")
+        existing = archive / "#Creator 2026-03-06 123.mp4"
+        existing.write_bytes(b"already merged")
+        _fake_merge(monkeypatch)
+
+        recover_orphaned_sessions(LOGGER)
+
+        assert existing.read_bytes() == b"already merged"
         assert ts_file.exists()
-        assert not (archive / "#Creator 2026-03-06 123.mp4").exists()
 
     def test_part_and_ytdl_files_are_never_touched(self, archive, monkeypatch):
         """Test in-flight yt-dlp artifacts are ignored and survive a mixed recovery."""
@@ -133,13 +167,12 @@ class TestOrphanRecovery:
             path.write_bytes(payload)
 
         captured = []
-        _fake_successful_merge(monkeypatch, captured)
+        _fake_merge(monkeypatch, captured=captured)
 
-        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
+        recover_orphaned_sessions(LOGGER)
 
-        assert recovered == 1
         # Only the .ts payload may ever reach the merge inputs.
-        assert captured == [([ts_file], archive / "#Creator 2026-03-06 123.mp4")]
+        assert [ts_files for ts_files, _ in captured] == [[ts_file]]
         for path, payload in untouchable.items():
             assert path.read_bytes() == payload
 
@@ -157,74 +190,28 @@ class TestOrphanRecovery:
         """Test only the canonical YYYYMMDD_HHMMSS_ session pattern is recovered."""
         stray = archive / filename
         stray.write_bytes(b"ts")
-        _fake_successful_merge(monkeypatch)
+        _fake_merge(monkeypatch)
 
-        caplog.set_level(logging.INFO)
-        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
+        caplog.set_level(logging.DEBUG)
+        recover_orphaned_sessions(LOGGER)
 
-        assert recovered == 0
-        assert stray.exists()
-        assert list(archive.glob("*.mp4")) == []
+        assert list(archive.iterdir()) == [stray]
         assert not caplog.records
 
-    def test_existing_output_collision_is_skipped_and_inputs_kept(
-        self, archive, monkeypatch, caplog
-    ):
-        """Test recovery never overwrites an existing mp4; it skips and keeps inputs."""
-        ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
-        ts_file.write_bytes(b"ts")
-        existing = archive / "#Creator 2026-03-06 123.mp4"
-        existing.write_bytes(b"already merged")
-        _fake_successful_merge(monkeypatch)
+    def test_missing_archive_directory_is_ignored(self, tmp_path, monkeypatch, caplog):
+        """Test a first run with no archive directory is a quiet no-op."""
+        monkeypatch.chdir(tmp_path)
 
-        caplog.set_level(logging.WARNING)
-        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
+        caplog.set_level(logging.DEBUG)
+        recover_orphaned_sessions(LOGGER)
 
-        assert recovered == 0
-        assert existing.read_bytes() == b"already merged"
-        assert ts_file.exists()
-        assert any(
-            "already exists" in record.getMessage()
-            for record in caplog.records
-            if record.levelno == logging.WARNING
-        )
+        assert not caplog.records
 
-    def test_second_run_after_failure_recovers_the_same_session(self, archive, monkeypatch):
-        """Test a failed recovery stays retryable: the next startup merges it."""
-        ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
-        ts_file.write_bytes(b"ts")
-        logger = logging.getLogger("test_recovery")
-
-        _fake_failing_merge(monkeypatch)
-        assert recover_orphaned_sessions(logger) == 0
-        # Filesystem is no worse than before: input intact, no partial artifact.
-        assert ts_file.exists()
-        assert list(archive.glob("*.mp4")) == []
-
-        _fake_successful_merge(monkeypatch)
-        assert recover_orphaned_sessions(logger) == 1
-        assert (archive / "#Creator 2026-03-06 123.mp4").exists()
-        assert not ts_file.exists()
-
-    def test_successful_run_is_idempotent(self, archive, monkeypatch):
-        """Test re-running recovery after success finds nothing left to do."""
-        ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
-        ts_file.write_bytes(b"ts")
-        _fake_successful_merge(monkeypatch)
-        logger = logging.getLogger("test_recovery")
-
-        assert recover_orphaned_sessions(logger) == 1
-        merged = archive / "#Creator 2026-03-06 123.mp4"
-        assert merged.read_bytes() == b"mp4"
-
-        assert recover_orphaned_sessions(logger) == 0
-        assert merged.read_bytes() == b"mp4"
-
-    def test_cleanup_failure_keeps_the_merged_mp4(self, archive, monkeypatch, caplog):
+    def test_cleanup_failure_keeps_the_merged_mp4(self, archive, monkeypatch):
         """Test a locked input after a good merge never discards the mp4."""
         ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
         ts_file.write_bytes(b"ts")
-        _fake_successful_merge(monkeypatch)
+        _fake_merge(monkeypatch)
 
         real_unlink = Path.unlink
 
@@ -235,15 +222,10 @@ class TestOrphanRecovery:
 
         monkeypatch.setattr(Path, "unlink", deny_ts_unlink)
 
-        caplog.set_level(logging.INFO)
-        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
+        recover_orphaned_sessions(LOGGER)
 
-        assert recovered == 1
         assert (archive / "#Creator 2026-03-06 123.mp4").exists()
         assert ts_file.exists()
-        assert any(
-            "could not remove" in record.getMessage() for record in caplog.records
-        )
 
     def test_separate_sessions_and_creators_recover_independently(
         self, tmp_path, monkeypatch
@@ -257,84 +239,41 @@ class TestOrphanRecovery:
         (first / "20260306_120000_#Creator 2026-03-06 A.ts").write_bytes(b"ts")
         (first / "20260306_133000_#Creator 2026-03-06 B.ts").write_bytes(b"ts")
         (second / "20260306_140000_#Other 2026-03-06 C.ts").write_bytes(b"ts")
-        _fake_successful_merge(monkeypatch)
+        _fake_merge(monkeypatch)
 
-        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
+        recover_orphaned_sessions(LOGGER)
 
-        assert recovered == 3
-        assert (first / "#Creator 2026-03-06 A.mp4").exists()
-        assert (first / "#Creator 2026-03-06 B.mp4").exists()
-        assert (second / "#Other 2026-03-06 C.mp4").exists()
-        assert list(first.glob("*.ts")) == []
-        assert list(second.glob("*.ts")) == []
+        assert sorted(first.iterdir()) == [
+            first / "#Creator 2026-03-06 A.mp4",
+            first / "#Creator 2026-03-06 B.mp4",
+        ]
+        assert list(second.iterdir()) == [second / "#Other 2026-03-06 C.mp4"]
 
-    def test_quiet_and_safe_when_nothing_to_recover(self, archive, caplog):
-        """Test a clean archive logs nothing and reports no recoveries."""
-        (archive / "#Creator 2026-03-06 done.mp4").write_bytes(b"complete")
+    def test_ffmpeg_is_run_with_check_and_a_timeout_on_a_mp4_target(
+        self, archive, monkeypatch
+    ):
+        """Test recovery reaches ffmpeg through the shared helper, bounded and checked.
 
-        caplog.set_level(logging.DEBUG)
-        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
-
-        assert recovered == 0
-        assert not caplog.records
-
-    def test_missing_archive_directory_is_ignored(self, tmp_path, monkeypatch, caplog):
-        """Test a first run with no archive directory is a quiet no-op."""
-        monkeypatch.chdir(tmp_path)
-
-        caplog.set_level(logging.DEBUG)
-
-        assert recover_orphaned_sessions(logging.getLogger("test_recovery")) == 0
-        assert not caplog.records
-
-    def test_recovery_invokes_the_shared_ffmpeg_concat_command(self, archive, monkeypatch):
-        """Test recovery reaches ffmpeg through the same concat command as the live merge.
-
-        Exercises the real merge helper, stubbing only the subprocess call, so
-        the argv and concat list are the ones ffmpeg would actually receive.
+        Stubs only the subprocess call, so the kwargs and output target are the
+        ones ffmpeg would actually be given.
         """
-        ts_file = archive / "20260306_120000_#Creator 2026-03-06 it's live.ts"
+        ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
         ts_file.write_bytes(b"ts")
         captured = {}
 
         def fake_run(command, **kwargs):
             captured["command"] = command
             captured["kwargs"] = kwargs
-            captured["list_content"] = Path(command[7]).read_text(encoding="utf-8")
             # Stand in for ffmpeg actually producing the output.
             Path(command[-1]).write_bytes(b"mp4")
 
         monkeypatch.setattr("core.orphan_recovery.subprocess.run", fake_run)
 
-        assert recover_orphaned_sessions(logging.getLogger("test_recovery")) == 1
+        recover_orphaned_sessions(LOGGER)
 
-        assert captured["command"][:7] == [
-            "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i",
-        ]
-        assert captured["command"][8:10] == ["-c", "copy"]
-        assert captured["command"][-1] == str(archive / "#Creator 2026-03-06 it's live.mp4")
-        # Apostrophes must survive into the concat list, or ffmpeg reads a
-        # truncated path and the recording is lost.
-        assert r"it'\''s live.ts" in captured["list_content"]
-        # Without check/timeout a wedged or failing ffmpeg would look successful
-        # and the raw inputs would be deleted.
+        assert list(archive.iterdir()) == [archive / "#Creator 2026-03-06 123.mp4"]
+        # Without check/timeout a wedged or failing ffmpeg would look successful.
         assert captured["kwargs"]["check"] is True
         assert captured["kwargs"]["timeout"] > 0
-        # The temporary concat list must not survive as a new leftover.
-        assert not (archive / "merge-inputs.txt").exists()
-
-
-class TestRecoveryFfmpegRunner:
-    """The subprocess contract the recovery failure handling depends on."""
-
-    def test_non_zero_exit_raises(self):
-        """Test a failing merge child raises so inputs are never deleted."""
-        with pytest.raises(subprocess.CalledProcessError):
-            _run_recovery_ffmpeg([sys.executable, "-c", "raise SystemExit(1)"], 30)
-
-    def test_timeout_raises(self):
-        """Test a wedged merge child is killed and reported, not waited on forever."""
-        with pytest.raises(subprocess.TimeoutExpired):
-            _run_recovery_ffmpeg(
-                [sys.executable, "-c", "import time; time.sleep(30)"], 1
-            )
+        # The temporary target keeps the suffix ffmpeg infers the muxer from.
+        assert captured["command"][-1].endswith(".mp4")

--- a/tests/test_orphan_recovery.py
+++ b/tests/test_orphan_recovery.py
@@ -1,0 +1,340 @@
+"""Tests for startup recovery of orphaned .ts recordings."""
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from core.orphan_recovery import _run_recovery_ffmpeg, recover_orphaned_sessions
+
+
+@pytest.fixture
+def archive(tmp_path, monkeypatch):
+    """Point recovery at a temporary archive/Creator directory."""
+    monkeypatch.chdir(tmp_path)
+    creator_dir = tmp_path / "archive" / "Creator"
+    creator_dir.mkdir(parents=True)
+    return creator_dir
+
+
+def _fake_successful_merge(monkeypatch, captured=None):
+    """Replace the ffmpeg seam with a writer that never spawns a process."""
+
+    def fake_merge(ts_files, output_path, run_command):
+        if captured is not None:
+            captured.append((list(ts_files), output_path))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(b"mp4")
+
+    monkeypatch.setattr("core.orphan_recovery.merge_ts_files_to_mp4", fake_merge)
+
+
+def _fake_failing_merge(monkeypatch, error=None):
+    """Replace the ffmpeg seam with one that writes a partial mp4 then fails."""
+
+    def fake_merge(ts_files, output_path, run_command):
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(b"partial")
+        raise error or RuntimeError("boom")
+
+    monkeypatch.setattr("core.orphan_recovery.merge_ts_files_to_mp4", fake_merge)
+
+
+class TestOrphanRecovery:
+    """Recovery of session .ts files left behind by an interrupted run."""
+
+    def test_canonical_orphan_is_merged_and_inputs_deleted(self, archive, monkeypatch, caplog):
+        """Test a canonical orphan merges to mp4 and its inputs are removed."""
+        ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
+        ts_file.write_bytes(b"ts")
+        _fake_successful_merge(monkeypatch)
+
+        caplog.set_level(logging.INFO)
+        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
+
+        assert recovered == 1
+        merged = archive / "#Creator 2026-03-06 123.mp4"
+        assert merged.exists()
+        assert not ts_file.exists()
+        assert any(
+            "Recovered interrupted recording" in record.getMessage()
+            for record in caplog.records
+            if record.levelno == logging.INFO
+        )
+
+    def test_sibling_fragments_of_one_session_merge_in_order(self, archive, monkeypatch):
+        """Test numbered siblings of a session merge together, sorted, into one mp4."""
+        prefix = "20260306_120000_"
+        base = archive / f"{prefix}#Creator 2026-03-06 123.ts"
+        sibling = archive / f"{prefix}#Creator 2026-03-06 123_1.ts"
+        base.write_bytes(b"ts")
+        sibling.write_bytes(b"ts")
+        captured = []
+        _fake_successful_merge(monkeypatch, captured)
+
+        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
+
+        assert recovered == 1
+        assert captured == [([base, sibling], archive / "#Creator 2026-03-06 123.mp4")]
+        assert not base.exists()
+        assert not sibling.exists()
+
+    def test_failed_merge_keeps_all_inputs_and_discards_partial_output(
+        self, archive, monkeypatch, caplog
+    ):
+        """Test a failed recovery keeps every input and leaves no partial mp4."""
+        prefix = "20260306_120000_"
+        base = archive / f"{prefix}#Creator 2026-03-06 123.ts"
+        sibling = archive / f"{prefix}#Creator 2026-03-06 123_1.ts"
+        base.write_bytes(b"ts")
+        sibling.write_bytes(b"ts")
+        _fake_failing_merge(monkeypatch)
+
+        caplog.set_level(logging.WARNING)
+        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
+
+        assert recovered == 0
+        assert base.exists()
+        assert sibling.exists()
+        assert not (archive / "#Creator 2026-03-06 123.mp4").exists()
+        assert any(
+            "Orphan recovery merge failed" in record.getMessage()
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+        )
+
+    def test_merge_timeout_keeps_inputs(self, archive, monkeypatch):
+        """Test an ffmpeg timeout is a failure that preserves the recording."""
+        ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
+        ts_file.write_bytes(b"ts")
+        _fake_failing_merge(
+            monkeypatch, error=subprocess.TimeoutExpired(cmd=["ffmpeg"], timeout=1)
+        )
+
+        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
+
+        assert recovered == 0
+        assert ts_file.exists()
+        assert not (archive / "#Creator 2026-03-06 123.mp4").exists()
+
+    def test_part_and_ytdl_files_are_never_touched(self, archive, monkeypatch):
+        """Test in-flight yt-dlp artifacts are ignored and survive a mixed recovery."""
+        prefix = "20260306_120000_"
+        ts_file = archive / f"{prefix}#Creator 2026-03-06 123.ts"
+        ts_file.write_bytes(b"ts")
+        untouchable = {
+            archive / f"{prefix}#Creator 2026-03-06 123.ts.part": b"part",
+            archive / f"{prefix}#Creator 2026-03-06 123.ts.ytdl": b"ytdl",
+            archive / f"{prefix}#Creator 2026-03-06 123.ts.part-Frag3": b"frag",
+        }
+        for path, payload in untouchable.items():
+            path.write_bytes(payload)
+
+        captured = []
+        _fake_successful_merge(monkeypatch, captured)
+
+        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
+
+        assert recovered == 1
+        # Only the .ts payload may ever reach the merge inputs.
+        assert captured == [([ts_file], archive / "#Creator 2026-03-06 123.mp4")]
+        for path, payload in untouchable.items():
+            assert path.read_bytes() == payload
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "no-session-prefix.ts",
+            "2026030_120000_#Creator short date.ts",
+            "20260306_1200_#Creator short time.ts",
+            "20260306120000_#Creator no separators.ts",
+            "x20260306_120000_#Creator leading junk.ts",
+        ],
+    )
+    def test_non_canonical_names_are_ignored(self, archive, monkeypatch, filename, caplog):
+        """Test only the canonical YYYYMMDD_HHMMSS_ session pattern is recovered."""
+        stray = archive / filename
+        stray.write_bytes(b"ts")
+        _fake_successful_merge(monkeypatch)
+
+        caplog.set_level(logging.INFO)
+        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
+
+        assert recovered == 0
+        assert stray.exists()
+        assert list(archive.glob("*.mp4")) == []
+        assert not caplog.records
+
+    def test_existing_output_collision_is_skipped_and_inputs_kept(
+        self, archive, monkeypatch, caplog
+    ):
+        """Test recovery never overwrites an existing mp4; it skips and keeps inputs."""
+        ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
+        ts_file.write_bytes(b"ts")
+        existing = archive / "#Creator 2026-03-06 123.mp4"
+        existing.write_bytes(b"already merged")
+        _fake_successful_merge(monkeypatch)
+
+        caplog.set_level(logging.WARNING)
+        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
+
+        assert recovered == 0
+        assert existing.read_bytes() == b"already merged"
+        assert ts_file.exists()
+        assert any(
+            "already exists" in record.getMessage()
+            for record in caplog.records
+            if record.levelno == logging.WARNING
+        )
+
+    def test_second_run_after_failure_recovers_the_same_session(self, archive, monkeypatch):
+        """Test a failed recovery stays retryable: the next startup merges it."""
+        ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
+        ts_file.write_bytes(b"ts")
+        logger = logging.getLogger("test_recovery")
+
+        _fake_failing_merge(monkeypatch)
+        assert recover_orphaned_sessions(logger) == 0
+        # Filesystem is no worse than before: input intact, no partial artifact.
+        assert ts_file.exists()
+        assert list(archive.glob("*.mp4")) == []
+
+        _fake_successful_merge(monkeypatch)
+        assert recover_orphaned_sessions(logger) == 1
+        assert (archive / "#Creator 2026-03-06 123.mp4").exists()
+        assert not ts_file.exists()
+
+    def test_successful_run_is_idempotent(self, archive, monkeypatch):
+        """Test re-running recovery after success finds nothing left to do."""
+        ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
+        ts_file.write_bytes(b"ts")
+        _fake_successful_merge(monkeypatch)
+        logger = logging.getLogger("test_recovery")
+
+        assert recover_orphaned_sessions(logger) == 1
+        merged = archive / "#Creator 2026-03-06 123.mp4"
+        assert merged.read_bytes() == b"mp4"
+
+        assert recover_orphaned_sessions(logger) == 0
+        assert merged.read_bytes() == b"mp4"
+
+    def test_cleanup_failure_keeps_the_merged_mp4(self, archive, monkeypatch, caplog):
+        """Test a locked input after a good merge never discards the mp4."""
+        ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
+        ts_file.write_bytes(b"ts")
+        _fake_successful_merge(monkeypatch)
+
+        real_unlink = Path.unlink
+
+        def deny_ts_unlink(self, missing_ok=False):
+            if self.suffix == ".ts":
+                raise OSError("locked")
+            return real_unlink(self, missing_ok=missing_ok)
+
+        monkeypatch.setattr(Path, "unlink", deny_ts_unlink)
+
+        caplog.set_level(logging.INFO)
+        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
+
+        assert recovered == 1
+        assert (archive / "#Creator 2026-03-06 123.mp4").exists()
+        assert ts_file.exists()
+        assert any(
+            "could not remove" in record.getMessage() for record in caplog.records
+        )
+
+    def test_separate_sessions_and_creators_recover_independently(
+        self, tmp_path, monkeypatch
+    ):
+        """Test each session merges to its own mp4 across creator directories."""
+        monkeypatch.chdir(tmp_path)
+        first = tmp_path / "archive" / "Creator"
+        second = tmp_path / "archive" / "Other"
+        first.mkdir(parents=True)
+        second.mkdir(parents=True)
+        (first / "20260306_120000_#Creator 2026-03-06 A.ts").write_bytes(b"ts")
+        (first / "20260306_133000_#Creator 2026-03-06 B.ts").write_bytes(b"ts")
+        (second / "20260306_140000_#Other 2026-03-06 C.ts").write_bytes(b"ts")
+        _fake_successful_merge(monkeypatch)
+
+        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
+
+        assert recovered == 3
+        assert (first / "#Creator 2026-03-06 A.mp4").exists()
+        assert (first / "#Creator 2026-03-06 B.mp4").exists()
+        assert (second / "#Other 2026-03-06 C.mp4").exists()
+        assert list(first.glob("*.ts")) == []
+        assert list(second.glob("*.ts")) == []
+
+    def test_quiet_and_safe_when_nothing_to_recover(self, archive, caplog):
+        """Test a clean archive logs nothing and reports no recoveries."""
+        (archive / "#Creator 2026-03-06 done.mp4").write_bytes(b"complete")
+
+        caplog.set_level(logging.DEBUG)
+        recovered = recover_orphaned_sessions(logging.getLogger("test_recovery"))
+
+        assert recovered == 0
+        assert not caplog.records
+
+    def test_missing_archive_directory_is_ignored(self, tmp_path, monkeypatch, caplog):
+        """Test a first run with no archive directory is a quiet no-op."""
+        monkeypatch.chdir(tmp_path)
+
+        caplog.set_level(logging.DEBUG)
+
+        assert recover_orphaned_sessions(logging.getLogger("test_recovery")) == 0
+        assert not caplog.records
+
+    def test_recovery_invokes_the_shared_ffmpeg_concat_command(self, archive, monkeypatch):
+        """Test recovery reaches ffmpeg through the same concat command as the live merge.
+
+        Exercises the real merge helper, stubbing only the subprocess call, so
+        the argv and concat list are the ones ffmpeg would actually receive.
+        """
+        ts_file = archive / "20260306_120000_#Creator 2026-03-06 it's live.ts"
+        ts_file.write_bytes(b"ts")
+        captured = {}
+
+        def fake_run(command, **kwargs):
+            captured["command"] = command
+            captured["kwargs"] = kwargs
+            captured["list_content"] = Path(command[7]).read_text(encoding="utf-8")
+            # Stand in for ffmpeg actually producing the output.
+            Path(command[-1]).write_bytes(b"mp4")
+
+        monkeypatch.setattr("core.orphan_recovery.subprocess.run", fake_run)
+
+        assert recover_orphaned_sessions(logging.getLogger("test_recovery")) == 1
+
+        assert captured["command"][:7] == [
+            "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i",
+        ]
+        assert captured["command"][8:10] == ["-c", "copy"]
+        assert captured["command"][-1] == str(archive / "#Creator 2026-03-06 it's live.mp4")
+        # Apostrophes must survive into the concat list, or ffmpeg reads a
+        # truncated path and the recording is lost.
+        assert r"it'\''s live.ts" in captured["list_content"]
+        # Without check/timeout a wedged or failing ffmpeg would look successful
+        # and the raw inputs would be deleted.
+        assert captured["kwargs"]["check"] is True
+        assert captured["kwargs"]["timeout"] > 0
+        # The temporary concat list must not survive as a new leftover.
+        assert not (archive / "merge-inputs.txt").exists()
+
+
+class TestRecoveryFfmpegRunner:
+    """The subprocess contract the recovery failure handling depends on."""
+
+    def test_non_zero_exit_raises(self):
+        """Test a failing merge child raises so inputs are never deleted."""
+        with pytest.raises(subprocess.CalledProcessError):
+            _run_recovery_ffmpeg([sys.executable, "-c", "raise SystemExit(1)"], 30)
+
+    def test_timeout_raises(self):
+        """Test a wedged merge child is killed and reported, not waited on forever."""
+        with pytest.raises(subprocess.TimeoutExpired):
+            _run_recovery_ffmpeg(
+                [sys.executable, "-c", "import time; time.sleep(30)"], 1
+            )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,10 +2,11 @@
 
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
-from core.utils import format_file_size, terminate_child_processes
+from core.utils import format_file_size, merge_ts_files_to_mp4, terminate_child_processes
 
 
 class TestFormatFileSize:
@@ -57,6 +58,35 @@ class TestFormatFileSize:
     def test_format_file_size(self, size_bytes: int, expected: str):
         """Test formatting file sizes across all unit ranges."""
         assert format_file_size(size_bytes) == expected
+
+
+class TestMergeTsFilesToMp4:
+    """The ffmpeg concat contract shared by the live merge and startup recovery."""
+
+    def test_builds_the_concat_command_and_removes_its_list(self, tmp_path):
+        """Test the argv ffmpeg receives, the concat list it reads, and its cleanup."""
+        ts_file = tmp_path / "#Creator 2026-03-06 it's live.ts"
+        ts_file.write_bytes(b"ts")
+        output_path = tmp_path / "final.mp4"
+        list_path = tmp_path / "merge-inputs.txt"
+        captured = {}
+
+        def fake_run(command):
+            captured["command"] = command
+            captured["list_content"] = Path(command[7]).read_text(encoding="utf-8")
+
+        merge_ts_files_to_mp4([ts_file], output_path, fake_run)
+
+        assert captured["command"] == [
+            "ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(list_path),
+            "-c", "copy", str(output_path),
+        ]
+        # Apostrophes must survive into the concat list, or ffmpeg reads a
+        # truncated path and the recording is lost.
+        assert captured["list_content"].startswith("file '")
+        assert r"it'\''s live.ts" in captured["list_content"]
+        # The list must not survive as a new leftover of its own.
+        assert not list_path.exists()
 
 
 class TestTerminateChildProcesses:


### PR DESCRIPTION
## Summary
Two paths leave a finished recording stranded as `.ts` files: a merge abandoned when graceful shutdown's aggregate budget ran out, and a raw download whose completion event arrived after the merge executor closed. Nothing ever merged them afterwards. Now startup recovers them.

- Recovery runs synchronously in `main()` after logging setup and before the scheduler starts polling, so it cannot race a fresh recording (single-instance assumption documented; a second instance on the same volume is out of scope).
- Only canonical `YYYYMMDD_HHMMSS_*` session `.ts` files are recovered — globbing `*.ts` alone keeps yt-dlp's in-flight artifacts (`.part`, `.part-FragN`, `.ytdl`) out of both the concat list and the cleanup loop.
- The merge reuses the exact ffmpeg concat invocation the live path uses, extracted to `core/utils.py:merge_ts_files_to_mp4` (behavior-neutral for the shutdown-protected merge path: pid registration, escaping, list cleanup all unchanged).
- Data-integrity guarantees: ffmpeg writes to a temporary name and only a validated result (file exists, size > 0) is atomically renamed onto the final path; inputs are deleted only after that; any failure keeps all inputs and discards the partial temp; an interrupted recovery leaves the final name free so the next startup retries; an existing final output is never overwritten (skip + warn — a recovery collision most likely means an earlier success whose cleanup failed).
- One INFO per recovered session, one WARNING per failed/skipped session; silent when there is nothing to recover.

## Acceptance criteria
- [ ] Canonical orphaned session → merged mp4, inputs deleted only after validation
- [ ] `.part`/`.ytdl` never touched, non-canonical names ignored
- [ ] Failure/timeout/interrupted merge keeps every input; next startup retries
- [ ] Existing output never overwritten
- [ ] Recovery ordering pinned: after logger setup, before scheduler start

## Verification
- Full suite 3 consecutive runs: `390 passed in 38.55s` / `38.55s` / `38.59s`
- 12 targeted mutations (drop validation, size-only, direct-to-final write, delete-on-failure, collision check, regex loosening, glob widening, check=False, grouping, locked-input, partial-temp, list-file) — all caught; no survivors
- Dual independent review (L3-calibrated pragmatic + over-engineering pass) + fix round addressing all findings (incl. Critical output-validation gap and interrupted-merge idempotency)
- Not verified here: a real ffmpeg run (binary absent in dev env); the invocation is the pre-existing production concat code moved verbatim, with argv/list-format pinned by test
