### PR TITLE
fix: adopt interrupted .ts.part downloads at shutdown and startup

### DIFF
--- a/core/downloader.py
+++ b/core/downloader.py
@@ -292,10 +292,6 @@ class StreamDownloader:
         """
         Generate a unique file path by appending a counter if file exists.
 
-        Shared with startup orphan recovery, which reserves its merged mp4 name
-        under the same policy, so a recovered recording never overwrites an
-        earlier one and is named the way a live merge would have named it.
-
         Args:
             base_path: Initial desired file path
 
@@ -328,40 +324,18 @@ class StreamDownloader:
         fragment_pattern = f"{output_path.stem}_*{output_path.suffix}"
         return any(output_path.parent.glob(fragment_pattern))
 
-    def _adopt_part_output(self, output_path: Path) -> Optional[int]:
-        """
-        Rename a dead recording's .ts.part onto its raw output name.
-
-        When shutdown reaps the recording ffmpeg it exits non-zero, so yt-dlp
-        calls the download failed and never renames .part to .ts — the entire
-        recording stays in a file nothing downstream looks at. The child is
-        provably dead here (this process terminated it and yt-dlp has already
-        returned), so claiming its .part races nobody.
-
-        Only .ts is adopted. A truncated MPEG-TS is still demuxable, which is
-        what makes concat safe on it; a truncated .mp4 has no moov atom yet and
-        would be unplayable, so that case keeps the old report-only behavior.
-
-        Called only when the finished output is missing and no numbered sibling
-        fragments exist: with several pieces in flight, which of them are
-        complete is not knowable from here.
-
-        Returns:
-            The adopted size in bytes, or None when there was nothing to adopt.
-        """
+    def _adopt_part_output(self, output_path: Path) -> bool:
+        """Rename a dead recording's .ts.part onto its raw output name."""
+        # Only .ts: a truncated MPEG-TS is still demuxable, which is what makes
+        # concat safe on it, while a truncated mp4 has no moov atom yet and
+        # would be unplayable.
         if output_path.suffix != ".ts":
-            return None
+            return False
 
         part_path = Path(f"{output_path}.part")
         try:
-            if not part_path.is_file():
-                return None
-
-            # A zero-byte part holds no recording; renaming it would only turn
-            # an empty artifact into an empty merge input.
-            part_size = part_path.stat().st_size
-            if part_size == 0:
-                return None
+            if not part_path.is_file() or part_path.stat().st_size == 0:
+                return False
 
             part_path.rename(output_path)
         except OSError as exc:
@@ -370,9 +344,9 @@ class StreamDownloader:
             self.log.warning(
                 f"⚠️ Could not adopt partial download {part_path.name}: {exc}",
             )
-            return None
+            return False
 
-        return part_size
+        return True
 
     def _build_output_state_details(self, output_path: Path) -> str:
         """Build a compact output-state summary for downloader logs."""
@@ -457,22 +431,17 @@ class StreamDownloader:
                     self._notify_download_complete(output_path)
                     return
 
-                # No finished raw file, but the recording itself may be sitting
-                # in the .part yt-dlp abandoned. Adopting it here is what lets
-                # the normal completion path run, so the merge happens inside
-                # shutdown's existing budget instead of waiting for a restart.
-                adopted_size = self._adopt_part_output(output_path)
-                if adopted_size is not None:
+                # The recording itself may be sitting in the .part yt-dlp
+                # abandoned, and adopting it keeps the merge inside shutdown's
+                # existing budget instead of waiting for a restart.
+                if self._adopt_part_output(output_path):
                     self.log.info(
                         f"⏹️ Recording stopped for shutdown (session {session_prefix}); "
-                        f"adopted partial download ({format_file_size(adopted_size)}) "
-                        f"as raw output: {output_path.name}",
+                        f"adopted partial download as raw output: {output_path.name}",
                     )
                     self._notify_download_complete(output_path)
                     return
 
-                # Nothing adoptable: a fragmented or empty .part is reported by
-                # the startup orphan scan, not merged.
                 self.log.warning(
                     f"⏹️ Recording stopped for shutdown (session {session_prefix}) with no "
                     f"finished raw output: {error_message}; "

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -169,7 +169,7 @@ class StreamDownloader:
         output_path = self._build_output_path(safe_title)
 
         # Ensure unique file path and create directories
-        output_path = self._get_unique_path(output_path)
+        output_path = self.get_unique_path(output_path)
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Store current download info
@@ -288,9 +288,13 @@ class StreamDownloader:
         return options
 
     @classmethod
-    def _get_unique_path(cls, base_path: Path) -> Path:
+    def get_unique_path(cls, base_path: Path) -> Path:
         """
         Generate a unique file path by appending a counter if file exists.
+
+        Shared with startup orphan recovery, which reserves its merged mp4 name
+        under the same policy, so a recovered recording never overwrites an
+        earlier one and is named the way a live merge would have named it.
 
         Args:
             base_path: Initial desired file path

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -324,6 +324,52 @@ class StreamDownloader:
         fragment_pattern = f"{output_path.stem}_*{output_path.suffix}"
         return any(output_path.parent.glob(fragment_pattern))
 
+    def _adopt_part_output(self, output_path: Path) -> Optional[int]:
+        """
+        Rename a dead recording's .ts.part onto its raw output name.
+
+        When shutdown reaps the recording ffmpeg it exits non-zero, so yt-dlp
+        calls the download failed and never renames .part to .ts — the entire
+        recording stays in a file nothing downstream looks at. The child is
+        provably dead here (this process terminated it and yt-dlp has already
+        returned), so claiming its .part races nobody.
+
+        Only .ts is adopted. A truncated MPEG-TS is still demuxable, which is
+        what makes concat safe on it; a truncated .mp4 has no moov atom yet and
+        would be unplayable, so that case keeps the old report-only behavior.
+
+        Called only when the finished output is missing and no numbered sibling
+        fragments exist: with several pieces in flight, which of them are
+        complete is not knowable from here.
+
+        Returns:
+            The adopted size in bytes, or None when there was nothing to adopt.
+        """
+        if output_path.suffix != ".ts":
+            return None
+
+        part_path = Path(f"{output_path}.part")
+        try:
+            if not part_path.is_file():
+                return None
+
+            # A zero-byte part holds no recording; renaming it would only turn
+            # an empty artifact into an empty merge input.
+            part_size = part_path.stat().st_size
+            if part_size == 0:
+                return None
+
+            part_path.rename(output_path)
+        except OSError as exc:
+            # Must not escape: this runs inside the shutdown error handler, and
+            # raising here would leave the session without a terminal event.
+            self.log.warning(
+                f"⚠️ Could not adopt partial download {part_path.name}: {exc}",
+            )
+            return None
+
+        return part_size
+
     def _build_output_state_details(self, output_path: Path) -> str:
         """Build a compact output-state summary for downloader logs."""
         part_path = Path(f"{output_path}.part")
@@ -407,9 +453,22 @@ class StreamDownloader:
                     self._notify_download_complete(output_path)
                     return
 
-                # No finished raw file: yt-dlp leaves a truncated .part behind,
-                # which is the startup orphan scan's job to report, not the
-                # merge step's.
+                # No finished raw file, but the recording itself may be sitting
+                # in the .part yt-dlp abandoned. Adopting it here is what lets
+                # the normal completion path run, so the merge happens inside
+                # shutdown's existing budget instead of waiting for a restart.
+                adopted_size = self._adopt_part_output(output_path)
+                if adopted_size is not None:
+                    self.log.info(
+                        f"⏹️ Recording stopped for shutdown (session {session_prefix}); "
+                        f"adopted partial download ({format_file_size(adopted_size)}) "
+                        f"as raw output: {output_path.name}",
+                    )
+                    self._notify_download_complete(output_path)
+                    return
+
+                # Nothing adoptable: a fragmented or empty .part is reported by
+                # the startup orphan scan, not merged.
                 self.log.warning(
                     f"⏹️ Recording stopped for shutdown (session {session_prefix}) with no "
                     f"finished raw output: {error_message}; "

--- a/core/orphan_recovery.py
+++ b/core/orphan_recovery.py
@@ -118,27 +118,14 @@ def _recover_one_session(
         )
         return
 
-    output_path = output_dir / f"{final_stem}.mp4"
-    if output_path.exists():
-        # Most likely this session already merged and only the .ts cleanup
-        # failed (a locked input leaves the mp4 in place by design). Re-merging
-        # would archive a duplicate of a finished recording, so the inputs are
-        # left for an operator to compare and remove.
-        logger.warning(
-            f"⚠️ Skipping orphan recovery for session {session_id}: "
-            f"{output_path.name} already exists. "
-            f"Raw .ts files left in: {output_dir}"
-        )
-        return
-
     # ffmpeg writes to a temporary name in the same directory, and only a
-    # validated result is renamed onto the final one. A process death mid-merge
-    # would otherwise leave a partial file under the final name, which the
-    # collision check above reads as a finished recording — skipping that
-    # session, and its intact inputs, on every later startup. The .mp4 suffix
-    # is kept so ffmpeg still infers the mp4 muxer; a stale temp from an
+    # validated result is renamed onto a final one. A process death mid-merge
+    # would otherwise leave a partial mp4 under a final name that nothing ever
+    # cleans up, and the suffix policy below would then treat that wreckage as
+    # a real recording and push this session's output to _1. The .mp4 suffix is
+    # kept so ffmpeg still infers the mp4 muxer; a stale temp from an
     # interrupted attempt is overwritten by the invocation's -y.
-    temp_path = output_path.with_name(f".{final_stem}.recovering.mp4")
+    temp_path = output_dir / f".{final_stem}.recovering.mp4"
     try:
         merge_ts_files_to_mp4(
             ts_files,
@@ -158,7 +145,18 @@ def _recover_one_session(
         if not temp_path.is_file() or temp_path.stat().st_size == 0:
             raise RuntimeError(f"merge produced no output at {temp_path.name}")
 
-        # Atomic within the directory: the final name never exists half-written.
+        # Same suffix policy as a live merge: a name already taken becomes
+        # NAME_1.mp4 rather than a skip. Adopting stranded .ts.part files made
+        # "same title, different session" the common collision — one stop and
+        # restart during a stream produces two sessions with identical titles
+        # in one directory. Skipping stranded the second recording forever;
+        # suffixing costs at most a visible duplicate when the rarer cause
+        # (this session already merged, only .ts cleanup failed) applies.
+        #
+        # Reserved here rather than before the merge, which can run for hours:
+        # replace() overwrites silently, so the name is claimed in the same
+        # breath as the rename that consumes it.
+        output_path = StreamDownloader.get_unique_path(output_dir / f"{final_stem}.mp4")
         temp_path.replace(output_path)
     except Exception as exc:
         # Same contract as the live merge: drop the partial output so a failure

--- a/core/orphan_recovery.py
+++ b/core/orphan_recovery.py
@@ -1,20 +1,15 @@
 """
 Startup recovery for raw recordings whose merge never completed.
 
-A merge abandoned when shutdown's aggregate budget ran out, a raw download
-whose completion arrived after the merge executor had closed, or a recording
-whose ffmpeg was reaped before yt-dlp could rename its .ts.part, all leave a
-recording on disk that no later run would look at again. This merges them
-through the same ffmpeg concat invocation the live merge uses.
-
-A canonical NAME.ts.part is adopted first: at startup nothing is writing it,
-and truncated MPEG-TS is still demuxable, so it becomes NAME.ts and joins the
-normal pipeline. Numbered .part-FragN fragments and .ytdl files are never
-touched — they may be torn mid-write, and merging them would produce broken
-video.
+A merge abandoned when shutdown's budget ran out, a raw download that finished
+after the merge executor had closed, or a recording whose ffmpeg was reaped
+before yt-dlp could rename its .ts.part all leave a recording on disk that no
+later run would look at again. This merges them through the same ffmpeg concat
+invocation the live merge uses, adopting a canonical NAME.ts.part first.
 """
 
 import logging
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -46,13 +41,12 @@ def recover_orphaned_sessions(logger: logging.Logger) -> None:
     archive = Path.cwd() / StreamDownloader.ARCHIVE_DIR
 
     # Adoption runs first, so a claimed part is just another .ts input to the
-    # grouping below. Only the exact *.ts.part suffix is globbed: .part-FragN
-    # and .ytdl end differently and stay out of recovery entirely.
+    # grouping below. Only the exact *.ts.part suffix qualifies, here and in
+    # the *.ts glob: .part-FragN and .ytdl may be torn mid-write, and merging
+    # them would produce broken video.
     for part_file in sorted(archive.glob("*/*.ts.part")):
         _adopt_orphaned_part(logger, part_file)
 
-    # Globbing *.ts alone keeps every remaining in-flight artifact out of the
-    # concat list and the cleanup loop that follows it.
     sessions: Dict[Tuple[Path, str], List[Path]] = {}
     for ts_file in sorted(archive.glob("*/*.ts")):
         match = _SESSION_PREFIX_RE.match(ts_file.name)
@@ -65,12 +59,7 @@ def recover_orphaned_sessions(logger: logging.Logger) -> None:
 
 
 def _adopt_orphaned_part(logger: logging.Logger, part_file: Path) -> None:
-    """
-    Rename one stranded NAME.ts.part onto NAME.ts so it can be merged.
-
-    Safe only because of the startup single-instance assumption above: no
-    recording is running, so this part belongs to a process that is gone.
-    """
+    """Rename one stranded NAME.ts.part onto NAME.ts so it can be merged."""
     if _SESSION_PREFIX_RE.match(part_file.name) is None:
         return
 
@@ -118,13 +107,10 @@ def _recover_one_session(
         )
         return
 
-    # ffmpeg writes to a temporary name in the same directory, and only a
-    # validated result is renamed onto a final one. A process death mid-merge
-    # would otherwise leave a partial mp4 under a final name that nothing ever
-    # cleans up, and the suffix policy below would then treat that wreckage as
-    # a real recording and push this session's output to _1. The .mp4 suffix is
-    # kept so ffmpeg still infers the mp4 muxer; a stale temp from an
-    # interrupted attempt is overwritten by the invocation's -y.
+    # ffmpeg writes a temp in the same directory so a death mid-merge cannot
+    # leave a partial mp4 under a final name, which the suffix policy below
+    # would then read as a real recording. The .mp4 suffix keeps ffmpeg's muxer
+    # inference; a stale temp from an interrupted attempt is overwritten by -y.
     temp_path = output_dir / f".{final_stem}.recovering.mp4"
     try:
         merge_ts_files_to_mp4(
@@ -145,19 +131,14 @@ def _recover_one_session(
         if not temp_path.is_file() or temp_path.stat().st_size == 0:
             raise RuntimeError(f"merge produced no output at {temp_path.name}")
 
-        # Same suffix policy as a live merge: a name already taken becomes
-        # NAME_1.mp4 rather than a skip. Adopting stranded .ts.part files made
-        # "same title, different session" the common collision — one stop and
-        # restart during a stream produces two sessions with identical titles
-        # in one directory. Skipping stranded the second recording forever;
-        # suffixing costs at most a visible duplicate when the rarer cause
-        # (this session already merged, only .ts cleanup failed) applies.
-        #
-        # Reserved here rather than before the merge, which can run for hours:
-        # replace() overwrites silently, so the name is claimed in the same
-        # breath as the rename that consumes it.
-        output_path = StreamDownloader.get_unique_path(output_dir / f"{final_stem}.mp4")
-        temp_path.replace(output_path)
+        # Same suffix policy as a live merge: a taken name becomes NAME_1.mp4
+        # rather than a skip, because one stop and restart during a stream
+        # produces two sessions with identical titles in one directory.
+        # Reserved at install time rather than before the merge, which can run
+        # for hours.
+        output_path = _install_without_overwrite(
+            logger, temp_path, output_dir / f"{final_stem}.mp4"
+        )
     except Exception as exc:
         # Same contract as the live merge: drop the partial output so a failure
         # cannot pass for a finished recording, and keep every input so the
@@ -174,8 +155,8 @@ def _recover_one_session(
             ts_file.unlink(missing_ok=True)
         except OSError as cleanup_error:
             # The mp4 is the artifact of record from here; a locked input must
-            # not undo a good merge. Startup's leftover scan will list it, and
-            # the next run skips this session on the existing-output check.
+            # not undo a good merge. The leftover .ts is merged again on a
+            # later run, under the next free suffix, so nothing is overwritten.
             logger.warning(
                 f"Merged, but could not remove {ts_file.name}: {cleanup_error}"
             )
@@ -184,6 +165,25 @@ def _recover_one_session(
         f"🛟 Recovered interrupted recording (session {session_id}): "
         f"merged {len(ts_files)} raw file(s) into {output_path}"
     )
+
+
+def _install_without_overwrite(
+    logger: logging.Logger, temp_path: Path, base_path: Path
+) -> Path:
+    """Install the merged mp4 under the first free name, never clobbering one."""
+    while True:
+        candidate = StreamDownloader.get_unique_path(base_path)
+        try:
+            # Availability and install are two steps, and a claimant can win
+            # the gap between them — replace() would destroy it silently.
+            # os.link refuses an existing target instead, so a lost race costs
+            # one more suffix. Every collision leaves that name taken for good,
+            # so the retries run out at get_unique_path's duplicate cap.
+            os.link(temp_path, candidate)
+        except FileExistsError:
+            continue
+        _discard_partial_output(logger, temp_path)
+        return candidate
 
 
 def _discard_partial_output(logger: logging.Logger, temp_path: Path) -> None:

--- a/core/orphan_recovery.py
+++ b/core/orphan_recovery.py
@@ -1,10 +1,17 @@
 """
-Startup recovery for raw .ts recordings whose merge never completed.
+Startup recovery for raw recordings whose merge never completed.
 
-A merge abandoned when shutdown's aggregate budget ran out, or a raw download
-whose completion arrived after the merge executor had closed, leaves a finished
-recording on disk as .ts files that no later run would look at again. This
-merges them through the same ffmpeg concat invocation the live merge uses.
+A merge abandoned when shutdown's aggregate budget ran out, a raw download
+whose completion arrived after the merge executor had closed, or a recording
+whose ffmpeg was reaped before yt-dlp could rename its .ts.part, all leave a
+recording on disk that no later run would look at again. This merges them
+through the same ffmpeg concat invocation the live merge uses.
+
+A canonical NAME.ts.part is adopted first: at startup nothing is writing it,
+and truncated MPEG-TS is still demuxable, so it becomes NAME.ts and joins the
+normal pipeline. Numbered .part-FragN fragments and .ytdl files are never
+touched — they may be torn mid-write, and merging them would produce broken
+video.
 """
 
 import logging
@@ -38,10 +45,14 @@ def recover_orphaned_sessions(logger: logging.Logger) -> None:
     """
     archive = Path.cwd() / StreamDownloader.ARCHIVE_DIR
 
-    # Globbing *.ts alone is what keeps yt-dlp's in-flight artifacts out of
-    # recovery entirely: .part, .part-FragN and .ytdl all end in another
-    # suffix, so they can enter neither a concat list nor a cleanup loop. Those
-    # may be truncated mid-write, and merging them would produce broken video.
+    # Adoption runs first, so a claimed part is just another .ts input to the
+    # grouping below. Only the exact *.ts.part suffix is globbed: .part-FragN
+    # and .ytdl end differently and stay out of recovery entirely.
+    for part_file in sorted(archive.glob("*/*.ts.part")):
+        _adopt_orphaned_part(logger, part_file)
+
+    # Globbing *.ts alone keeps every remaining in-flight artifact out of the
+    # concat list and the cleanup loop that follows it.
     sessions: Dict[Tuple[Path, str], List[Path]] = {}
     for ts_file in sorted(archive.glob("*/*.ts")):
         match = _SESSION_PREFIX_RE.match(ts_file.name)
@@ -51,6 +62,39 @@ def recover_orphaned_sessions(logger: logging.Logger) -> None:
 
     for (output_dir, session_prefix), ts_files in sorted(sessions.items()):
         _recover_one_session(logger, output_dir, session_prefix, ts_files)
+
+
+def _adopt_orphaned_part(logger: logging.Logger, part_file: Path) -> None:
+    """
+    Rename one stranded NAME.ts.part onto NAME.ts so it can be merged.
+
+    Safe only because of the startup single-instance assumption above: no
+    recording is running, so this part belongs to a process that is gone.
+    """
+    if _SESSION_PREFIX_RE.match(part_file.name) is None:
+        return
+
+    output_path = part_file.with_suffix("")
+    if output_path.exists():
+        # The session already has raw output under that name, so this part is
+        # from a different attempt whose content cannot be reconciled here.
+        # Overwriting would destroy a finished recording; the operator decides.
+        logger.warning(
+            f"⚠️ Not adopting {part_file.name}: {output_path.name} already exists"
+        )
+        return
+
+    try:
+        if part_file.stat().st_size == 0:
+            logger.warning(f"⚠️ Not adopting {part_file.name}: it is empty")
+            return
+
+        part_file.rename(output_path)
+    except OSError as exc:
+        logger.warning(f"⚠️ Could not adopt {part_file.name}: {exc}")
+        return
+
+    logger.info(f"🛟 Adopted interrupted download as raw output: {output_path.name}")
 
 
 def _recover_one_session(

--- a/main.py
+++ b/main.py
@@ -41,9 +41,9 @@ def _warn_about_orphaned_downloads(logger: logging.Logger) -> None:
     when a merge fails or the process dies first.
     """
     # Runs after recovery, so what it lists is what recovery could not fix:
-    # sessions it skipped or failed to merge, plus the yt-dlp artifacts it
-    # never touches. ponytail: report-only for .part fragments, which may be
-    # truncated mid-write, so merging those would produce broken video.
+    # sessions it skipped or failed to merge, the .ts.part files it refused to
+    # adopt, plus the .part-FragN and .ytdl artifacts it never touches, which
+    # may be torn mid-write and would merge into broken video.
     archive = Path.cwd() / StreamDownloader.ARCHIVE_DIR
     if not archive.is_dir():
         return

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -878,6 +878,133 @@ class TestDownloadErrorCallback:
         assert len(completed_events) == 1
         assert completed_events[0].session_key == "creator1:stream1"
 
+    def _stopped_downloader(self, tmp_path, mock_ydl, completed, failed, **kwargs):
+        """Build a downloader whose recording ffmpeg is reaped mid-download."""
+        downloader = StreamDownloader(
+            "TestCreator",
+            session_key="creator1:stream1",
+            output_dir=tmp_path,
+            on_download_complete=lambda event: completed.append(event),
+            on_download_failure=lambda event: failed.append(event),
+            **kwargs,
+        )
+        downloader._download_start_time = datetime.now()
+
+        def kill_recording_mid_download(*args, **kwargs):
+            downloader.request_stop()
+            # ffmpeg exits 255 when terminated, so yt-dlp calls the download
+            # failed and never renames the .part it was writing.
+            raise yt_dlp.utils.DownloadError("ERROR: ffmpeg exited with code 255")
+
+        mock_ydl.download.side_effect = kill_recording_mid_download
+        return downloader
+
+    def test_worker_adopts_the_partial_download_left_by_a_reaped_recording(
+        self, mock_yt_dlp, tmp_path
+    ):
+        """Test the stranded .ts.part becomes the raw output and reaches the merge step."""
+        mock_ydl_class, mock_ydl = mock_yt_dlp
+        completed, failed = [], []
+        downloader = self._stopped_downloader(
+            tmp_path, mock_ydl, completed, failed, output_extension=".ts"
+        )
+        output_path = tmp_path / "20260728_200507_#TestCreator 2026-07-28 Live.ts"
+        part_path = Path(f"{output_path}.part")
+        part_path.write_bytes(b"\x47" * 188)
+
+        downloader._download_worker("http://example.com/stream.m3u8", {}, output_path)
+
+        # The whole recording moves under the name the merge step globs for.
+        assert output_path.read_bytes() == b"\x47" * 188
+        assert not part_path.exists()
+        assert failed == []
+        assert len(completed) == 1
+        assert completed[0].session_key == "creator1:stream1"
+        assert completed[0].output_dir == tmp_path
+
+    def test_worker_does_not_adopt_a_part_with_sibling_fragments(
+        self, mock_yt_dlp, tmp_path
+    ):
+        """Test a fragmented recording keeps its .part and the old completion path."""
+        mock_ydl_class, mock_ydl = mock_yt_dlp
+        completed, failed = [], []
+        downloader = self._stopped_downloader(
+            tmp_path, mock_ydl, completed, failed, output_extension=".ts"
+        )
+        output_path = tmp_path / "20260728_200507_#TestCreator 2026-07-28 Live.ts"
+        part_path = Path(f"{output_path}.part")
+        part_path.write_bytes(b"\x47" * 188)
+        sibling = tmp_path / "20260728_200507_#TestCreator 2026-07-28 Live_1.ts"
+        sibling.write_bytes(b"fragment")
+
+        downloader._download_worker("http://example.com/stream.m3u8", {}, output_path)
+
+        # Which pieces are complete is not knowable here, so the part is left
+        # exactly as it was and only the finished fragments go to the merge.
+        assert part_path.read_bytes() == b"\x47" * 188
+        assert not output_path.exists()
+        assert len(completed) == 1
+
+    def test_worker_does_not_adopt_an_empty_partial_download(self, mock_yt_dlp, tmp_path):
+        """Test a zero-byte part is not turned into an empty merge input."""
+        mock_ydl_class, mock_ydl = mock_yt_dlp
+        completed, failed = [], []
+        downloader = self._stopped_downloader(
+            tmp_path, mock_ydl, completed, failed, output_extension=".ts"
+        )
+        output_path = tmp_path / "20260728_200507_#TestCreator 2026-07-28 Live.ts"
+        part_path = Path(f"{output_path}.part")
+        part_path.write_bytes(b"")
+
+        downloader._download_worker("http://example.com/stream.m3u8", {}, output_path)
+
+        assert part_path.exists()
+        assert not output_path.exists()
+        assert completed == []
+        assert len(failed) == 1
+
+    def test_worker_does_not_adopt_a_partial_mp4_download(self, mock_yt_dlp, tmp_path):
+        """Test a truncated mp4, which has no moov atom yet, is never adopted."""
+        mock_ydl_class, mock_ydl = mock_yt_dlp
+        completed, failed = [], []
+        downloader = self._stopped_downloader(tmp_path, mock_ydl, completed, failed)
+        output_path = tmp_path / "20260728_200507_#TestCreator 2026-07-28 Live.mp4"
+        part_path = Path(f"{output_path}.part")
+        part_path.write_bytes(b"truncated mp4 without a moov atom")
+
+        downloader._download_worker("http://example.com/stream.m3u8", {}, output_path)
+
+        assert part_path.exists()
+        assert not output_path.exists()
+        assert completed == []
+        assert len(failed) == 1
+
+    def test_worker_keeps_the_part_when_adoption_cannot_rename_it(
+        self, mock_yt_dlp, tmp_path, monkeypatch
+    ):
+        """Test a failed rename falls back to reporting the recording as failed."""
+        mock_ydl_class, mock_ydl = mock_yt_dlp
+        completed, failed = [], []
+        downloader = self._stopped_downloader(
+            tmp_path, mock_ydl, completed, failed, output_extension=".ts"
+        )
+        output_path = tmp_path / "20260728_200507_#TestCreator 2026-07-28 Live.ts"
+        part_path = Path(f"{output_path}.part")
+        part_path.write_bytes(b"\x47" * 188)
+
+        def deny_rename(self, target):
+            raise OSError("cross-device link")
+
+        monkeypatch.setattr(Path, "rename", deny_rename)
+
+        downloader._download_worker("http://example.com/stream.m3u8", {}, output_path)
+
+        # The session still has to reach a terminal state, or its raw lock is
+        # held until the process restarts.
+        assert part_path.read_bytes() == b"\x47" * 188
+        assert completed == []
+        assert len(failed) == 1
+
     def test_worker_logs_partial_output_details_on_failure(self, mock_yt_dlp, tmp_path):
         """Test final download error logs include .part output details."""
         mock_ydl_class, mock_ydl = mock_yt_dlp
@@ -886,7 +1013,8 @@ class TestDownloadErrorCallback:
             session_key="creator1:stream1",
         )
         output_path = tmp_path / "test.ts"
-        Path(f"{output_path}.part").write_bytes(b"abcdef")
+        part_path = Path(f"{output_path}.part")
+        part_path.write_bytes(b"abcdef")
         downloader._download_start_time = datetime.now()
         mock_ydl.download.side_effect = yt_dlp.utils.DownloadError("Some other error")
 
@@ -899,6 +1027,10 @@ class TestDownloadErrorCallback:
             and "part_size=6.0 B" in str(call)
             for call in mock_log.call_args_list
         )
+        # Adoption belongs to the shutdown path alone: yt-dlp may still resume
+        # into this .part on a later attempt, so nothing may claim it here.
+        assert part_path.read_bytes() == b"abcdef"
+        assert not output_path.exists()
 
     def test_worker_emits_failure_event_on_non_m3u8_error(self, mock_yt_dlp, tmp_path):
         """Test non-blocked download errors emit a raw failure event."""

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -878,8 +878,12 @@ class TestDownloadErrorCallback:
         assert len(completed_events) == 1
         assert completed_events[0].session_key == "creator1:stream1"
 
-    def _stopped_downloader(self, tmp_path, mock_ydl, completed, failed, **kwargs):
-        """Build a downloader whose recording ffmpeg is reaped mid-download."""
+    def _stopped_downloader(self, tmp_path, mock_ydl, **kwargs):
+        """Build a downloader whose recording ffmpeg is reaped mid-download.
+
+        Returns the downloader with the event lists its callbacks append to.
+        """
+        completed, failed = [], []
         downloader = StreamDownloader(
             "TestCreator",
             session_key="creator1:stream1",
@@ -897,16 +901,15 @@ class TestDownloadErrorCallback:
             raise yt_dlp.utils.DownloadError("ERROR: ffmpeg exited with code 255")
 
         mock_ydl.download.side_effect = kill_recording_mid_download
-        return downloader
+        return downloader, completed, failed
 
     def test_worker_adopts_the_partial_download_left_by_a_reaped_recording(
         self, mock_yt_dlp, tmp_path
     ):
         """Test the stranded .ts.part becomes the raw output and reaches the merge step."""
         mock_ydl_class, mock_ydl = mock_yt_dlp
-        completed, failed = [], []
-        downloader = self._stopped_downloader(
-            tmp_path, mock_ydl, completed, failed, output_extension=".ts"
+        downloader, completed, failed = self._stopped_downloader(
+            tmp_path, mock_ydl, output_extension=".ts"
         )
         output_path = tmp_path / "20260728_200507_#TestCreator 2026-07-28 Live.ts"
         part_path = Path(f"{output_path}.part")
@@ -927,9 +930,8 @@ class TestDownloadErrorCallback:
     ):
         """Test a fragmented recording keeps its .part and the old completion path."""
         mock_ydl_class, mock_ydl = mock_yt_dlp
-        completed, failed = [], []
-        downloader = self._stopped_downloader(
-            tmp_path, mock_ydl, completed, failed, output_extension=".ts"
+        downloader, completed, _failed = self._stopped_downloader(
+            tmp_path, mock_ydl, output_extension=".ts"
         )
         output_path = tmp_path / "20260728_200507_#TestCreator 2026-07-28 Live.ts"
         part_path = Path(f"{output_path}.part")
@@ -948,9 +950,8 @@ class TestDownloadErrorCallback:
     def test_worker_does_not_adopt_an_empty_partial_download(self, mock_yt_dlp, tmp_path):
         """Test a zero-byte part is not turned into an empty merge input."""
         mock_ydl_class, mock_ydl = mock_yt_dlp
-        completed, failed = [], []
-        downloader = self._stopped_downloader(
-            tmp_path, mock_ydl, completed, failed, output_extension=".ts"
+        downloader, completed, failed = self._stopped_downloader(
+            tmp_path, mock_ydl, output_extension=".ts"
         )
         output_path = tmp_path / "20260728_200507_#TestCreator 2026-07-28 Live.ts"
         part_path = Path(f"{output_path}.part")
@@ -966,8 +967,7 @@ class TestDownloadErrorCallback:
     def test_worker_does_not_adopt_a_partial_mp4_download(self, mock_yt_dlp, tmp_path):
         """Test a truncated mp4, which has no moov atom yet, is never adopted."""
         mock_ydl_class, mock_ydl = mock_yt_dlp
-        completed, failed = [], []
-        downloader = self._stopped_downloader(tmp_path, mock_ydl, completed, failed)
+        downloader, completed, failed = self._stopped_downloader(tmp_path, mock_ydl)
         output_path = tmp_path / "20260728_200507_#TestCreator 2026-07-28 Live.mp4"
         part_path = Path(f"{output_path}.part")
         part_path.write_bytes(b"truncated mp4 without a moov atom")
@@ -984,9 +984,8 @@ class TestDownloadErrorCallback:
     ):
         """Test a failed rename falls back to reporting the recording as failed."""
         mock_ydl_class, mock_ydl = mock_yt_dlp
-        completed, failed = [], []
-        downloader = self._stopped_downloader(
-            tmp_path, mock_ydl, completed, failed, output_extension=".ts"
+        downloader, completed, failed = self._stopped_downloader(
+            tmp_path, mock_ydl, output_extension=".ts"
         )
         output_path = tmp_path / "20260728_200507_#TestCreator 2026-07-28 Live.ts"
         part_path = Path(f"{output_path}.part")

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -138,19 +138,19 @@ class TestBuildOutputPath:
 
 
 class TestGetUniquePath:
-    """Tests for _get_unique_path class method."""
+    """Tests for the get_unique_path class method."""
 
     def test_no_conflict_returns_original(self, tmp_path):
         """Test returns original path when no file exists."""
         path = tmp_path / "test.mp4"
-        result = StreamDownloader._get_unique_path(path)
+        result = StreamDownloader.get_unique_path(path)
         assert result == path
 
     def test_with_conflict_adds_counter(self, tmp_path):
         """Test adds _1 suffix when file exists."""
         path = tmp_path / "test.mp4"
         path.touch()
-        result = StreamDownloader._get_unique_path(path)
+        result = StreamDownloader.get_unique_path(path)
         assert result == tmp_path / "test_1.mp4"
 
     def test_multiple_conflicts_increments_counter(self, tmp_path):
@@ -159,7 +159,7 @@ class TestGetUniquePath:
         path.touch()
         (tmp_path / "test_1.mp4").touch()
         (tmp_path / "test_2.mp4").touch()
-        result = StreamDownloader._get_unique_path(path)
+        result = StreamDownloader.get_unique_path(path)
         assert result == tmp_path / "test_3.mp4"
 
     def test_max_duplicates_raises_error(self, tmp_path):
@@ -169,7 +169,7 @@ class TestGetUniquePath:
         for i in range(1, 1001):
             (tmp_path / f"test_{i}.mp4").touch()
         with pytest.raises(RuntimeError, match="Too many duplicate files"):
-            StreamDownloader._get_unique_path(path)
+            StreamDownloader.get_unique_path(path)
 
 
 class TestYtDlpLoggerBridge:

--- a/tests/test_orphan_recovery.py
+++ b/tests/test_orphan_recovery.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from core.downloader import StreamDownloader
 from core.orphan_recovery import recover_orphaned_sessions
 
 LOGGER = logging.getLogger("test_recovery")
@@ -182,32 +183,50 @@ class TestOrphanRecovery:
         assert final_path.read_bytes() == b"claimed mid-merge"
         assert (archive / "#Creator 2026-03-06 123_1.mp4").read_bytes() == b"mp4"
 
-    def test_two_stranded_sessions_with_one_title_both_reach_their_own_mp4(
+    def test_a_name_claimed_after_selection_is_not_overwritten(
         self, archive, monkeypatch
     ):
-        """Test the stop-and-restart case: same title, two sessions, two recordings kept.
+        """Test the install refuses a target claimed after the name was chosen.
 
-        This is the shape of every docker-stop during a live stream, and the
-        case a skip-on-collision policy stranded permanently.
+        Checking a name for availability and taking it are two steps, and the
+        winner of that gap owns the file. A plain rename would overwrite the
+        claimant's recording and then delete this session's inputs on top of it.
         """
-        first = archive / "20260728_200507_#Creator 2026-07-28 Live.ts"
-        second = archive / "20260728_200831_#Creator 2026-07-28 Live.ts"
-        first.write_bytes(b"first session")
-        second.write_bytes(b"second session")
+        ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
+        ts_file.write_bytes(b"ts")
+        final_path = archive / "#Creator 2026-03-06 123.mp4"
+        _fake_merge(monkeypatch)
 
-        def fake_concat(ts_files, output_path, run_command):
-            output_path.write_bytes(b"".join(f.read_bytes() for f in ts_files))
+        select_name = StreamDownloader.get_unique_path
+        claimed = []
 
-        monkeypatch.setattr("core.orphan_recovery.merge_ts_files_to_mp4", fake_concat)
+        def claim_the_name_just_selected(base_path):
+            selected = select_name(base_path)
+            # Exactly once, so the retry can still find a free name.
+            if not claimed:
+                claimed.append(selected)
+                selected.write_bytes(b"claimed after selection")
+            return selected
+
+        monkeypatch.setattr(
+            StreamDownloader,
+            "get_unique_path",
+            staticmethod(claim_the_name_just_selected),
+        )
 
         recover_orphaned_sessions(LOGGER)
 
-        # Each session's payload reaches its own file, oldest session first.
-        assert (archive / "#Creator 2026-07-28 Live.mp4").read_bytes() == b"first session"
-        assert (
-            archive / "#Creator 2026-07-28 Live_1.mp4"
-        ).read_bytes() == b"second session"
-        assert list(archive.glob("*.ts")) == []
+        # The claimant is byte-identical, this recording took the next suffix,
+        # and the inputs are gone only because the mp4 they became is on disk.
+        assert claimed == [final_path]
+        assert final_path.read_bytes() == b"claimed after selection"
+        assert (archive / "#Creator 2026-03-06 123_1.mp4").read_bytes() == b"mp4"
+        assert not ts_file.exists()
+        # The temp is consumed by the install, not left behind by the retry.
+        assert sorted(archive.iterdir()) == [
+            final_path,
+            archive / "#Creator 2026-03-06 123_1.mp4",
+        ]
 
     def test_only_the_ts_part_is_adopted_out_of_a_mixed_artifact_directory(
         self, archive, monkeypatch
@@ -271,27 +290,6 @@ class TestOrphanRecovery:
 
         assert captured == []
         assert list(archive.iterdir()) == [part_file]
-
-    def test_adopted_part_stays_retryable_when_its_merge_fails(
-        self, archive, monkeypatch
-    ):
-        """Test adoption is not undone by a failed merge: the next run recovers it."""
-        prefix = "20260306_120000_"
-        part_file = archive / f"{prefix}#Creator 2026-03-06 123.ts.part"
-        part_file.write_bytes(b"truncated but demuxable ts")
-        adopted = archive / f"{prefix}#Creator 2026-03-06 123.ts"
-        _fake_merge(monkeypatch, writes=b"partial", error=RuntimeError("boom"))
-
-        recover_orphaned_sessions(LOGGER)
-
-        # Adoption is one-way: the input is kept under its .ts name, not
-        # reverted, so the retry below is the ordinary .ts recovery path.
-        assert list(archive.iterdir()) == [adopted]
-
-        _fake_merge(monkeypatch)
-        recover_orphaned_sessions(LOGGER)
-
-        assert sorted(archive.iterdir()) == [archive / "#Creator 2026-03-06 123.mp4"]
 
     @pytest.mark.parametrize(
         "filename",

--- a/tests/test_orphan_recovery.py
+++ b/tests/test_orphan_recovery.py
@@ -153,15 +153,22 @@ class TestOrphanRecovery:
         assert existing.read_bytes() == b"already merged"
         assert ts_file.exists()
 
-    def test_part_and_ytdl_files_are_never_touched(self, archive, monkeypatch):
-        """Test in-flight yt-dlp artifacts are ignored and survive a mixed recovery."""
+    def test_only_the_ts_part_is_adopted_out_of_a_mixed_artifact_directory(
+        self, archive, monkeypatch
+    ):
+        """Test a stranded .ts.part is adopted and merged while .part-FragN and .ytdl are not.
+
+        Pins the adoption invariant by suffix: exactly NAME.ts.part qualifies.
+        Fragments and .ytdl may be torn mid-write, and a bare .part is not a
+        recording this application can name a session from.
+        """
         prefix = "20260306_120000_"
-        ts_file = archive / f"{prefix}#Creator 2026-03-06 123.ts"
-        ts_file.write_bytes(b"ts")
+        adoptable = archive / f"{prefix}#Creator 2026-03-06 123.ts.part"
+        adoptable.write_bytes(b"truncated but demuxable ts")
         untouchable = {
-            archive / f"{prefix}#Creator 2026-03-06 123.ts.part": b"part",
             archive / f"{prefix}#Creator 2026-03-06 123.ts.ytdl": b"ytdl",
             archive / f"{prefix}#Creator 2026-03-06 123.ts.part-Frag3": b"frag",
+            archive / f"{prefix}#Creator 2026-03-06 456.part": b"bare part",
         }
         for path, payload in untouchable.items():
             path.write_bytes(payload)
@@ -171,10 +178,64 @@ class TestOrphanRecovery:
 
         recover_orphaned_sessions(LOGGER)
 
-        # Only the .ts payload may ever reach the merge inputs.
-        assert [ts_files for ts_files, _ in captured] == [[ts_file]]
+        # The part is now the session's raw input, under its .ts name.
+        adopted = archive / f"{prefix}#Creator 2026-03-06 123.ts"
+        assert [ts_files for ts_files, _ in captured] == [[adopted]]
+        assert (archive / "#Creator 2026-03-06 123.mp4").read_bytes() == b"mp4"
+        assert not adoptable.exists()
         for path, payload in untouchable.items():
             assert path.read_bytes() == payload
+
+    def test_part_is_left_alone_when_its_ts_name_is_already_taken(
+        self, archive, monkeypatch
+    ):
+        """Test adoption never overwrites existing raw output for the same session."""
+        prefix = "20260306_120000_"
+        ts_file = archive / f"{prefix}#Creator 2026-03-06 123.ts"
+        ts_file.write_bytes(b"finished raw output")
+        part_file = archive / f"{prefix}#Creator 2026-03-06 123.ts.part"
+        part_file.write_bytes(b"a different attempt")
+        captured = []
+        _fake_merge(monkeypatch, captured=captured)
+
+        recover_orphaned_sessions(LOGGER)
+
+        # Only the existing .ts is merged; the part survives for an operator.
+        assert [ts_files for ts_files, _ in captured] == [[ts_file]]
+        assert part_file.read_bytes() == b"a different attempt"
+
+    def test_empty_part_is_not_adopted(self, archive, monkeypatch):
+        """Test a zero-byte part holds no recording, so it is left as it is."""
+        part_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts.part"
+        part_file.write_bytes(b"")
+        captured = []
+        _fake_merge(monkeypatch, captured=captured)
+
+        recover_orphaned_sessions(LOGGER)
+
+        assert captured == []
+        assert list(archive.iterdir()) == [part_file]
+
+    def test_adopted_part_stays_retryable_when_its_merge_fails(
+        self, archive, monkeypatch
+    ):
+        """Test adoption is not undone by a failed merge: the next run recovers it."""
+        prefix = "20260306_120000_"
+        part_file = archive / f"{prefix}#Creator 2026-03-06 123.ts.part"
+        part_file.write_bytes(b"truncated but demuxable ts")
+        adopted = archive / f"{prefix}#Creator 2026-03-06 123.ts"
+        _fake_merge(monkeypatch, writes=b"partial", error=RuntimeError("boom"))
+
+        recover_orphaned_sessions(LOGGER)
+
+        # Adoption is one-way: the input is kept under its .ts name, not
+        # reverted, so the retry below is the ordinary .ts recovery path.
+        assert list(archive.iterdir()) == [adopted]
+
+        _fake_merge(monkeypatch)
+        recover_orphaned_sessions(LOGGER)
+
+        assert sorted(archive.iterdir()) == [archive / "#Creator 2026-03-06 123.mp4"]
 
     @pytest.mark.parametrize(
         "filename",
@@ -184,6 +245,8 @@ class TestOrphanRecovery:
             "20260306_1200_#Creator short time.ts",
             "20260306120000_#Creator no separators.ts",
             "x20260306_120000_#Creator leading junk.ts",
+            "no-session-prefix.ts.part",
+            "x20260306_120000_#Creator leading junk.ts.part",
         ],
     )
     def test_non_canonical_names_are_ignored(self, archive, monkeypatch, filename, caplog):

--- a/tests/test_orphan_recovery.py
+++ b/tests/test_orphan_recovery.py
@@ -138,10 +138,10 @@ class TestOrphanRecovery:
         assert final_path.read_bytes() == b"mp4"
         assert list(archive.iterdir()) == [final_path]
 
-    def test_existing_output_collision_is_skipped_and_inputs_kept(
+    def test_existing_output_gets_the_next_suffix_and_is_never_overwritten(
         self, archive, monkeypatch
     ):
-        """Test recovery never overwrites an existing mp4; it skips and keeps inputs."""
+        """Test a taken mp4 name pushes this session to _1 instead of skipping it."""
         ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
         ts_file.write_bytes(b"ts")
         existing = archive / "#Creator 2026-03-06 123.mp4"
@@ -150,8 +150,64 @@ class TestOrphanRecovery:
 
         recover_orphaned_sessions(LOGGER)
 
+        # The earlier recording is byte-identical afterwards: reserving a free
+        # name is what keeps the rename from overwriting it.
         assert existing.read_bytes() == b"already merged"
-        assert ts_file.exists()
+        assert (archive / "#Creator 2026-03-06 123_1.mp4").read_bytes() == b"mp4"
+        assert not ts_file.exists()
+
+    def test_a_name_taken_while_the_merge_runs_is_not_overwritten(
+        self, archive, monkeypatch
+    ):
+        """Test the final name is reserved at rename time, not before the merge.
+
+        A concat can run for hours, so a name that was free when it started may
+        be taken by the time it finishes — and the rename overwrites silently.
+        """
+        ts_file = archive / "20260306_120000_#Creator 2026-03-06 123.ts"
+        ts_file.write_bytes(b"ts")
+        final_path = archive / "#Creator 2026-03-06 123.mp4"
+
+        def merge_then_lose_the_name(ts_files, output_path, run_command):
+            output_path.write_bytes(b"mp4")
+            # The name goes from free to taken while ffmpeg is still busy.
+            final_path.write_bytes(b"claimed mid-merge")
+
+        monkeypatch.setattr(
+            "core.orphan_recovery.merge_ts_files_to_mp4", merge_then_lose_the_name
+        )
+
+        recover_orphaned_sessions(LOGGER)
+
+        assert final_path.read_bytes() == b"claimed mid-merge"
+        assert (archive / "#Creator 2026-03-06 123_1.mp4").read_bytes() == b"mp4"
+
+    def test_two_stranded_sessions_with_one_title_both_reach_their_own_mp4(
+        self, archive, monkeypatch
+    ):
+        """Test the stop-and-restart case: same title, two sessions, two recordings kept.
+
+        This is the shape of every docker-stop during a live stream, and the
+        case a skip-on-collision policy stranded permanently.
+        """
+        first = archive / "20260728_200507_#Creator 2026-07-28 Live.ts"
+        second = archive / "20260728_200831_#Creator 2026-07-28 Live.ts"
+        first.write_bytes(b"first session")
+        second.write_bytes(b"second session")
+
+        def fake_concat(ts_files, output_path, run_command):
+            output_path.write_bytes(b"".join(f.read_bytes() for f in ts_files))
+
+        monkeypatch.setattr("core.orphan_recovery.merge_ts_files_to_mp4", fake_concat)
+
+        recover_orphaned_sessions(LOGGER)
+
+        # Each session's payload reaches its own file, oldest session first.
+        assert (archive / "#Creator 2026-07-28 Live.mp4").read_bytes() == b"first session"
+        assert (
+            archive / "#Creator 2026-07-28 Live_1.mp4"
+        ).read_bytes() == b"second session"
+        assert list(archive.glob("*.ts")) == []
 
     def test_only_the_ts_part_is_adopted_out_of_a_mixed_artifact_directory(
         self, archive, monkeypatch


### PR DESCRIPTION
## Summary
Live container testing revealed that graceful shutdown never produced a merged `.mp4` for live HLS recordings: terminating ffmpeg (exit 255) makes yt-dlp treat the download as failed, so `NAME.ts.part` is never renamed to `NAME.ts`, the shutdown merge has nothing to merge, and startup recovery ignored `.part` files by policy — the recording stayed stranded forever (bytes intact, but never playable as an mp4).

Adjudicated invariant change: a canonical `NAME.ts.part` may be ADOPTED (renamed to `NAME.ts`, then merged) only when provably dead. `.part-FragN` fragments and `.ytdl` files remain never touched.

- **Shutdown adoption** (`core/downloader.py`): in the stop-for-shutdown path, when the output is missing but a non-empty single `.ts.part` exists (no sibling fragments, `.ts` outputs only — a truncated mp4 has no moov atom and is unplayable), the part is renamed to the expected `.ts` and the NORMAL completion event fires, so the existing shutdown merge produces the `.mp4` within the budget. Rename failure falls back to keep+warn.
- **Startup adoption** (`core/orphan_recovery.py`): canonical `*.ts.part` files are adopted first and flow through the unchanged merge/validate/temp+atomic-rename pipeline. Target-`.ts`-exists and zero-byte parts are left with a warning.
- **Collision policy**: recovery now suffixes like the live path (`NAME_1.mp4`, via promoted `StreamDownloader.get_unique_path`) instead of skipping — adoption made "same title, different session" the common collision (every stop+restart during one stream produces it); a rare duplicate beats a permanently stranded recording.
- **No-overwrite install**: the final name is claimed atomically at rename time (`os.link` + unlink, retrying the next suffix on `FileExistsError`), closing the selection-to-replace overwrite window. Requires hardlink support (ext4/btrfs fine); on filesystems without it recovery fails safe: warning, inputs kept.

## Acceptance criteria
- [ ] `docker stop` during a live recording yields a merged `.mp4` (adopted part → completion event → shutdown merge)
- [ ] Startup adopts stranded canonical `.ts.part`, merges them, suffixes on same-title collisions, never overwrites any existing file
- [ ] `.part-FragN` / `.ytdl` / non-canonical / zero-byte / `.mp4.part` files untouched
- [ ] All failure paths keep every input; idempotent retry preserved

## Verification
- Full suite 3 consecutive runs: `401 passed in 38.55s` / `38.54s` / `38.54s`
- 10-mutation table (adoption guards, fragment exclusion, collision, plain-replace install, empty outputs) — all caught, no survivors
- Real-specimen end-to-end with the app image's ffmpeg 8.1.2 against copies of four genuine stranded recordings from the live test: 4/4 recovered into playable h264/aac mp4s (41 MB/144.9 s and 13 MB/46.8 s pairs, suffixed correctly); originals untouched
- Dual independent review (L3-calibrated pragmatic + over-engineering pass) + fix round addressing all findings (incl. Critical selection-to-replace overwrite window)
