### PR TITLE
chore: prepare v2.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ docker run -d \
   -v $(pwd)/config:/app/config \
   -v $(pwd)/archive:/app/archive \
   -v $(pwd)/logs:/app/logs \
-  paverz/rplay-live-dl:v2.2.1-vibe
+  paverz/rplay-live-dl:v2.3.0-vibe
 ```
 
 #### Docker healthcheck

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   rplay-live-dl:
-    image: paverz/rplay-live-dl:v2.2.1-vibe
+    image: paverz/rplay-live-dl:v2.3.0-vibe
     container_name: rplay-live-dl
     env_file: .env
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rplay-live-dl"
-version = "2.2.1"
+version = "2.3.0"
 description = ""
 authors = ["paver(kevinsun)"]
 license = "MIT"


### PR DESCRIPTION
## Summary
Version/tag references only (pyproject, compose image tag, README image tag). Consistency enforced by `tests/test_release_metadata.py`.

## Highlights since v2.2.1 (PR #38–#54)
- Live-HLS resilience: ffmpeg reconnect args actually applied (FFmpegFD) — #38
- Graceful shutdown finalizes recordings; interrupted `.ts.part` adopted and merged at shutdown AND at next startup; recovery collisions suffix instead of strand — #40, #53, #54
- Immediate re-poll when a download fails mid-stream — #45
- Startup credential validation + auth-error dedup; stream-key error contract; key2 redaction in yt-dlp logs — #39, #48, #51
- LOG_LEVEL/LOG_YTDLP_INTERNAL fail-fast validation — #44
- MIN_FREE_DISK_GB free-disk guard — #50
- Docker HEALTHCHECK (heartbeat file, 3×INTERVAL) — #52
- Quiet-night heartbeat at INFO — #49
- CI matrix 3.11–3.14, Actions bumps, Dockerfile ARG/Poetry pin/.dockerignore, yt-dlp CalVer constraint, compose TZ + release-metadata test — #41–#43, #46

## Verification
- Full suite: `401 passed` (includes three-way version consistency test)
- Two rounds of real-container verification on devpc: startup recovery merged 4/4 stranded recordings; `docker stop` during a live recording produced the merged `.mp4` with zero `.ts`/`.part` leftovers; healthcheck healthy; ffmpeg 8.1.2 reconnect options confirmed in-image
