### PR TITLE
fix: demote download failure diagnostics to DEBUG with short retry lines

### DIFF
--- a/core/downloader.py
+++ b/core/downloader.py
@@ -147,6 +147,7 @@ class StreamDownloader:
         self.filename_prefix = filename_prefix
         self._on_download_complete = on_download_complete
         self._on_download_failure = on_download_failure
+        self._last_download_attempt = 0
         self._yt_dlp_logger = _YtDlpLoggerBridge(
             self,
             enabled=is_ytdlp_internal_logging_enabled(),
@@ -348,8 +349,19 @@ class StreamDownloader:
 
         return True
 
-    def _build_output_state_details(self, output_path: Path) -> str:
-        """Build a compact output-state summary for downloader logs."""
+    @staticmethod
+    def _extract_short_error_reason(error_text: str) -> str:
+        """Prefer an HTTP Error token; else first line, truncated to ~120 chars."""
+        match = re.search(r"HTTP Error \d+[^;,)]*", error_text)
+        if match:
+            return match.group(0).strip()
+        first_line = (error_text.splitlines() or ["unknown error"])[0].strip()
+        if len(first_line) > 120:
+            return f"{first_line[:117]}..."
+        return first_line or "unknown error"
+
+    def _inspect_output_state(self, output_path: Path) -> Dict[str, Any]:
+        """Collect output/part/fragment facts once for dual-level log formatting."""
         part_path = Path(f"{output_path}.part")
         output_exists = output_path.exists()
         part_exists = part_path.exists()
@@ -358,11 +370,57 @@ class StreamDownloader:
             format_file_size(output_path.stat().st_size) if output_exists else "0 B"
         )
         part_size = format_file_size(part_path.stat().st_size) if part_exists else "0 B"
+        return {
+            "output_path": output_path,
+            "part_path": part_path,
+            "output_exists": output_exists,
+            "part_exists": part_exists,
+            "sibling_fragments": sibling_fragments,
+            "output_size": output_size,
+            "part_size": part_size,
+        }
+
+    def _build_output_state_details(self, output_path: Path) -> str:
+        """Full diagnostic dump for DEBUG logs (includes paths and session fields)."""
+        state = self._inspect_output_state(output_path)
         return (
-            f"output_path={output_path}, "
-            f"output_exists={output_exists}, output_size={output_size}, "
-            f"part_path={part_path}, part_exists={part_exists}, part_size={part_size}, "
-            f"sibling_fragments={sibling_fragments}"
+            f"output_path={state['output_path']}, "
+            f"output_exists={state['output_exists']}, output_size={state['output_size']}, "
+            f"part_path={state['part_path']}, part_exists={state['part_exists']}, "
+            f"part_size={state['part_size']}, "
+            f"sibling_fragments={state['sibling_fragments']}"
+        )
+
+    def _build_compact_output_state_summary(self, output_path: Path) -> str:
+        """Path-free human summary for WARNING/ERROR logs."""
+        state = self._inspect_output_state(output_path)
+        output = (
+            f"present ({state['output_size']})"
+            if state["output_exists"]
+            else "missing"
+        )
+        part = (
+            f"present ({state['part_size']})"
+            if state["part_exists"]
+            else "missing"
+        )
+        fragments = "yes" if state["sibling_fragments"] else "no"
+        return f"output={output}, part={part}, fragments={fragments}"
+
+    def _log_output_state_debug(
+        self,
+        prefix: str,
+        error_message: str,
+        output_path: Optional[Path],
+    ) -> None:
+        """Emit the legacy full dump at DEBUG only (session_key + paths)."""
+        if output_path is None:
+            details = "output_path=unknown"
+        else:
+            details = self._build_output_state_details(output_path)
+        self.log.debug(
+            f"{prefix}{error_message}; "
+            f"session_key={self.session_key or 'none'}, {details}",
         )
 
     def _download_worker(
@@ -400,9 +458,15 @@ class StreamDownloader:
                     f"({size_str}, {duration_str})",
                 )
             else:
+                compact = self._build_compact_output_state_summary(output_path)
                 self.log.warning(
                     "⚠️  Download finished but file not found: "
-                    f"{output_path}; {self._build_output_state_details(output_path)}",
+                    f"{output_path.name}; {compact}",
+                )
+                self._log_output_state_debug(
+                    "Download finished but file not found: ",
+                    str(output_path),
+                    output_path,
                 )
                 if not self._has_sibling_fragment_outputs(output_path):
                     # Without this the session never leaves RAW_RUNNING: no
@@ -442,10 +506,16 @@ class StreamDownloader:
                     self._notify_download_complete(output_path)
                     return
 
+                short_reason = self._extract_short_error_reason(error_message)
+                compact = self._build_compact_output_state_summary(output_path)
                 self.log.warning(
                     f"⏹️ Recording stopped for shutdown (session {session_prefix}) with no "
-                    f"finished raw output: {error_message}; "
-                    f"{self._build_output_state_details(output_path)}",
+                    f"finished raw output: {short_reason}; {compact}",
+                )
+                self._log_output_state_debug(
+                    "Recording stopped for shutdown with no finished raw output: ",
+                    error_message,
+                    output_path,
                 )
                 self._notify_download_failure(error_message)
                 return
@@ -453,11 +523,14 @@ class StreamDownloader:
             # ponytail: .error, not .exception — this handler mostly sees classified
             # 401/403/404 access failures where the yt-dlp message says it all; the
             # truly-unexpected path below keeps the traceback.
+            attempts = max(1, self._last_download_attempt)
+            short_reason = self._extract_short_error_reason(error_message)
+            compact = self._build_compact_output_state_summary(output_path)
             self.log.error(
-                "❌ Download error: "
-                f"{error_message}; session_key={self.session_key or 'none'}, "
-                f"{self._build_output_state_details(output_path)}",
+                f"❌ Download failed after {attempts} attempts: "
+                f"{short_reason}; {compact}",
             )
+            self._log_output_state_debug("Download failed: ", error_message, output_path)
             if self._is_auth_error(error_message):
                 self._notify_auth_error(error_message)
             elif self._is_m3u8_access_error(error_message):
@@ -466,10 +539,17 @@ class StreamDownloader:
                 self._notify_download_failure(error_message)
 
         except Exception as e:
+            attempts = max(1, self._last_download_attempt)
+            short_reason = self._extract_short_error_reason(str(e))
+            compact = self._build_compact_output_state_summary(output_path)
             self.log.exception(
-                "❌ Unexpected download error: "
-                f"{e}; session_key={self.session_key or 'none'}, "
-                f"{self._build_output_state_details(output_path)}",
+                f"❌ Download failed after {attempts} attempts: "
+                f"{short_reason}; {compact}",
+            )
+            self._log_output_state_debug(
+                "Unexpected download error: ",
+                str(e),
+                output_path,
             )
             self._notify_download_failure(str(e))
 
@@ -529,14 +609,17 @@ class StreamDownloader:
         wait_seconds = 0.0
         if retry_state.next_action is not None:
             wait_seconds = retry_state.next_action.sleep
-        output_state = "output_path=unknown"
-        if self._current_output_path is not None:
-            output_state = self._build_output_state_details(self._current_output_path)
+        short_reason = self._extract_short_error_reason(str(exception))
         self.log.warning(
-            f"⚠️ Download attempt {retry_state.attempt_number}/"
-            f"{self.DOWNLOAD_TASK_RETRY_ATTEMPTS} failed; retrying in "
-            f"{wait_seconds:.1f}s: {exception}; "
-            f"session_key={self.session_key or 'none'}, {output_state}",
+            f"⚠️ Attempt {retry_state.attempt_number}/"
+            f"{self.DOWNLOAD_TASK_RETRY_ATTEMPTS} failed ({short_reason}); "
+            f"retrying in {wait_seconds:.1f}s",
+        )
+        self._log_output_state_debug(
+            f"Attempt {retry_state.attempt_number}/"
+            f"{self.DOWNLOAD_TASK_RETRY_ATTEMPTS} failed: ",
+            str(exception),
+            self._current_output_path,
         )
 
     def _download_stream_with_retries(
@@ -547,11 +630,13 @@ class StreamDownloader:
     ) -> None:
         """Run yt-dlp and retry the full task for transient download failures."""
         attempt_number = 0
+        self._last_download_attempt = 0
 
         try:
             for attempt in self._build_download_retrying():
                 with attempt:
                     attempt_number = attempt.retry_state.attempt_number
+                    self._last_download_attempt = attempt_number
                     if self._stop_requested.is_set():
                         # Set while the previous backoff was sleeping; a fresh
                         # yt-dlp run here would only be killed again.

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1005,31 +1005,86 @@ class TestDownloadErrorCallback:
         assert len(failed) == 1
 
     def test_worker_logs_partial_output_details_on_failure(self, mock_yt_dlp, tmp_path):
-        """Test final download error logs include .part output details."""
+        """Test failure logs: short WARNING/ERROR + full dump only at DEBUG."""
         mock_ydl_class, mock_ydl = mock_yt_dlp
         downloader = StreamDownloader(
             "TestCreator",
             session_key="creator1:stream1",
         )
-        output_path = tmp_path / "test.ts"
+        # Path shaped like production so WARNING/ERROR must not leak it.
+        archive_dir = tmp_path / "app" / "archive" / "TestCreator"
+        archive_dir.mkdir(parents=True)
+        output_path = archive_dir / "test.ts"
         part_path = Path(f"{output_path}.part")
         part_path.write_bytes(b"abcdef")
         downloader._download_start_time = datetime.now()
-        mock_ydl.download.side_effect = yt_dlp.utils.DownloadError("Some other error")
+        downloader._current_output_path = output_path
+        # Retryable so we exercise both short WARNING retries and final ERROR.
+        mock_ydl.download.side_effect = yt_dlp.utils.DownloadError(
+            "ERROR: Unable to download webpage: HTTP Error 500: Internal Server Error"
+        )
 
-        with patch.object(downloader.logger, "log") as mock_log:
+        with patch("core.downloader.time.sleep"), patch.object(
+            downloader, "log"
+        ) as mock_log:
             downloader._download_worker("http://example.com/stream.m3u8", {}, output_path)
 
+        warning_msgs = [str(call.args[0]) for call in mock_log.warning.call_args_list]
+        error_msgs = [str(call.args[0]) for call in mock_log.error.call_args_list]
+        debug_msgs = [str(call.args[0]) for call in mock_log.debug.call_args_list]
+
+        assert warning_msgs, "expected short WARNING lines per failed attempt"
+        for msg in warning_msgs:
+            assert "Attempt" in msg and "failed" in msg and "retrying in" in msg
+            assert "HTTP Error 500" in msg
+            assert "session_key=" not in msg
+            assert "/app/archive" not in msg
+            assert "output_path=" not in msg
+            assert "part_path=" not in msg
+
         assert any(
-            "output_path=" in str(call)
-            and "part_exists=True" in str(call)
-            and "part_size=6.0 B" in str(call)
-            for call in mock_log.call_args_list
+            "Download failed after" in msg
+            and "HTTP Error 500" in msg
+            and "output=missing" in msg
+            and "part=present (6.0 B)" in msg
+            and "fragments=no" in msg
+            and "session_key=" not in msg
+            and "output_path=" not in msg
+            and "/app/archive" not in msg
+            for msg in error_msgs
+        )
+
+        assert any(
+            "session_key=creator1:stream1" in msg
+            and "output_path=" in msg
+            and "part_path=" in msg
+            and "part_exists=True" in msg
+            and "part_size=6.0 B" in msg
+            and "sibling_fragments=False" in msg
+            for msg in debug_msgs
         )
         # Adoption belongs to the shutdown path alone: yt-dlp may still resume
         # into this .part on a later attempt, so nothing may claim it here.
         assert part_path.read_bytes() == b"abcdef"
         assert not output_path.exists()
+
+    def test_extract_short_error_reason_prefers_http_error(self):
+        """Test short-reason helper keeps the HTTP Error token."""
+        reason = StreamDownloader._extract_short_error_reason(
+            "ERROR: Unable to download webpage: HTTP Error 404: Not Found; "
+            "please report this issue"
+        )
+        assert reason == "HTTP Error 404: Not Found"
+
+    def test_extract_short_error_reason_truncates_generic_text(self):
+        """Test short-reason helper falls back to a truncated first line."""
+        long_line = "x" * 150
+        reason = StreamDownloader._extract_short_error_reason(f"{long_line}\nsecond")
+        assert reason == f"{'x' * 117}..."
+        assert len(reason) == 120
+
+        short = StreamDownloader._extract_short_error_reason("Some other error")
+        assert short == "Some other error"
 
     def test_worker_emits_failure_event_on_non_m3u8_error(self, mock_yt_dlp, tmp_path):
         """Test non-blocked download errors emit a raw failure event."""


### PR DESCRIPTION
## Summary
One failed download previously emitted four near-identical very long lines: every retry logged the full diagnostic dump (session key, both full filesystem paths, sizes, fragment state) at WARNING/ERROR. Now logging is level-aware — reformatted and demoted, nothing deleted:

- WARNING per retry: `[name] ⚠️ Attempt 1/3 failed (HTTP Error 404: Not Found); retrying in 2.0s`
- Final ERROR: `[name] ❌ Download failed after 3 attempts: <reason>; output=missing, part=present (41.3 MB), fragments=no`
- DEBUG: the complete legacy dump (session_key, full paths, sizes) for every attempt — `LOG_LEVEL=DEBUG` restores exactly the old detail
- Identifier hygiene: session_key (contains the creator OID) and filesystem paths now appear at DEBUG only

## Acceptance criteria
- [ ] WARNING/ERROR lines contain no `session_key=` and no filesystem paths
- [ ] `LOG_LEVEL=DEBUG` shows every field the old format printed
- [ ] Callback/event `error_message` payloads unchanged (401/403/404 classification and #47 routing tests untouched)
- [ ] Retry cadence, tenacity config, shutdown adoption (#54), key2 masking all unchanged

## Verification
- Full suite 3 consecutive runs: `403 passed in 32.81s` / `32.56s` / `32.54s`
- Diff audit: zero edits to `_notify_*` bodies or event construction; key2 mask line intact
