### PR TITLE
chore: prepare v2.3.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ docker run -d \
   -v $(pwd)/config:/app/config \
   -v $(pwd)/archive:/app/archive \
   -v $(pwd)/logs:/app/logs \
-  paverz/rplay-live-dl:v2.3.0-vibe
+  paverz/rplay-live-dl:v2.3.1-vibe
 ```
 
 #### Docker healthcheck

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   rplay-live-dl:
-    image: paverz/rplay-live-dl:v2.3.0-vibe
+    image: paverz/rplay-live-dl:v2.3.1-vibe
     container_name: rplay-live-dl
     env_file: .env
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rplay-live-dl"
-version = "2.3.0"
+version = "2.3.1"
 description = ""
 authors = ["paver(kevinsun)"]
 license = "MIT"


### PR DESCRIPTION
Version/tag references only (pyproject, compose image tag, README image tag); consistency enforced by tests/test_release_metadata.py. v2.3.1 = v2.3.0 changes (#38-#55) + level-aware failure logging (#57). Local suite: 403 passed.