### PR TITLE
fix: demote heartbeat log to DEBUG and unify retry wording (v2.3.2)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.py]
+max_line_length = 120

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ config/config.yaml
 archive/
 logs/
 .worktrees/
+poetry.toml
+pyrightconfig.json

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ docker run -d \
   -v $(pwd)/config:/app/config \
   -v $(pwd)/archive:/app/archive \
   -v $(pwd)/logs:/app/logs \
-  paverz/rplay-live-dl:v2.3.1-vibe
+  paverz/rplay-live-dl:latest
 ```
 
 #### Docker healthcheck

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -651,7 +651,7 @@ class StreamDownloader:
                     # Only a retry is worth a line of its own.
                     if attempt_number > 1:
                         self.log.info(
-                            f"🔁 Retry {attempt_number}/{self.DOWNLOAD_TASK_RETRY_ATTEMPTS}",
+                            f"🔁 Attempt {attempt_number}/{self.DOWNLOAD_TASK_RETRY_ATTEMPTS}",
                         )
                     if self.logger.isEnabledFor(logging.DEBUG):
                         self.log.debug(
@@ -677,7 +677,7 @@ class StreamDownloader:
 
         if attempt_number > 1:
             self.log.info(
-                f"✅ Download succeeded on retry attempt "
+                f"✅ Download succeeded on attempt "
                 f"{attempt_number}/{self.DOWNLOAD_TASK_RETRY_ATTEMPTS}",
             )
 

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
 import yt_dlp
+import yt_dlp.utils
 from pathvalidate import sanitize_filename
 from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait_exponential
 
@@ -657,7 +658,7 @@ class StreamDownloader:
                             f"{self._build_output_state_details(output_path)}",
                         )
                     try:
-                        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                        with yt_dlp.YoutubeDL(ydl_opts) as ydl:  # pyright: ignore[reportArgumentType]
                             ydl.download([stream_url])
                     except yt_dlp.utils.DownloadError as exc:
                         error_message = str(exc)

--- a/core/downloader.py
+++ b/core/downloader.py
@@ -103,6 +103,9 @@ class StreamDownloader:
     MAX_DUPLICATE_FILES = 1000
 
     # Error message patterns indicating non-retriable access failure.
+    # Verified against the live service: no-access (paid) streams return 404 from
+    # the moment they go live, so 404 right after stream start means blocked, not
+    # CDN warmup. Do not "fix" this by retrying 404 longer.
     ACCESS_ERROR_PATTERNS = [
         "HTTP Error 403",
         "HTTP Error 404",

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -625,7 +625,7 @@ class LiveStreamMonitor:
                 f"{monitored_live}/{monitored_count} monitored creator(s) live"
             )
         elif periodic_heartbeat and monitored_count > 0:
-            self.logger.info(
+            self.logger.debug(
                 f"📊 Checked {total_live} live stream(s), "
                 f"none of {monitored_count} monitored creator(s) are live"
             )

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -1026,7 +1026,10 @@ class LiveStreamMonitor:
         )
 
     def _handle_raw_download_blocked(self, event: RawDownloadBlocked) -> None:
-        """Apply blocked-session state when downloader reports access failure."""
+        """Apply blocked-session state when downloader reports access failure.
+
+        Reaching here via 404 shortly after stream start is expected for no-access (paid) streams.
+        """
         with self._state_lock:
             session = self.sessions.get(event.session_key)
             if session is None:

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -953,6 +953,7 @@ class LiveStreamMonitor:
                 late_creator_name = session.creator_name
                 late_output_dir = session.output_dir
             else:
+                late_creator_name = None
                 late_output_dir = None
 
         if late_output_dir is not None:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   rplay-live-dl:
-    image: paverz/rplay-live-dl:v2.3.1-vibe
+    image: paverz/rplay-live-dl:latest
     container_name: rplay-live-dl
     env_file: .env
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rplay-live-dl"
-version = "2.3.1"
+version = "2.3.2"
 description = ""
 authors = ["paver(kevinsun)"]
 license = "MIT"

--- a/tests/test_live_stream_monitor.py
+++ b/tests/test_live_stream_monitor.py
@@ -1834,14 +1834,14 @@ class TestHeartbeatLogOptimization:
             api=mock_api,
         )
 
-        with patch.object(monitor.logger, 'info') as mock_info:
+        with patch.object(monitor.logger, 'debug') as mock_debug:
             # Run multiple checks
             for _ in range(10):
                 monitor.check_live_streams_and_start_download()
 
-        # Should have at least one periodic heartbeat (info level, so quiet
-        # nights still show life in default INFO logs)
-        heartbeat_logs = [c for c in mock_info.call_args_list if "Checked" in str(c)]
+        # Should have at least one periodic heartbeat (debug level; quiet
+        # nights only show life when DEBUG logging is enabled)
+        heartbeat_logs = [c for c in mock_debug.call_args_list if "Checked" in str(c)]
         assert len(heartbeat_logs) >= 1
 
 

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -15,29 +15,15 @@ def test_version_is_valid_semver():
     assert re.match(r"^\d+\.\d+\.\d+", main.__version__)
 
 
-def test_release_version_is_consistent():
-    """Test that release metadata uses the same version in every published location."""
+def test_release_image_references_use_latest():
+    """Test that published image references track :latest instead of stale pinned tags."""
     root = Path(__file__).resolve().parents[1]
-    versions = {
-        "pyproject.toml": re.search(
-            r'^\s*version\s*=\s*"(\d+\.\d+\.\d+)',
-            (root / "pyproject.toml").read_text(),
-            re.MULTILINE,
-        ).group(1),
-        "docker-compose.yaml": re.search(
-            r"^\s*image:\s+\S+:v?(\d+\.\d+\.\d+)",
-            (root / "docker-compose.yaml").read_text(),
-            re.MULTILINE,
-        ).group(1),
-        "README.md": re.search(
-            r"paverz/rplay-live-dl:v?(\d+\.\d+\.\d+)",
-            (root / "README.md").read_text(),
-        ).group(1),
-    }
-    expected = versions["pyproject.toml"]
+    compose = (root / "docker-compose.yaml").read_text()
+    readme = (root / "README.md").read_text()
 
-    for filename, version in versions.items():
-        assert version == expected, (
-            f"{filename} version {version!r} disagrees with "
-            f"pyproject.toml version {expected!r}"
+    assert re.search(r"^\s*image:\s+paverz/rplay-live-dl:latest\s*$", compose, re.MULTILINE)
+    assert "paverz/rplay-live-dl:latest" in readme
+    for filename, text in (("docker-compose.yaml", compose), ("README.md", readme)):
+        assert not re.search(r"paverz/rplay-live-dl:v\d", text), (
+            f"{filename} still pins an old image tag; use :latest"
         )


### PR DESCRIPTION
## Summary
Since v2.3.0 promoted the heartbeat to INFO (#49), every quiet poll printed a status line that buried actual recording events. v2.3.2 restores the signal: quiet nights are silent at INFO, and all retry logs speak the same `Attempt n/3` language.

It also ships a possibly-unbound-variable fix, documented 404 no-access behavior, pyright cleanups, and the release metadata bump.

### User-facing
- **Heartbeat back to DEBUG** (closes #59): the periodic `📊 Checked N live stream(s)…` line is DEBUG again; state-change status lines stay INFO.
- **Retry wording unified**: `🔁 Retry n/3` → `🔁 Attempt n/3`, and `✅ Download succeeded on retry attempt n/3` → `✅ … on attempt n/3`, matching the `⚠️ Attempt n/3 failed` line introduced in #57. Strings only; retry behavior unchanged.

### Fixes & chores
- fix: `late_creator_name` possibly-unbound in `_handle_raw_download_completed` when merge submission is closed by shutdown
- docs: record the verified 404 no-access (paid stream) behavior in downloader + monitor
- chore: silence pyright warnings in `core/downloader.py` (`import yt_dlp.utils`, one targeted ignore)
- chore: add `.editorconfig` (120-char line limit for `*.py`); ignore local `poetry.toml` / `pyrightconfig.json`

### Release metadata
- Version bump → `2.3.2` (pyproject)
- compose/README image references now track `paverz/rplay-live-dl:latest`; `tests/test_release_metadata.py` now guards `:latest` instead of pinned-tag consistency
- CI is unchanged: tag push still publishes both `:latest` and the version tag, and still refuses tags not on `main`

## Acceptance criteria
- [x] Default (INFO) logs on a quiet night contain no periodic heartbeat lines
- [x] `LOG_LEVEL=DEBUG` still shows the heartbeat every N checks
- [x] Retry lines read `Attempt n/3` everywhere; retry count and cadence unchanged (3 total attempts)
- [x] No callback/event payload changes

## Verification
- Full suite: `poetry run pytest` → 403 passed in 32.60s
