### PR TITLE
fix: use loginType=rplay for key2 authentication

### DIFF
--- a/core/rplay.py
+++ b/core/rplay.py
@@ -259,7 +259,7 @@ class RPlayAPI:
 
         url = (
             f"{self.base_url}/live/key2?"
-            f"lang=en&requestorOid={self.user_oid}&loginType=plax"
+            f"lang=en&requestorOid={self.user_oid}&loginType=rplay"
         )
 
         try:


### PR DESCRIPTION
## Summary

`/live/key2` hardcodes `loginType=plax`, but the rplay API now requires `loginType=rplay`. With `plax`, key2 returns `200` with a body of only `{"region":"us-east"}` and no `authKey`, which the client reports as "Invalid authentication response" and then restart-loops — even with a valid, fresh token. This one-line change switches `loginType` to `rplay`, matching what the rplay web client itself sends.

## Testing

- `poetry run pytest` — all passing.
- Verified against the live API: with `loginType=rplay`, `/live/key2` returns `{"authKey":"..."}`; with `plax` it returns only `{"region":"us-east"}`.

## Note

Depends on rplay's current private API shape, which can change without notice.

Split as requested — this PR is now just the loginType fix (581849d). The refresh enhancement is moved to #62. Also fixed the line breaks and the title.