### PR TITLE
feat: auto-refresh short-lived access token via REFRESH_TOKEN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,16 @@
 AUTH_TOKEN=
 USER_OID=
 
+# Optional but strongly recommended. Without it, AUTH_TOKEN is used as-is
+# and expires ~10 minutes after you copy it, so the container will fail
+# authentication shortly after. With it set, the app mints a fresh
+# access token automatically and keeps running.
+#
+# How to get it: log in at rplay.live, open the browser console, and run:
+#   JSON.parse(localStorage.vuex).AccountModule.userInfo.refreshToken
+# Copy the value below.
+REFRESH_TOKEN=
+
 # Optional: monitor poll interval in seconds (10-3600)
 INTERVAL=60
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ logs/
 .worktrees/
 poetry.toml
 pyrightconfig.json
+docker-compose.override.yaml

--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@
 
 `2.0.0-vibe` contains a breaking config-path change.
 
-| Before v2 | Since `2.0.0-vibe` |
-| --- | --- |
-| `./config.yaml` | `./config/config.yaml` |
-| mount one file | mount the whole `./config` directory |
+| Before v2       | Since `2.0.0-vibe`                   |
+| --------------- | ------------------------------------ |
+| `./config.yaml` | `./config/config.yaml`               |
+| mount one file  | mount the whole `./config` directory |
 
 Upgrade checklist:
 
@@ -76,6 +76,7 @@ Startup protection:
 ## ✨ Features
 
 - automated live monitoring for multiple creators
+- automatic access-token refresh for long-running deployments (short-lived tokens are re-minted from `REFRESH_TOKEN`)
 - session-aware download tracking to avoid creator-level blocking
 - flat archive layout with timestamp-prefixed `.ts` files per session
 - immediate merge queueing after raw download completion
@@ -136,14 +137,38 @@ Development:
 
 ### Obtaining Credentials
 
+RPlay persists its Vuex store to `localStorage` under the `vuex` key. Parsing it exposes an `AccountModule.userInfo` object that holds every token credential this tool needs — `token` (your `AUTH_TOKEN`), `refreshToken` (your `REFRESH_TOKEN`), and `loginType`. You can read all of them from one place in the browser console:
+
+```js
+JSON.parse(localStorage.vuex).AccountModule.userInfo
+```
+
 #### `AUTH_TOKEN`
 
+The short-lived access token. It expires roughly 10 minutes after it is issued, so on its own it is only enough to start the app once — set `REFRESH_TOKEN` (below) so the app can keep minting fresh access tokens automatically.
+
 1. Log in to `rplay.live`
-2. Open browser DevTools (`F12`)
-3. Execute `localStorage.getItem('_AUTHORIZATION_')`
+2. Open browser DevTools (`F12`) → Console
+3. Execute either of:
+   - `localStorage.getItem('_AUTHORIZATION_')`
+   - `JSON.parse(localStorage.vuex).AccountModule.userInfo.token`
 4. Copy the returned token
 
 ![auth_token](https://github.com/Zhen-Bo/rplay-live-dl/blob/main/images/auth_token.png?raw=true)
+
+#### `REFRESH_TOKEN` (recommended)
+
+The durable token used to mint fresh access tokens. Because `AUTH_TOKEN` expires in ~10 minutes, a deployment without `REFRESH_TOKEN` will fail authentication shortly after starting (the container logs `Invalid authentication response` and restart-loops). With `REFRESH_TOKEN` set, the app refreshes the access token before it expires and runs indefinitely.
+
+1. Log in to `rplay.live`
+2. Open browser DevTools (`F12`) → Console
+3. Execute:
+   ```js
+   JSON.parse(localStorage.vuex).AccountModule.userInfo.refreshToken
+   ```
+4. Copy the returned value
+
+> Unlike `AUTH_TOKEN`, the refresh token is stable — the same value keeps working, so you paste it once into `.env` and leave it.
 
 #### `USER_OID`
 
@@ -174,6 +199,13 @@ Full example:
 AUTH_TOKEN=your_auth_token
 USER_OID=your_user_oid
 
+# Recommended: refresh token used to auto-mint fresh access tokens.
+# AUTH_TOKEN expires ~10 minutes after you copy it; without this the
+# container fails authentication shortly after starting. Get it from the
+# browser console at rplay.live:
+#   JSON.parse(localStorage.vuex).AccountModule.userInfo.refreshToken
+REFRESH_TOKEN=
+
 # Optional: monitor poll interval in seconds (10-3600)
 INTERVAL=60
 
@@ -198,23 +230,26 @@ APP_GIT_SHA=
 
 Environment variables:
 
-| Variable | Required | Default | Validation / accepted values | Purpose |
-| --- | --- | --- | --- | --- |
-| `AUTH_TOKEN` | yes | none | non-empty | RPlay auth token used for API and stream access |
-| `USER_OID` | yes | none | non-empty | Your RPlay user identifier |
-| `INTERVAL` | no | `60` | integer `10`-`3600` | Poll interval in seconds |
-| `MIN_FREE_DISK_GB` | no | `5` | non-negative number; `0` disables the guard; invalid/negative values abort startup | Skip starting a new recording when free space on the output volume is below this many GiB |
-| `LOG_LEVEL` | no | `INFO` | `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`; invalid values abort startup with a non-zero exit | Console and file log verbosity |
-| `LOG_YTDLP_INTERNAL` | no | `false` | truthy: `1`, `true`, `yes`, `on`; falsy: `0`, `false`, `no`, `off`, empty; other values abort startup | Enables noisy yt-dlp internal debug lines |
-| `LOG_MAX_SIZE_MB` | no | `5` | integer `1`-`100` | Maximum size of each log file before rotation |
-| `LOG_BACKUP_COUNT` | no | `5` | integer `1`-`50` | Number of rotated log files to keep |
-| `LOG_RETENTION_DAYS` | no | `30` | integer `1`-`365` | Age-based cleanup window for old logs |
-| `APP_GIT_SHA` | no | empty | free-form string | Startup version metadata shown in logs; usually injected by Docker/image builds |
+| Variable             | Required | Default | Validation / accepted values                                                                          | Purpose                                                                                                                        |
+| -------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `AUTH_TOKEN`         | yes      | none    | non-empty                                                                                             | RPlay access token used for API and stream access; short-lived (~10 min), refreshed automatically when `REFRESH_TOKEN` is set  |
+| `USER_OID`           | yes      | none    | non-empty                                                                                             | Your RPlay user identifier                                                                                                     |
+| `REFRESH_TOKEN`      | no       | empty   | surrounding whitespace trimmed; empty disables auto-refresh                                            | Durable token used to mint fresh access tokens; without it `AUTH_TOKEN` is used as-is and expires in ~10 min                   |
+| `INTERVAL`           | no       | `60`    | integer `10`-`3600`                                                                                   | Poll interval in seconds                                                                                                       |
+| `MIN_FREE_DISK_GB`   | no       | `5`     | non-negative number; `0` disables the guard; invalid/negative values abort startup                    | Skip starting a new recording when free space on the output volume is below this many GiB                                      |
+| `LOG_LEVEL`          | no       | `INFO`  | `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`; invalid values abort startup with a non-zero exit    | Console and file log verbosity                                                                                                 |
+| `LOG_YTDLP_INTERNAL` | no       | `false` | truthy: `1`, `true`, `yes`, `on`; falsy: `0`, `false`, `no`, `off`, empty; other values abort startup | Enables noisy yt-dlp internal debug lines                                                                                      |
+| `LOG_MAX_SIZE_MB`    | no       | `5`     | integer `1`-`100`                                                                                     | Maximum size of each log file before rotation                                                                                  |
+| `LOG_BACKUP_COUNT`   | no       | `5`     | integer `1`-`50`                                                                                      | Number of rotated log files to keep                                                                                            |
+| `LOG_RETENTION_DAYS` | no       | `30`    | integer `1`-`365`                                                                                     | Age-based cleanup window for old logs                                                                                          |
+| `APP_GIT_SHA`        | no       | empty   | free-form string                                                                                      | Startup version metadata shown in logs; usually injected by Docker/image builds                                               |
 
 Notes:
 
 - local runs load from `.env` or process environment variables
 - the bundled Docker Compose file loads `.env` through `env_file`, so its values become real container environment variables
+- `AUTH_TOKEN` is short-lived (~10 minutes). Set `REFRESH_TOKEN` so the app can mint fresh access tokens automatically before each poll; without it, recording stops once `AUTH_TOKEN` expires
+- `REFRESH_TOKEN` is stable — the refresh call returns a new access token but no new refresh token, so the same value keeps working
 - `LOG_YTDLP_INTERNAL=true` is only for deep diagnosis; it is intentionally noisy
 
 #### Creator configuration
@@ -226,20 +261,20 @@ Copy `config.yaml.example` to `config/config.yaml` and edit it like this:
 apiBaseUrl: https://api.rplay.live
 
 creators:
-    - name: "Creator Nickname 1"
-      id: "Creator OID 1"
-    - name: "Creator Nickname 2"
-      id: "Creator OID 2"
+  - name: "Creator Nickname 1"
+    id: "Creator OID 1"
+  - name: "Creator Nickname 2"
+    id: "Creator OID 2"
 ```
 
 Configuration keys:
 
-| Key | Required | Default | Validation | Purpose |
-| --- | --- | --- | --- | --- |
-| `apiBaseUrl` | no | `https://api.rplay.live` | absolute URL; surrounding whitespace is trimmed and trailing `/` is removed | Base URL for the RPlay API |
-| `creators` | no | empty list | YAML list | Creators to monitor |
-| `creators[].name` | yes | none | non-empty, max `100` characters | Display name used in logs, folder names, and final filenames |
-| `creators[].id` | yes | none | non-empty | Creator OID from the RPlay profile/network requests |
+| Key               | Required | Default                  | Validation                                                                  | Purpose                                                      |
+| ----------------- | -------- | ------------------------ | --------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| `apiBaseUrl`      | no       | `https://api.rplay.live` | absolute URL; surrounding whitespace is trimmed and trailing `/` is removed | Base URL for the RPlay API                                   |
+| `creators`        | no       | empty list               | YAML list                                                                   | Creators to monitor                                          |
+| `creators[].name` | yes      | none                     | non-empty, max `100` characters                                             | Display name used in logs, folder names, and final filenames |
+| `creators[].id`   | yes      | none                     | non-empty                                                                   | Creator OID from the RPlay profile/network requests          |
 
 Notes:
 
@@ -255,6 +290,7 @@ The v2 runtime uses a session-aware download pipeline.
 1. **Poll**
    - the monitor loads `config/config.yaml`
    - it refreshes `apiBaseUrl` from config before calling the API
+   - when `REFRESH_TOKEN` is set, it refreshes the access token if it is missing or within 60 seconds of expiry; otherwise it uses `AUTH_TOKEN` as-is
    - it checks live status for all configured creators
 
 2. **Create a session**
@@ -342,7 +378,7 @@ docker run -d \
 
 #### Docker healthcheck
 
-The image runs `python -m core.health` every 60s (`--retries=3`). Healthy when `/tmp/rplay-live-dl-heartbeat` exists and its mtime is strictly fresher than `3 × INTERVAL` seconds (touched once per monitor poll cycle, including failed ones). Docker only *displays* unhealthy status; it does not restart the container. With default `INTERVAL=60`, probes start failing after 180s without a heartbeat update, and Docker marks the container unhealthy ~300–360s after the last heartbeat update.
+The image runs `python -m core.health` every 60s (`--retries=3`). Healthy when `/tmp/rplay-live-dl-heartbeat` exists and its mtime is strictly fresher than `3 × INTERVAL` seconds (touched once per monitor poll cycle, including failed ones). Docker only _displays_ unhealthy status; it does not restart the container. With default `INTERVAL=60`, probes start failing after 180s without a heartbeat update, and Docker marks the container unhealthy ~300–360s after the last heartbeat update.
 
 ### Directory Structure
 
@@ -393,12 +429,29 @@ Fix:
 Check:
 
 - `AUTH_TOKEN` is still valid
+- `REFRESH_TOKEN` is set and valid (`AUTH_TOKEN` alone expires in ~10 minutes, so without a refresh token recording stops shortly after startup)
 - `USER_OID` is correct
 - creator ID is correct
 - there is enough free disk space
 - logs do not show API or connection failures
 
-#### 3. Stream access fails (`401` / `403` / `404`)
+#### 3. Authentication fails at startup (`Invalid authentication response`)
+
+Behavior:
+
+- the app logs `Authentication failed: Invalid authentication response` and exits, then restarts
+
+Cause:
+
+- the access token was already expired by the time the container started, and no valid `REFRESH_TOKEN` is available to mint a fresh one
+
+Check:
+
+- set `REFRESH_TOKEN` in `.env` (see [Obtaining Credentials](#obtaining-credentials)); this is the usual fix
+- if `REFRESH_TOKEN` is set and it still fails, the refresh token itself may be stale — grab a fresh value from `JSON.parse(localStorage.vuex).AccountModule.userInfo.refreshToken`
+- confirm `USER_OID` matches your `User Number` at `https://rplay.live/myinfo/`
+
+#### 4. Stream access fails (`401` / `403` / `404`)
 
 Behavior:
 
@@ -415,7 +468,7 @@ Check:
 - if repeated `403` persists, confirm the stream is not paid/private for your account
 - if repeated `404` persists after the automatic retries, wait a few seconds and confirm the stream actually remained live
 
-#### 4. Merge failed
+#### 5. Merge failed
 
 Behavior:
 
@@ -429,7 +482,7 @@ Check:
 - available disk space
 - the preserved raw `.ts` files in `archive/<creator>/` for manual recovery
 
-#### 5. Shutdown takes time
+#### 6. Shutdown takes time
 
 Behavior:
 

--- a/core/live_stream_monitor.py
+++ b/core/live_stream_monitor.py
@@ -116,6 +116,7 @@ class LiveStreamMonitor:
         self,
         auth_token: str,
         user_oid: str,
+        refresh_token: Optional[str] = None,
         config_path: str = DEFAULT_CONFIG_PATH,
         api: Optional[RPlayAPI] = None,
         merge_timeout_seconds: int = DEFAULT_MERGE_TIMEOUT_SECONDS,
@@ -132,7 +133,7 @@ class LiveStreamMonitor:
             merge_timeout_seconds: Timeout for ffmpeg merge commands
             min_free_disk_gb: Minimum free disk space in GiB before recording; 0 disables
         """
-        self.api = api if api is not None else RPlayAPI(auth_token, user_oid)
+        self.api = api if api is not None else RPlayAPI(auth_token, user_oid, refresh_token=refresh_token)
         self.config_path = config_path
         self.merge_timeout_seconds = merge_timeout_seconds
         self.min_free_disk_gb = min_free_disk_gb

--- a/core/rplay.py
+++ b/core/rplay.py
@@ -10,7 +10,18 @@ from typing import List
 from urllib.parse import urlencode
 
 import requests
-from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait_exponential
+from tenacity import (
+    Retrying,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+import base64
+import json
+import threading
+import time
+from typing import List, Optional
 
 from core.constants import (
     DEFAULT_HTTP_HEADERS,
@@ -66,10 +77,14 @@ class RPlayAPI:
     with automatic retry on transient failures.
     """
 
+    # Refresh the access token when it has this many seconds or fewer left.
+    TOKEN_REFRESH_LEEWAY_SECONDS = 60
+
     def __init__(
         self,
         auth_token: str,
         user_oid: str,
+        refresh_token: Optional[str] = None,
         base_url: str = DEFAULT_RPLAY_API_BASE_URL,
     ) -> None:
         """
@@ -84,10 +99,12 @@ class RPlayAPI:
         """
         self.auth_token = auth_token
         self.user_oid = user_oid
+        self.refresh_token = refresh_token
         self.base_url = base_url.rstrip("/")
         self.headers = DEFAULT_HTTP_HEADERS.copy()
         self.logger = setup_logger("RPlayAPI")
         self._session = self._create_session()
+        self._token_lock = threading.Lock()
 
     def set_base_url(self, base_url: str) -> None:
         """Update the API base URL used for future requests."""
@@ -192,7 +209,9 @@ class RPlayAPI:
             raise RPlayConnectionError("Request timed out")
 
         except requests.exceptions.ConnectionError as exc:
-            self.logger.error(f"Connection error while fetching livestream status: {exc}")
+            self.logger.error(
+                f"Connection error while fetching livestream status: {exc}"
+            )
             raise RPlayConnectionError(f"Connection failed: {exc}")
 
         except _RetryableStatusCodeError as exc:
@@ -207,7 +226,9 @@ class RPlayAPI:
             raise
 
         except Exception as exc:
-            self.logger.exception(f"Unexpected error while fetching livestream status: {exc}")
+            self.logger.exception(
+                f"Unexpected error while fetching livestream status: {exc}"
+            )
             raise RPlayAPIError(f"Unexpected error: {exc}")
 
         return []
@@ -223,10 +244,12 @@ class RPlayAPI:
         Returns:
             str: Complete M3U8 format stream URL with authentication parameters
         """
-        params = urlencode({
-            "creatorOid": creator_oid,
-            "key2": stream_key,
-        })
+        params = urlencode(
+            {
+                "creatorOid": creator_oid,
+                "key2": stream_key,
+            }
+        )
 
         return f"{self.base_url}/live/stream/playlist.m3u8?{params}"
 
@@ -242,6 +265,101 @@ class RPlayAPI:
         # ponytail: key2 is the cheapest authenticated call; no parallel health endpoint.
         self._get_stream_key()
 
+    @staticmethod
+    def _decode_token_exp(token: str) -> Optional[int]:
+        """Return the JWT 'exp' claim (epoch seconds), or None if unreadable."""
+        try:
+            payload_b64 = token.split(".")[1]
+            payload_b64 += "=" * (-len(payload_b64) % 4)
+            payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+            exp = payload.get("exp")
+            return int(exp) if exp is not None else None
+        except Exception:
+            return None
+
+    def _token_is_expiring(self) -> bool:
+        """True when the current access token is missing, unreadable, or near expiry."""
+        if not self.auth_token:
+            return True
+        exp = self._decode_token_exp(self.auth_token)
+        if exp is None:
+            # Can't read expiry (e.g. a placeholder AUTH_TOKEN) — refresh to be safe.
+            return True
+        return exp - time.time() <= self.TOKEN_REFRESH_LEEWAY_SECONDS
+
+    def _ensure_valid_token(self) -> None:
+        """Refresh the access token if it is missing or about to expire."""
+        # Without a refresh token there is nothing to do; the caller falls back
+        # to the configured AUTH_TOKEN as-is.
+        if not self.refresh_token:
+            return
+        with self._token_lock:
+            if self._token_is_expiring():
+                self.refresh_auth_token()
+
+    def refresh_auth_token(self) -> None:
+        """Mint a fresh access token from the stored refresh token."""
+        if not self.refresh_token:
+            raise RPlayAuthError(
+                "Access token expired and no REFRESH_TOKEN is configured."
+            )
+
+        url = f"{self.base_url}/rplay/account/refresh-token"
+        headers = self.headers.copy()
+        headers["refresh-token"] = self.refresh_token
+        headers["platform-type"] = "rplay"
+        headers["Content-Type"] = "application/json"
+
+        try:
+            for attempt in self._build_retrying(
+                attempts=DEFAULT_MAX_RETRIES,
+                retry_delay=DEFAULT_RETRY_BACKOFF_FACTOR,
+                operation="Refreshing access token",
+            ):
+                with attempt:
+                    response = self._session.post(
+                        url,
+                        headers=headers,
+                        json={"requestorOid": self.user_oid},
+                        timeout=DEFAULT_REQUEST_TIMEOUT,
+                    )
+                    status_code = getattr(response, "status_code", None)
+
+                    if self._is_auth_status_code(status_code):
+                        raise RPlayAuthError(
+                            "Token refresh rejected. "
+                            "Please update REFRESH_TOKEN in your .env file."
+                        )
+                    if self._is_retryable_status_code(status_code):
+                        raise _RetryableStatusCodeError(status_code)
+
+                    response.raise_for_status()
+                    data = response.json()
+                    access_token = data.get("accessToken")
+                    if not isinstance(access_token, str) or not access_token:
+                        raise RPlayAuthError("Invalid token refresh response")
+                    self.auth_token = access_token
+                    self.logger.info("Access token refreshed")
+                    return
+
+        except RPlayAuthError:
+            raise
+        except requests.exceptions.Timeout:
+            raise RPlayConnectionError("Request timed out while refreshing token")
+        except requests.exceptions.ConnectionError as exc:
+            raise RPlayConnectionError(
+                f"Connection failed while refreshing token: {exc}"
+            )
+        except _RetryableStatusCodeError as exc:
+            raise RPlayAPIError(f"Failed to refresh token: {exc}")
+        except requests.exceptions.HTTPError as exc:
+            raise RPlayAPIError(f"Failed to refresh token: {exc}")
+        except Exception as exc:
+            # Mirror _get_stream_key: suppress detail that may embed the token.
+            msg = f"Unexpected error while refreshing token: {type(exc).__name__}"
+            self.logger.error(msg)
+            raise RPlayAPIError(msg) from None
+
     def _get_stream_key(self) -> str:
         """
         Retrieve the authentication key required for stream access.
@@ -254,6 +372,7 @@ class RPlayAPI:
             RPlayConnectionError: If the API request times out or loses connection
             RPlayAPIError: If the API returns a non-retryable HTTP failure
         """
+        self._ensure_valid_token()
         auth_headers = self.headers.copy()
         auth_headers["Authorization"] = self.auth_token
 

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -66,6 +66,7 @@ class LiveStreamScheduler:
         self.monitor = LiveStreamMonitor(
             self.env.auth_token,
             self.env.user_oid,
+            refresh_token=self.env.refresh_token,
             min_free_disk_gb=self.env.min_free_disk_gb,
         )
         self.scheduler = BlockingScheduler()

--- a/main.py
+++ b/main.py
@@ -51,11 +51,15 @@ def _warn_about_orphaned_downloads(logger: logging.Logger) -> None:
     # *.part* covers .part, .part-FragN and .part-FragN.part in one pattern,
     # so the three patterns are disjoint and need no dedup.
     patterns = ("[0-9]*_*.ts", "*.part*", "*.ytdl")
-    orphans = sorted(path for pattern in patterns for path in archive.glob(f"*/{pattern}"))
+    orphans = sorted(
+        path for pattern in patterns for path in archive.glob(f"*/{pattern}")
+    )
     if not orphans:
         return
 
-    logger.warning(f"Found {len(orphans)} file(s) left behind by interrupted recordings:")
+    logger.warning(
+        f"Found {len(orphans)} file(s) left behind by interrupted recordings:"
+    )
     for path in orphans[:10]:
         logger.warning(f"  {path.relative_to(archive)}")
     if len(orphans) > 10:
@@ -109,12 +113,16 @@ def main() -> None:
     except ConfigError as exc:
         # ponytail: scheduler owns hard config failures; probe with default URL.
         logger.warning(
-            f"Could not load config for credential check "
-            f"(using default API URL): {exc}"
+            f"Could not load config for credential check (using default API URL): {exc}"
         )
         api_base_url = DEFAULT_RPLAY_API_BASE_URL
 
-    api = RPlayAPI(env.auth_token, env.user_oid, base_url=api_base_url)
+    api = RPlayAPI(
+        env.auth_token,
+        env.user_oid,
+        refresh_token=env.refresh_token,
+        base_url=api_base_url,
+    )
     try:
         api.validate_credentials()
         logger.info("API credentials validated successfully")

--- a/models/env.py
+++ b/models/env.py
@@ -47,6 +47,10 @@ class EnvConfig(BaseSettings):
         description="User's unique identifier (OID)",
         min_length=1,
     )
+    refresh_token: str = Field(
+        default="",
+        description="Refresh token used to mint fresh access tokens (enables auto-refresh)",
+    )
     interval: int = Field(
         default=DEFAULT_INTERVAL,
         description="Check interval in seconds",
@@ -100,6 +104,11 @@ class EnvConfig(BaseSettings):
         """Validate that auth token is not just whitespace."""
         if not v.strip():
             raise ValueError("AUTH_TOKEN cannot be empty or whitespace")
+        return v.strip()
+
+    @field_validator("refresh_token")
+    @classmethod
+    def validate_refresh_token(cls, v: str) -> str:
         return v.strip()
 
     @field_validator("user_oid")

--- a/tests/test_live_stream_monitor.py
+++ b/tests/test_live_stream_monitor.py
@@ -64,7 +64,7 @@ class TestLiveStreamMonitorInit:
             auth_token="test_token",
             user_oid="test_oid",
         )
-        mock_api_class.assert_called_once_with("test_token", "test_oid")
+        mock_api_class.assert_called_once_with("test_token", "test_oid", refresh_token=None)
 
     def test_init_uses_injected_api(self, mock_api):
         """Test that injected API is used instead of creating new one."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -15,7 +15,7 @@ from models.env import EnvConfig
 @pytest.fixture
 def mock_env():
     """Create mock EnvConfig."""
-    return EnvConfig(auth_token="test_token", user_oid="test_oid", interval=60)
+    return EnvConfig(auth_token="test_token", refresh_token="test_refresh", user_oid="test_oid", interval=60)
 
 
 @pytest.fixture
@@ -57,6 +57,7 @@ class TestLiveStreamSchedulerInit:
         mock_monitor_class.assert_called_once_with(
             "test_token",
             "test_oid",
+            refresh_token="test_refresh",
             min_free_disk_gb=5.0,
         )
         assert scheduler.monitor is mock_monitor_class.return_value


### PR DESCRIPTION
## Summary

An optional convenience for long-running deployments, independent of the authentication fix in #61.

The access token (`AUTH_TOKEN`) is a JWT that expires roughly 10 minutes after it is issued (`exp - iat == 600`). The tool reads it once and reuses it forever, which forces an operator to paste a fresh token every 10 minutes to keep a deployment alive. This adds an optional `REFRESH_TOKEN` that the app uses to mint fresh access tokens automatically, so a deployment can run unattended.

It is opt-in and backward-compatible: with `REFRESH_TOKEN` unset, behavior is unchanged (a single static token) and the refresh path is a no-op.

## Refresh flow

```json
{
  "request": {
    "method": "POST",
    "url": "https://api.rplay.live/rplay/account/refresh-token",
    "headers": {
      "refresh-token": "<REFRESH_TOKEN>",
      "platform-type": "rplay",
      "Content-Type": "application/json"
    },
    "body": { "requestorOid": "<USER_OID>" }
  },
  "response": {
    "accessToken": "<fresh short-lived JWT>"
  }
}
```

The refresh token is stable — the response returns a new access token but no new refresh token — so it lives in `.env` as a static value. It can be read from the browser console at rplay.live: `JSON.parse(localStorage.vuex).AccountModule.userInfo.refreshToken`.

## Changes

- `core/rplay.py`: adds `refresh_auth_token()` and an expiry guard `_ensure_valid_token()`, called before each key2 fetch; a no-op when `REFRESH_TOKEN` is empty.
- `models/env.py`: adds the optional `REFRESH_TOKEN` setting.
- `main.py`, `core/scheduler.py`, `core/live_stream_monitor.py`: thread `refresh_token` through to the API client.
- `.env.example`, `README.md`: document `REFRESH_TOKEN`.
- Tests updated for the new constructor signatures.

## Testing

- `poetry run pytest` — all passing.
- Verified end to end: with `REFRESH_TOKEN` set, the container logs "Access token refreshed" and keeps running past the 10-minute token lifetime.

## Note

Builds on #61 to authenticate end to end; the refresh logic itself is independent and reviewable on its own.